### PR TITLE
Feature/20 v2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     networks:
       - agenticcp-network
     volumes:
@@ -46,11 +48,25 @@ services:
       # 개발용: 소스코드 실시간 반영 (선택사항)
       # - ./src:/app/src
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/api/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/actuator/health"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 40s
+
+  redis:
+    image: redis:7
+    container_name: agenticcp-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    networks:
+      - agenticcp-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
   phpmyadmin:
     image: phpmyadmin/phpmyadmin:5.2

--- a/src/main/java/com/agenticcp/core/common/config/OpenApiConfig.java
+++ b/src/main/java/com/agenticcp/core/common/config/OpenApiConfig.java
@@ -50,10 +50,17 @@ public class OpenApiConfig {
                                 .in(SecurityScheme.In.HEADER)
                                 .name("X-API-Key")
                                 .description("API 키를 입력하세요")
+                        )
+                        .addSecuritySchemes("tenantKey", new SecurityScheme()
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.HEADER)
+                                .name("X-Tenant-Key")
+                                .description("요청 테넌트를 지정하는 헤더 (예: test-tenant)")
                         ))
                 .addSecurityItem(new SecurityRequirement()
                         .addList("bearerAuth")
                         .addList("basicAuth")
-                        .addList("apiKey"));
+                        .addList("apiKey")
+                        .addList("tenantKey"));
     }
 }

--- a/src/main/java/com/agenticcp/core/common/config/RedisConfig.java
+++ b/src/main/java/com/agenticcp/core/common/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.agenticcp.core.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * Redis 설정 클래스
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Configuration
+public class RedisConfig {
+    
+    /**
+     * RedisTemplate 빈 설정
+     * 
+     * @param connectionFactory Redis 연결 팩토리
+     * @return RedisTemplate
+     */
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        
+        // Key 직렬화 설정
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        
+        // Value 직렬화 설정
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/com/agenticcp/core/common/context/TenantContextFilter.java
+++ b/src/main/java/com/agenticcp/core/common/context/TenantContextFilter.java
@@ -1,0 +1,128 @@
+package com.agenticcp.core.common.context;
+
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import com.agenticcp.core.domain.tenant.service.TenantService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * HTTP 요청에서 테넌트 정보를 추출하여 TenantContextHolder에 설정하는 필터
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Order(1) // 다른 필터보다 먼저 실행되도록 설정
+public class TenantContextFilter extends OncePerRequestFilter {
+    
+    private final TenantService tenantService;
+    
+    private static final String TENANT_KEY_HEADER = "X-Tenant-Key";
+    private static final String TENANT_KEY_PARAM = "tenantKey";
+    
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, 
+                                  FilterChain filterChain) throws ServletException, IOException {
+        
+        try {
+            // 테넌트 컨텍스트 설정
+            setTenantContext(request);
+            
+            // 다음 필터 또는 컨트롤러로 요청 전달
+            filterChain.doFilter(request, response);
+            
+        } finally {
+            // 요청 처리 완료 후 테넌트 컨텍스트 정리
+            TenantContextHolder.clear();
+        }
+    }
+    
+    /**
+     * HTTP 요청에서 테넌트 정보를 추출하여 컨텍스트에 설정
+     * 
+     * @param request HTTP 요청 객체
+     */
+    private void setTenantContext(HttpServletRequest request) {
+        String tenantKey = extractTenantKey(request);
+        
+        if (tenantKey != null) {
+            try {
+                // 테넌트 키로 테넌트 정보 조회
+                Tenant tenant = tenantService.getTenantByKey(tenantKey)
+                        .orElseThrow(() -> new IllegalStateException("Invalid tenant key: " + tenantKey));
+                
+                // 테넌트 컨텍스트에 설정
+                TenantContextHolder.setTenant(tenant);
+                
+                log.debug("Tenant context set for request: {} -> {}", request.getRequestURI(), tenantKey);
+                
+            } catch (Exception e) {
+                log.warn("Failed to set tenant context for key: {}, error: {}", tenantKey, e.getMessage());
+                // 테넌트 컨텍스트 설정 실패 시에도 요청은 계속 진행
+            }
+        } else {
+            log.debug("No tenant key found in request: {}", request.getRequestURI());
+        }
+    }
+    
+    /**
+     * HTTP 요청에서 테넌트 키를 추출
+     * 우선순위: Header > Query Parameter > Path Variable
+     * 
+     * @param request HTTP 요청 객체
+     * @return 추출된 테넌트 키, 없으면 null
+     */
+    private String extractTenantKey(HttpServletRequest request) {
+        // 1. Header에서 테넌트 키 추출
+        String tenantKey = request.getHeader(TENANT_KEY_HEADER);
+        if (tenantKey != null && !tenantKey.trim().isEmpty()) {
+            return tenantKey.trim();
+        }
+        
+        // 2. Query Parameter에서 테넌트 키 추출
+        tenantKey = request.getParameter(TENANT_KEY_PARAM);
+        if (tenantKey != null && !tenantKey.trim().isEmpty()) {
+            return tenantKey.trim();
+        }
+        
+        // 3. Path Variable에서 테넌트 키 추출 (예: /api/tenants/{tenantKey}/roles)
+        String requestURI = request.getRequestURI();
+        if (requestURI.contains("/tenants/")) {
+            String[] pathParts = requestURI.split("/");
+            for (int i = 0; i < pathParts.length - 1; i++) {
+                if ("tenants".equals(pathParts[i]) && i + 1 < pathParts.length) {
+                    String extractedKey = pathParts[i + 1];
+                    if (!extractedKey.isEmpty() && !extractedKey.equals("active") && 
+                        !extractedKey.equals("type") && !extractedKey.equals("trial") && 
+                        !extractedKey.equals("expired") && !extractedKey.equals("count")) {
+                        return extractedKey;
+                    }
+                }
+            }
+        }
+        
+        return null;
+    }
+    
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        // 특정 경로는 테넌트 컨텍스트 필터를 적용하지 않음
+        String requestURI = request.getRequestURI();
+        return requestURI.startsWith("/api/health") || 
+               requestURI.startsWith("/api/auth") ||
+               requestURI.startsWith("/api/swagger") ||
+               requestURI.startsWith("/api/v3/api-docs");
+    }
+}

--- a/src/main/java/com/agenticcp/core/common/context/TenantContextHolder.java
+++ b/src/main/java/com/agenticcp/core/common/context/TenantContextHolder.java
@@ -1,0 +1,106 @@
+package com.agenticcp.core.common.context;
+
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 테넌트 컨텍스트를 ThreadLocal로 관리하는 클래스
+ * 현재 요청의 테넌트 정보를 저장하고 조회할 수 있도록 함
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Slf4j
+public class TenantContextHolder {
+    
+    private static final ThreadLocal<Tenant> TENANT_CONTEXT = new ThreadLocal<>();
+    private static final ThreadLocal<String> TENANT_KEY_CONTEXT = new ThreadLocal<>();
+    
+    /**
+     * 현재 스레드에 테넌트 정보를 설정
+     * 
+     * @param tenant 설정할 테넌트 객체
+     */
+    public static void setTenant(Tenant tenant) {
+        if (tenant != null) {
+            TENANT_CONTEXT.set(tenant);
+            TENANT_KEY_CONTEXT.set(tenant.getTenantKey());
+            log.debug("Tenant context set: {}", tenant.getTenantKey());
+        }
+    }
+    
+    /**
+     * 현재 스레드에 테넌트 키를 설정
+     * 
+     * @param tenantKey 설정할 테넌트 키
+     */
+    public static void setTenantKey(String tenantKey) {
+        TENANT_KEY_CONTEXT.set(tenantKey);
+        log.debug("Tenant key context set: {}", tenantKey);
+    }
+    
+    /**
+     * 현재 스레드의 테넌트 정보를 조회
+     * 
+     * @return 현재 테넌트 객체, 없으면 null
+     */
+    public static Tenant getCurrentTenant() {
+        return TENANT_CONTEXT.get();
+    }
+    
+    /**
+     * 현재 스레드의 테넌트 키를 조회
+     * 
+     * @return 현재 테넌트 키, 없으면 null
+     */
+    public static String getCurrentTenantKey() {
+        return TENANT_KEY_CONTEXT.get();
+    }
+    
+    /**
+     * 현재 스레드의 테넌트 키를 조회 (null 체크 포함)
+     * 
+     * @return 현재 테넌트 키
+     * @throws IllegalStateException 테넌트 컨텍스트가 설정되지 않은 경우
+     */
+    public static String getCurrentTenantKeyOrThrow() {
+        String tenantKey = getCurrentTenantKey();
+        if (tenantKey == null) {
+            throw new IllegalStateException("Tenant context is not set");
+        }
+        return tenantKey;
+    }
+    
+    /**
+     * 현재 스레드의 테넌트 정보를 조회 (null 체크 포함)
+     * 
+     * @return 현재 테넌트 객체
+     * @throws IllegalStateException 테넌트 컨텍스트가 설정되지 않은 경우
+     */
+    public static Tenant getCurrentTenantOrThrow() {
+        Tenant tenant = getCurrentTenant();
+        if (tenant == null) {
+            throw new IllegalStateException("Tenant context is not set");
+        }
+        return tenant;
+    }
+    
+    /**
+     * 현재 스레드의 테넌트 컨텍스트를 초기화
+     */
+    public static void clear() {
+        TENANT_CONTEXT.remove();
+        TENANT_KEY_CONTEXT.remove();
+        log.debug("Tenant context cleared");
+    }
+    
+    /**
+     * 현재 스레드에 테넌트 컨텍스트가 설정되어 있는지 확인
+     * 
+     * @return 테넌트 컨텍스트 설정 여부
+     */
+    public static boolean hasTenantContext() {
+        return getCurrentTenantKey() != null;
+    }
+}

--- a/src/main/java/com/agenticcp/core/common/context/TenantContextHolder.java
+++ b/src/main/java/com/agenticcp/core/common/context/TenantContextHolder.java
@@ -9,7 +9,7 @@ import lombok.extern.slf4j.Slf4j;
  * 
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-09-22
  */
 @Slf4j
 public class TenantContextHolder {

--- a/src/main/java/com/agenticcp/core/common/repository/TenantAwareRepository.java
+++ b/src/main/java/com/agenticcp/core/common/repository/TenantAwareRepository.java
@@ -1,0 +1,105 @@
+package com.agenticcp.core.common.repository;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 테넌트 인식 Repository 인터페이스
+ * 자동으로 현재 테넌트 컨텍스트를 적용하여 데이터를 필터링합니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@NoRepositoryBean
+public interface TenantAwareRepository<T, ID> extends JpaRepository<T, ID> {
+    
+    /**
+     * 현재 테넌트의 모든 엔티티 조회
+     * 
+     * @return 현재 테넌트의 엔티티 목록
+     */
+    default List<T> findAllForCurrentTenant() {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return findByTenant(currentTenant);
+    }
+    
+    /**
+     * 테넌트별 엔티티 조회 (구현 필요)
+     * 
+     * @param tenant 테넌트
+     * @return 엔티티 목록
+     */
+    List<T> findByTenant(Tenant tenant);
+    
+    /**
+     * 현재 테넌트에서 ID로 엔티티 조회
+     * 
+     * @param id 엔티티 ID
+     * @return 엔티티 (현재 테넌트에 속한 경우만)
+     */
+    default Optional<T> findByIdForCurrentTenant(ID id) {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return findByIdAndTenant(id, currentTenant);
+    }
+    
+    /**
+     * 테넌트와 ID로 엔티티 조회 (구현 필요)
+     * 
+     * @param id 엔티티 ID
+     * @param tenant 테넌트
+     * @return 엔티티
+     */
+    Optional<T> findByIdAndTenant(ID id, Tenant tenant);
+    
+    /**
+     * 현재 테넌트에서 엔티티 존재 여부 확인
+     * 
+     * @param id 엔티티 ID
+     * @return 존재 여부
+     */
+    default boolean existsByIdForCurrentTenant(ID id) {
+        return findByIdForCurrentTenant(id).isPresent();
+    }
+    
+    /**
+     * 현재 테넌트에서 엔티티 삭제
+     * 
+     * @param id 엔티티 ID
+     */
+    default void deleteByIdForCurrentTenant(ID id) {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        deleteByIdAndTenant(id, currentTenant);
+    }
+    
+    /**
+     * 테넌트와 ID로 엔티티 삭제 (구현 필요)
+     * 
+     * @param id 엔티티 ID
+     * @param tenant 테넌트
+     */
+    void deleteByIdAndTenant(ID id, Tenant tenant);
+    
+    /**
+     * 현재 테넌트의 엔티티 수 조회
+     * 
+     * @return 엔티티 수
+     */
+    default long countForCurrentTenant() {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return countByTenant(currentTenant);
+    }
+    
+    /**
+     * 테넌트별 엔티티 수 조회 (구현 필요)
+     * 
+     * @param tenant 테넌트
+     * @return 엔티티 수
+     */
+    long countByTenant(Tenant tenant);
+}

--- a/src/main/java/com/agenticcp/core/common/util/LogMaskingUtils.java
+++ b/src/main/java/com/agenticcp/core/common/util/LogMaskingUtils.java
@@ -1,0 +1,54 @@
+package com.agenticcp.core.common.util;
+
+/**
+ * 로그 마스킹 유틸리티
+ * 민감한 문자열(tenantKey, permissionKey 등)을 로그에 출력할 때 일부만 노출합니다.
+ */
+public final class LogMaskingUtils {
+
+	private LogMaskingUtils() {}
+
+	/**
+	 * 일반 문자열 마스킹. 앞/뒤 일부만 노출하고 가운데를 *로 마스킹합니다.
+	 * 예) abcdefg -> ab***fg (revealStart=2, revealEnd=2)
+	 */
+	public static String mask(String value, int revealStart, int revealEnd) {
+		if (value == null || value.isEmpty()) {
+			return "";
+		}
+		int length = value.length();
+		if (revealStart + revealEnd >= length) {
+			return repeat('*', Math.max(3, length));
+		}
+		String start = value.substring(0, Math.max(0, revealStart));
+		String end = value.substring(length - Math.max(0, revealEnd));
+		int maskLen = Math.max(3, length - start.length() - end.length());
+		return start + repeat('*', maskLen) + end;
+	}
+
+	public static String maskTenantKey(String tenantKey) {
+		return mask(tenantKey, 2, 2);
+	}
+
+	public static String maskPermissionKey(String permissionKey) {
+		return mask(permissionKey, 2, 2);
+	}
+
+	public static String maskUserIdentifier(String userIdOrEmail) {
+		return mask(userIdOrEmail, 2, 2);
+	}
+
+	public static String maskNullable(Object value, int revealStart, int revealEnd) {
+		return value == null ? "" : mask(String.valueOf(value), revealStart, revealEnd);
+	}
+
+	private static String repeat(char c, int count) {
+		StringBuilder sb = new StringBuilder(Math.max(0, count));
+		for (int i = 0; i < count; i++) {
+			sb.append(c);
+		}
+		return sb.toString();
+	}
+}
+
+

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/CloudProviderService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/CloudProviderService.java
@@ -4,6 +4,7 @@ import com.agenticcp.core.common.exception.ResourceNotFoundException;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider;
 import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
 import com.agenticcp.core.common.enums.Status;
+import com.agenticcp.core.common.util.LogMaskingUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,6 +14,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * 클라우드 공급자 관리 서비스
+ *
+ * 클라우드 공급자의 조회/생성/수정/상태변경 및 동기화 시점 업데이트 등의 기능을 제공합니다.
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -22,51 +31,83 @@ public class CloudProviderService {
     private final CloudProviderRepository cloudProviderRepository;
 
     public List<CloudProvider> getAllProviders() {
-        return cloudProviderRepository.findAll();
+        log.info("[CloudProviderService] getAllProviders");
+        List<CloudProvider> result = cloudProviderRepository.findAll();
+        log.info("[CloudProviderService] getAllProviders - success count={}", result.size());
+        return result;
     }
 
     public List<CloudProvider> getActiveProviders() {
-        return cloudProviderRepository.findActiveProviders(Status.ACTIVE);
+        log.info("[CloudProviderService] getActiveProviders");
+        List<CloudProvider> result = cloudProviderRepository.findActiveProviders(Status.ACTIVE);
+        log.info("[CloudProviderService] getActiveProviders - success count={}", result.size());
+        return result;
     }
 
     public Optional<CloudProvider> getProviderByKey(String providerKey) {
-        return cloudProviderRepository.findByProviderKey(providerKey);
+        log.info("[CloudProviderService] getProviderByKey - providerKey={}", LogMaskingUtils.mask(providerKey, 2, 2));
+        Optional<CloudProvider> result = cloudProviderRepository.findByProviderKey(providerKey);
+        log.info("[CloudProviderService] getProviderByKey - found={} providerKey={}", result.isPresent(), LogMaskingUtils.mask(providerKey, 2, 2));
+        return result;
     }
 
     public CloudProvider getProviderByKeyOrThrow(String providerKey) {
-        return cloudProviderRepository.findByProviderKey(providerKey)
+        log.info("[CloudProviderService] getProviderByKeyOrThrow - providerKey={}", LogMaskingUtils.mask(providerKey, 2, 2));
+        CloudProvider provider = cloudProviderRepository.findByProviderKey(providerKey)
                 .orElseThrow(() -> new ResourceNotFoundException("CloudProvider", "providerKey", providerKey));
+        log.info("[CloudProviderService] getProviderByKeyOrThrow - success providerKey={}", LogMaskingUtils.mask(providerKey, 2, 2));
+        return provider;
     }
 
     public List<CloudProvider> getProvidersByType(CloudProvider.ProviderType providerType) {
-        return cloudProviderRepository.findByProviderType(providerType);
+        log.info("[CloudProviderService] getProvidersByType - type={}", providerType);
+        List<CloudProvider> result = cloudProviderRepository.findByProviderType(providerType);
+        log.info("[CloudProviderService] getProvidersByType - success count={} type={}", result.size(), providerType);
+        return result;
     }
 
     public List<CloudProvider> getGlobalProviders() {
-        return cloudProviderRepository.findGlobalProviders(Status.ACTIVE);
+        log.info("[CloudProviderService] getGlobalProviders");
+        List<CloudProvider> result = cloudProviderRepository.findGlobalProviders(Status.ACTIVE);
+        log.info("[CloudProviderService] getGlobalProviders - success count={}", result.size());
+        return result;
     }
 
     public List<CloudProvider> getGovernmentProviders() {
-        return cloudProviderRepository.findGovernmentProviders(Status.ACTIVE);
+        log.info("[CloudProviderService] getGovernmentProviders");
+        List<CloudProvider> result = cloudProviderRepository.findGovernmentProviders(Status.ACTIVE);
+        log.info("[CloudProviderService] getGovernmentProviders - success count={}", result.size());
+        return result;
     }
 
     public List<CloudProvider> getProvidersNeedingSync(int hoursSinceLastSync) {
         LocalDateTime before = LocalDateTime.now().minusHours(hoursSinceLastSync);
-        return cloudProviderRepository.findProvidersNeedingSync(before);
+        log.info("[CloudProviderService] getProvidersNeedingSync - hoursSinceLastSync={}", hoursSinceLastSync);
+        List<CloudProvider> result = cloudProviderRepository.findProvidersNeedingSync(before);
+        log.info("[CloudProviderService] getProvidersNeedingSync - success count={} hoursSinceLastSync={}", result.size(), hoursSinceLastSync);
+        return result;
     }
 
     public Long getActiveProviderCount() {
-        return cloudProviderRepository.countActiveProviders(Status.ACTIVE);
+        log.info("[CloudProviderService] getActiveProviderCount");
+        Long count = cloudProviderRepository.countActiveProviders(Status.ACTIVE);
+        log.info("[CloudProviderService] getActiveProviderCount - success count={}", count);
+        return count;
     }
 
     @Transactional
     public CloudProvider createProvider(CloudProvider cloudProvider) {
-        log.info("Creating cloud provider: {}", cloudProvider.getProviderKey());
-        return cloudProviderRepository.save(cloudProvider);
+        log.info("[CloudProviderService] createProvider - providerKey={} name={}",
+                LogMaskingUtils.mask(cloudProvider.getProviderKey(), 2, 2),
+                cloudProvider.getProviderName());
+        CloudProvider saved = cloudProviderRepository.save(cloudProvider);
+        log.info("[CloudProviderService] createProvider - success providerKey={}", LogMaskingUtils.mask(saved.getProviderKey(), 2, 2));
+        return saved;
     }
 
     @Transactional
     public CloudProvider updateProvider(String providerKey, CloudProvider updatedProvider) {
+        log.info("[CloudProviderService] updateProvider - providerKey={}", LogMaskingUtils.mask(providerKey, 2, 2));
         CloudProvider existingProvider = getProviderByKeyOrThrow(providerKey);
         
         existingProvider.setProviderName(updatedProvider.getProviderName());
@@ -84,39 +125,47 @@ public class CloudProviderService {
         existingProvider.setComplianceCertifications(updatedProvider.getComplianceCertifications());
         existingProvider.setMetadata(updatedProvider.getMetadata());
         
-        log.info("Updating cloud provider: {}", providerKey);
-        return cloudProviderRepository.save(existingProvider);
+        CloudProvider saved = cloudProviderRepository.save(existingProvider);
+        log.info("[CloudProviderService] updateProvider - success providerKey={}", LogMaskingUtils.mask(providerKey, 2, 2));
+        return saved;
     }
 
     @Transactional
     public CloudProvider updateLastSync(String providerKey) {
+        log.info("[CloudProviderService] updateLastSync - providerKey={}", LogMaskingUtils.mask(providerKey, 2, 2));
         CloudProvider provider = getProviderByKeyOrThrow(providerKey);
         provider.setLastSync(LocalDateTime.now());
-        log.info("Updated last sync for provider: {}", providerKey);
-        return cloudProviderRepository.save(provider);
+        CloudProvider saved = cloudProviderRepository.save(provider);
+        log.info("[CloudProviderService] updateLastSync - success providerKey={}", LogMaskingUtils.mask(providerKey, 2, 2));
+        return saved;
     }
 
     @Transactional
     public CloudProvider activateProvider(String providerKey) {
+        log.info("[CloudProviderService] activateProvider - providerKey={}", LogMaskingUtils.mask(providerKey, 2, 2));
         CloudProvider provider = getProviderByKeyOrThrow(providerKey);
         provider.setStatus(Status.ACTIVE);
-        log.info("Activated provider: {}", providerKey);
-        return cloudProviderRepository.save(provider);
+        CloudProvider saved = cloudProviderRepository.save(provider);
+        log.info("[CloudProviderService] activateProvider - success providerKey={}", LogMaskingUtils.mask(providerKey, 2, 2));
+        return saved;
     }
 
     @Transactional
     public CloudProvider deactivateProvider(String providerKey) {
+        log.info("[CloudProviderService] deactivateProvider - providerKey={}", LogMaskingUtils.mask(providerKey, 2, 2));
         CloudProvider provider = getProviderByKeyOrThrow(providerKey);
         provider.setStatus(Status.INACTIVE);
-        log.info("Deactivated provider: {}", providerKey);
-        return cloudProviderRepository.save(provider);
+        CloudProvider saved = cloudProviderRepository.save(provider);
+        log.info("[CloudProviderService] deactivateProvider - success providerKey={}", LogMaskingUtils.mask(providerKey, 2, 2));
+        return saved;
     }
 
     @Transactional
     public void deleteProvider(String providerKey) {
+        log.info("[CloudProviderService] deleteProvider - providerKey={}", LogMaskingUtils.mask(providerKey, 2, 2));
         CloudProvider provider = getProviderByKeyOrThrow(providerKey);
         provider.setIsDeleted(true);
         cloudProviderRepository.save(provider);
-        log.info("Soft deleted provider: {}", providerKey);
+        log.info("[CloudProviderService] deleteProvider - success providerKey={}", LogMaskingUtils.mask(providerKey, 2, 2));
     }
 }

--- a/src/main/java/com/agenticcp/core/domain/platform/service/FeatureFlagService.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/service/FeatureFlagService.java
@@ -4,6 +4,7 @@ import com.agenticcp.core.common.exception.ResourceNotFoundException;
 import com.agenticcp.core.domain.platform.entity.FeatureFlag;
 import com.agenticcp.core.domain.platform.repository.FeatureFlagRepository;
 import com.agenticcp.core.common.enums.Status;
+import com.agenticcp.core.common.util.LogMaskingUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,6 +14,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * 기능 플래그 관리 서비스
+ *
+ * 기능 플래그의 조회/생성/수정/토글/삭제 등 릴리즈 전략 제어 기능을 제공합니다.
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -22,40 +31,61 @@ public class FeatureFlagService {
     private final FeatureFlagRepository featureFlagRepository;
 
     public List<FeatureFlag> getAllFlags() {
-        return featureFlagRepository.findAll();
+        log.info("[FeatureFlagService] getAllFlags");
+        List<FeatureFlag> result = featureFlagRepository.findAll();
+        log.info("[FeatureFlagService] getAllFlags - success count={}", result.size());
+        return result;
     }
 
     public Optional<FeatureFlag> getFlagByKey(String flagKey) {
-        return featureFlagRepository.findByFlagKey(flagKey);
+        log.info("[FeatureFlagService] getFlagByKey - flagKey={}", LogMaskingUtils.mask(flagKey, 2, 2));
+        Optional<FeatureFlag> result = featureFlagRepository.findByFlagKey(flagKey);
+        log.info("[FeatureFlagService] getFlagByKey - found={} flagKey={}", result.isPresent(), LogMaskingUtils.mask(flagKey, 2, 2));
+        return result;
     }
 
     public FeatureFlag getFlagByKeyOrThrow(String flagKey) {
-        return featureFlagRepository.findByFlagKey(flagKey)
+        log.info("[FeatureFlagService] getFlagByKeyOrThrow - flagKey={}", LogMaskingUtils.mask(flagKey, 2, 2));
+        FeatureFlag flag = featureFlagRepository.findByFlagKey(flagKey)
                 .orElseThrow(() -> new ResourceNotFoundException("FeatureFlag", "flagKey", flagKey));
+        log.info("[FeatureFlagService] getFlagByKeyOrThrow - success flagKey={}", LogMaskingUtils.mask(flagKey, 2, 2));
+        return flag;
     }
 
     public List<FeatureFlag> getActiveFlags() {
-        return featureFlagRepository.findActiveFlags(Status.ACTIVE, LocalDateTime.now());
+        log.info("[FeatureFlagService] getActiveFlags");
+        List<FeatureFlag> result = featureFlagRepository.findActiveFlags(Status.ACTIVE, LocalDateTime.now());
+        log.info("[FeatureFlagService] getActiveFlags - success count={}", result.size());
+        return result;
     }
 
     public boolean isFlagEnabled(String flagKey) {
-        return featureFlagRepository.findActiveFlagByKey(flagKey, Status.ACTIVE, LocalDateTime.now())
+        log.info("[FeatureFlagService] isFlagEnabled - flagKey={}", LogMaskingUtils.mask(flagKey, 2, 2));
+        boolean enabled = featureFlagRepository.findActiveFlagByKey(flagKey, Status.ACTIVE, LocalDateTime.now())
                 .map(FeatureFlag::getIsEnabled)
                 .orElse(false);
+        log.info("[FeatureFlagService] isFlagEnabled - result={} flagKey={}", enabled, LogMaskingUtils.mask(flagKey, 2, 2));
+        return enabled;
     }
 
     public List<FeatureFlag> getEnabledFlags() {
-        return featureFlagRepository.findByIsEnabled(true);
+        log.info("[FeatureFlagService] getEnabledFlags");
+        List<FeatureFlag> result = featureFlagRepository.findByIsEnabled(true);
+        log.info("[FeatureFlagService] getEnabledFlags - success count={}", result.size());
+        return result;
     }
 
     @Transactional
     public FeatureFlag createFlag(FeatureFlag featureFlag) {
-        log.info("Creating feature flag: {}", featureFlag.getFlagKey());
-        return featureFlagRepository.save(featureFlag);
+        log.info("[FeatureFlagService] createFlag - flagKey={} name={}", LogMaskingUtils.mask(featureFlag.getFlagKey(), 2, 2), featureFlag.getFlagName());
+        FeatureFlag saved = featureFlagRepository.save(featureFlag);
+        log.info("[FeatureFlagService] createFlag - success flagKey={}", LogMaskingUtils.mask(saved.getFlagKey(), 2, 2));
+        return saved;
     }
 
     @Transactional
     public FeatureFlag updateFlag(String flagKey, FeatureFlag updatedFlag) {
+        log.info("[FeatureFlagService] updateFlag - flagKey={}", LogMaskingUtils.mask(flagKey, 2, 2));
         FeatureFlag existingFlag = getFlagByKeyOrThrow(flagKey);
         
         existingFlag.setFlagName(updatedFlag.getFlagName());
@@ -69,23 +99,27 @@ public class FeatureFlagService {
         existingFlag.setEndDate(updatedFlag.getEndDate());
         existingFlag.setMetadata(updatedFlag.getMetadata());
         
-        log.info("Updating feature flag: {}", flagKey);
-        return featureFlagRepository.save(existingFlag);
+        FeatureFlag saved = featureFlagRepository.save(existingFlag);
+        log.info("[FeatureFlagService] updateFlag - success flagKey={}", LogMaskingUtils.mask(flagKey, 2, 2));
+        return saved;
     }
 
     @Transactional
     public FeatureFlag toggleFlag(String flagKey, boolean enabled) {
+        log.info("[FeatureFlagService] toggleFlag - flagKey={} enabled={}", LogMaskingUtils.mask(flagKey, 2, 2), enabled);
         FeatureFlag flag = getFlagByKeyOrThrow(flagKey);
         flag.setIsEnabled(enabled);
-        log.info("Toggling feature flag {} to {}", flagKey, enabled);
-        return featureFlagRepository.save(flag);
+        FeatureFlag saved = featureFlagRepository.save(flag);
+        log.info("[FeatureFlagService] toggleFlag - success flagKey={} enabled={}", LogMaskingUtils.mask(flagKey, 2, 2), enabled);
+        return saved;
     }
 
     @Transactional
     public void deleteFlag(String flagKey) {
+        log.info("[FeatureFlagService] deleteFlag - flagKey={}", LogMaskingUtils.mask(flagKey, 2, 2));
         FeatureFlag flag = getFlagByKeyOrThrow(flagKey);
         flag.setIsDeleted(true);
         featureFlagRepository.save(flag);
-        log.info("Soft deleted feature flag: {}", flagKey);
+        log.info("[FeatureFlagService] deleteFlag - success flagKey={}", LogMaskingUtils.mask(flagKey, 2, 2));
     }
 }

--- a/src/main/java/com/agenticcp/core/domain/platform/service/PlatformConfigService.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/service/PlatformConfigService.java
@@ -3,6 +3,7 @@ package com.agenticcp.core.domain.platform.service;
 import com.agenticcp.core.common.exception.ResourceNotFoundException;
 import com.agenticcp.core.domain.platform.entity.PlatformConfig;
 import com.agenticcp.core.domain.platform.repository.PlatformConfigRepository;
+import com.agenticcp.core.common.util.LogMaskingUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -11,6 +12,14 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * 플랫폼 설정 관리 서비스
+ *
+ * 플랫폼 전역 설정의 조회/생성/수정/삭제 기능을 제공합니다. 일부 값은 민감할 수 있으므로 로깅 시 주의합니다.
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -20,34 +29,55 @@ public class PlatformConfigService {
     private final PlatformConfigRepository platformConfigRepository;
 
     public List<PlatformConfig> getAllConfigs() {
-        return platformConfigRepository.findAllActive();
+        log.info("[PlatformConfigService] getAllConfigs");
+        List<PlatformConfig> result = platformConfigRepository.findAllActive();
+        log.info("[PlatformConfigService] getAllConfigs - success count={}", result.size());
+        return result;
     }
 
     public Optional<PlatformConfig> getConfigByKey(String configKey) {
-        return platformConfigRepository.findByConfigKey(configKey);
+        log.info("[PlatformConfigService] getConfigByKey - configKey={}", LogMaskingUtils.mask(configKey, 2, 2));
+        Optional<PlatformConfig> result = platformConfigRepository.findByConfigKey(configKey);
+        log.info("[PlatformConfigService] getConfigByKey - found={} configKey={}", result.isPresent(), LogMaskingUtils.mask(configKey, 2, 2));
+        return result;
     }
 
     public PlatformConfig getConfigByKeyOrThrow(String configKey) {
-        return platformConfigRepository.findByConfigKey(configKey)
+        log.info("[PlatformConfigService] getConfigByKeyOrThrow - configKey={}", LogMaskingUtils.mask(configKey, 2, 2));
+        PlatformConfig config = platformConfigRepository.findByConfigKey(configKey)
                 .orElseThrow(() -> new ResourceNotFoundException("PlatformConfig", "configKey", configKey));
+        log.info("[PlatformConfigService] getConfigByKeyOrThrow - success configKey={}", LogMaskingUtils.mask(configKey, 2, 2));
+        return config;
     }
 
     public List<PlatformConfig> getConfigsByType(PlatformConfig.ConfigType configType) {
-        return platformConfigRepository.findByConfigType(configType);
+        log.info("[PlatformConfigService] getConfigsByType - type={}", configType);
+        List<PlatformConfig> result = platformConfigRepository.findByConfigType(configType);
+        log.info("[PlatformConfigService] getConfigsByType - success count={} type={}", result.size(), configType);
+        return result;
     }
 
     public List<PlatformConfig> getSystemConfigs() {
-        return platformConfigRepository.findByIsSystem(true);
+        log.info("[PlatformConfigService] getSystemConfigs");
+        List<PlatformConfig> result = platformConfigRepository.findByIsSystem(true);
+        log.info("[PlatformConfigService] getSystemConfigs - success count={}", result.size());
+        return result;
     }
 
     @Transactional
     public PlatformConfig createConfig(PlatformConfig platformConfig) {
-        log.info("Creating platform config: {}", platformConfig.getConfigKey());
-        return platformConfigRepository.save(platformConfig);
+        log.info("[PlatformConfigService] createConfig - configKey={} isEncrypted={} type={}",
+                LogMaskingUtils.mask(platformConfig.getConfigKey(), 2, 2),
+                platformConfig.getIsEncrypted(),
+                platformConfig.getConfigType());
+        PlatformConfig saved = platformConfigRepository.save(platformConfig);
+        log.info("[PlatformConfigService] createConfig - success configKey={}", LogMaskingUtils.mask(saved.getConfigKey(), 2, 2));
+        return saved;
     }
 
     @Transactional
     public PlatformConfig updateConfig(String configKey, PlatformConfig updatedConfig) {
+        log.info("[PlatformConfigService] updateConfig - configKey={}", LogMaskingUtils.mask(configKey, 2, 2));
         PlatformConfig existingConfig = getConfigByKeyOrThrow(configKey);
         
         existingConfig.setConfigValue(updatedConfig.getConfigValue());
@@ -55,22 +85,25 @@ public class PlatformConfigService {
         existingConfig.setDescription(updatedConfig.getDescription());
         existingConfig.setIsEncrypted(updatedConfig.getIsEncrypted());
         
-        log.info("Updating platform config: {}", configKey);
-        return platformConfigRepository.save(existingConfig);
+        PlatformConfig saved = platformConfigRepository.save(existingConfig);
+        log.info("[PlatformConfigService] updateConfig - success configKey={}", LogMaskingUtils.mask(configKey, 2, 2));
+        return saved;
     }
 
     @Transactional
     public void deleteConfig(String configKey) {
+        log.info("[PlatformConfigService] deleteConfig - configKey={}", LogMaskingUtils.mask(configKey, 2, 2));
         PlatformConfig config = getConfigByKeyOrThrow(configKey);
         config.setIsDeleted(true);
         platformConfigRepository.save(config);
-        log.info("Soft deleted platform config: {}", configKey);
+        log.info("[PlatformConfigService] deleteConfig - success configKey={}", LogMaskingUtils.mask(configKey, 2, 2));
     }
 
     @Transactional
     public void hardDeleteConfig(String configKey) {
+        log.info("[PlatformConfigService] hardDeleteConfig - configKey={}", LogMaskingUtils.mask(configKey, 2, 2));
         PlatformConfig config = getConfigByKeyOrThrow(configKey);
         platformConfigRepository.delete(config);
-        log.info("Hard deleted platform config: {}", configKey);
+        log.info("[PlatformConfigService] hardDeleteConfig - success configKey={}", LogMaskingUtils.mask(configKey, 2, 2));
     }
 }

--- a/src/main/java/com/agenticcp/core/domain/security/service/SecurityPolicyService.java
+++ b/src/main/java/com/agenticcp/core/domain/security/service/SecurityPolicyService.java
@@ -5,6 +5,7 @@ import com.agenticcp.core.domain.security.entity.SecurityPolicy;
 import com.agenticcp.core.domain.security.repository.SecurityPolicyRepository;
 import com.agenticcp.core.common.enums.Status;
 import com.agenticcp.core.domain.tenant.entity.Tenant;
+import com.agenticcp.core.common.util.LogMaskingUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * 보안 정책 관리 서비스
+ *
+ * 보안 정책의 조회/생성/수정/활성화/비활성화 및 통계 관련 기능을 제공합니다.
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -23,28 +32,46 @@ public class SecurityPolicyService {
     private final SecurityPolicyRepository securityPolicyRepository;
 
     public List<SecurityPolicy> getAllPolicies() {
-        return securityPolicyRepository.findAll();
+        log.info("[SecurityPolicyService] getAllPolicies");
+        List<SecurityPolicy> result = securityPolicyRepository.findAll();
+        log.info("[SecurityPolicyService] getAllPolicies - success count={}", result.size());
+        return result;
     }
 
     public List<SecurityPolicy> getActivePolicies() {
-        return securityPolicyRepository.findActivePolicies(Status.ACTIVE);
+        log.info("[SecurityPolicyService] getActivePolicies");
+        List<SecurityPolicy> result = securityPolicyRepository.findActivePolicies(Status.ACTIVE);
+        log.info("[SecurityPolicyService] getActivePolicies - success count={}", result.size());
+        return result;
     }
 
     public Optional<SecurityPolicy> getPolicyByKey(String policyKey) {
-        return securityPolicyRepository.findByPolicyKey(policyKey);
+        log.info("[SecurityPolicyService] getPolicyByKey - policyKey={}", LogMaskingUtils.mask(policyKey, 2, 2));
+        Optional<SecurityPolicy> result = securityPolicyRepository.findByPolicyKey(policyKey);
+        log.info("[SecurityPolicyService] getPolicyByKey - found={} policyKey={}", result.isPresent(), LogMaskingUtils.mask(policyKey, 2, 2));
+        return result;
     }
 
     public SecurityPolicy getPolicyByKeyOrThrow(String policyKey) {
-        return securityPolicyRepository.findByPolicyKey(policyKey)
+        log.info("[SecurityPolicyService] getPolicyByKeyOrThrow - policyKey={}", LogMaskingUtils.mask(policyKey, 2, 2));
+        SecurityPolicy policy = securityPolicyRepository.findByPolicyKey(policyKey)
                 .orElseThrow(() -> new ResourceNotFoundException("SecurityPolicy", "policyKey", policyKey));
+        log.info("[SecurityPolicyService] getPolicyByKeyOrThrow - success policyKey={}", LogMaskingUtils.mask(policyKey, 2, 2));
+        return policy;
     }
 
     public List<SecurityPolicy> getPoliciesByTenant(Tenant tenant) {
-        return securityPolicyRepository.findByTenant(tenant);
+        log.info("[SecurityPolicyService] getPoliciesByTenant - tenantKey={}", LogMaskingUtils.maskTenantKey(tenant.getTenantKey()));
+        List<SecurityPolicy> result = securityPolicyRepository.findByTenant(tenant);
+        log.info("[SecurityPolicyService] getPoliciesByTenant - success count={} tenantKey={}", result.size(), LogMaskingUtils.maskTenantKey(tenant.getTenantKey()));
+        return result;
     }
 
     public List<SecurityPolicy> getActivePoliciesByTenant(Tenant tenant) {
-        return securityPolicyRepository.findActivePoliciesByTenant(tenant, Status.ACTIVE);
+        log.info("[SecurityPolicyService] getActivePoliciesByTenant - tenantKey={}", LogMaskingUtils.maskTenantKey(tenant.getTenantKey()));
+        List<SecurityPolicy> result = securityPolicyRepository.findActivePoliciesByTenant(tenant, Status.ACTIVE);
+        log.info("[SecurityPolicyService] getActivePoliciesByTenant - success count={} tenantKey={}", result.size(), LogMaskingUtils.maskTenantKey(tenant.getTenantKey()));
+        return result;
     }
 
     public List<SecurityPolicy> getPoliciesByType(SecurityPolicy.PolicyType policyType) {

--- a/src/main/java/com/agenticcp/core/domain/tenant/service/TenantService.java
+++ b/src/main/java/com/agenticcp/core/domain/tenant/service/TenantService.java
@@ -4,6 +4,7 @@ import com.agenticcp.core.common.exception.ResourceNotFoundException;
 import com.agenticcp.core.domain.tenant.entity.Tenant;
 import com.agenticcp.core.domain.tenant.repository.TenantRepository;
 import com.agenticcp.core.common.enums.Status;
+import com.agenticcp.core.common.util.LogMaskingUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,6 +14,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * 테넌트 관리 서비스
+ *
+ * 테넌트 조회/생성/수정/상태변경 및 통계 관련 기능을 제공합니다.
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -22,46 +31,75 @@ public class TenantService {
     private final TenantRepository tenantRepository;
 
     public List<Tenant> getAllTenants() {
-        return tenantRepository.findAll();
+        log.info("[TenantService] getAllTenants");
+        List<Tenant> result = tenantRepository.findAll();
+        log.info("[TenantService] getAllTenants - success count={}", result.size());
+        return result;
     }
 
     public List<Tenant> getActiveTenants() {
-        return tenantRepository.findActiveTenants(Status.ACTIVE);
+        log.info("[TenantService] getActiveTenants");
+        List<Tenant> result = tenantRepository.findActiveTenants(Status.ACTIVE);
+        log.info("[TenantService] getActiveTenants - success count={}", result.size());
+        return result;
     }
 
     public Optional<Tenant> getTenantByKey(String tenantKey) {
-        return tenantRepository.findByTenantKey(tenantKey);
+        log.info("[TenantService] getTenantByKey - tenantKey={}", LogMaskingUtils.maskTenantKey(tenantKey));
+        Optional<Tenant> result = tenantRepository.findByTenantKey(tenantKey);
+        log.info("[TenantService] getTenantByKey - found={} tenantKey={}", result.isPresent(), LogMaskingUtils.maskTenantKey(tenantKey));
+        return result;
     }
 
     public Tenant getTenantByKeyOrThrow(String tenantKey) {
-        return tenantRepository.findByTenantKey(tenantKey)
+        log.info("[TenantService] getTenantByKeyOrThrow - tenantKey={}", LogMaskingUtils.maskTenantKey(tenantKey));
+        Tenant tenant = tenantRepository.findByTenantKey(tenantKey)
                 .orElseThrow(() -> new ResourceNotFoundException("Tenant", "tenantKey", tenantKey));
+        log.info("[TenantService] getTenantByKeyOrThrow - success tenantKey={}", LogMaskingUtils.maskTenantKey(tenantKey));
+        return tenant;
     }
 
     public List<Tenant> getTenantsByType(Tenant.TenantType tenantType) {
-        return tenantRepository.findByTenantType(tenantType);
+        log.info("[TenantService] getTenantsByType - type={}", tenantType);
+        List<Tenant> result = tenantRepository.findByTenantType(tenantType);
+        log.info("[TenantService] getTenantsByType - success count={} type={}", result.size(), tenantType);
+        return result;
     }
 
     public List<Tenant> getActiveTrialTenants() {
-        return tenantRepository.findActiveTrialTenants(LocalDateTime.now());
+        log.info("[TenantService] getActiveTrialTenants");
+        List<Tenant> result = tenantRepository.findActiveTrialTenants(LocalDateTime.now());
+        log.info("[TenantService] getActiveTrialTenants - success count={}", result.size());
+        return result;
     }
 
     public List<Tenant> getExpiredTenants() {
-        return tenantRepository.findExpiredTenants(LocalDateTime.now(), Status.ACTIVE);
+        log.info("[TenantService] getExpiredTenants");
+        List<Tenant> result = tenantRepository.findExpiredTenants(LocalDateTime.now(), Status.ACTIVE);
+        log.info("[TenantService] getExpiredTenants - success count={}", result.size());
+        return result;
     }
 
     public Long getActiveTenantCount() {
-        return tenantRepository.countActiveTenants(Status.ACTIVE);
+        log.info("[TenantService] getActiveTenantCount");
+        Long count = tenantRepository.countActiveTenants(Status.ACTIVE);
+        log.info("[TenantService] getActiveTenantCount - success count={}", count);
+        return count;
     }
 
     @Transactional
     public Tenant createTenant(Tenant tenant) {
-        log.info("Creating tenant: {}", tenant.getTenantKey());
-        return tenantRepository.save(tenant);
+        log.info("[TenantService] createTenant - tenantKey={} name={}",
+                LogMaskingUtils.maskTenantKey(tenant.getTenantKey()),
+                tenant.getTenantName());
+        Tenant saved = tenantRepository.save(tenant);
+        log.info("[TenantService] createTenant - success tenantKey={}", LogMaskingUtils.maskTenantKey(saved.getTenantKey()));
+        return saved;
     }
 
     @Transactional
     public Tenant updateTenant(String tenantKey, Tenant updatedTenant) {
+        log.info("[TenantService] updateTenant - tenantKey={}", LogMaskingUtils.maskTenantKey(tenantKey));
         Tenant existingTenant = getTenantByKeyOrThrow(tenantKey);
         
         existingTenant.setTenantName(updatedTenant.getTenantName());
@@ -81,31 +119,37 @@ public class TenantService {
         existingTenant.setIsTrial(updatedTenant.getIsTrial());
         existingTenant.setTrialEndDate(updatedTenant.getTrialEndDate());
         
-        log.info("Updating tenant: {}", tenantKey);
-        return tenantRepository.save(existingTenant);
+        Tenant saved = tenantRepository.save(existingTenant);
+        log.info("[TenantService] updateTenant - success tenantKey={}", LogMaskingUtils.maskTenantKey(tenantKey));
+        return saved;
     }
 
     @Transactional
     public Tenant suspendTenant(String tenantKey) {
+        log.info("[TenantService] suspendTenant - tenantKey={}", LogMaskingUtils.maskTenantKey(tenantKey));
         Tenant tenant = getTenantByKeyOrThrow(tenantKey);
         tenant.setStatus(Status.SUSPENDED);
-        log.info("Suspending tenant: {}", tenantKey);
-        return tenantRepository.save(tenant);
+        Tenant saved = tenantRepository.save(tenant);
+        log.info("[TenantService] suspendTenant - success tenantKey={}", LogMaskingUtils.maskTenantKey(tenantKey));
+        return saved;
     }
 
     @Transactional
     public Tenant activateTenant(String tenantKey) {
+        log.info("[TenantService] activateTenant - tenantKey={}", LogMaskingUtils.maskTenantKey(tenantKey));
         Tenant tenant = getTenantByKeyOrThrow(tenantKey);
         tenant.setStatus(Status.ACTIVE);
-        log.info("Activating tenant: {}", tenantKey);
-        return tenantRepository.save(tenant);
+        Tenant saved = tenantRepository.save(tenant);
+        log.info("[TenantService] activateTenant - success tenantKey={}", LogMaskingUtils.maskTenantKey(tenantKey));
+        return saved;
     }
 
     @Transactional
     public void deleteTenant(String tenantKey) {
+        log.info("[TenantService] deleteTenant - tenantKey={}", LogMaskingUtils.maskTenantKey(tenantKey));
         Tenant tenant = getTenantByKeyOrThrow(tenantKey);
         tenant.setIsDeleted(true);
         tenantRepository.save(tenant);
-        log.info("Soft deleted tenant: {}", tenantKey);
+        log.info("[TenantService] deleteTenant - success tenantKey={}", LogMaskingUtils.maskTenantKey(tenantKey));
     }
 }

--- a/src/main/java/com/agenticcp/core/domain/user/controller/PermissionController.java
+++ b/src/main/java/com/agenticcp/core/domain/user/controller/PermissionController.java
@@ -1,0 +1,158 @@
+package com.agenticcp.core.domain.user.controller;
+
+import com.agenticcp.core.common.dto.ApiResponse;
+import com.agenticcp.core.domain.user.dto.CreatePermissionRequest;
+import com.agenticcp.core.domain.user.dto.PermissionResponse;
+import com.agenticcp.core.domain.user.dto.UpdatePermissionRequest;
+import com.agenticcp.core.domain.user.entity.Permission;
+import com.agenticcp.core.domain.user.service.PermissionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 권한 관리 컨트롤러
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@RestController
+@RequestMapping("/permissions")
+@RequiredArgsConstructor
+@Tag(name = "Permission Management", description = "권한 관리 API")
+public class PermissionController {
+    
+    private final PermissionService permissionService;
+    
+    @GetMapping
+    @Operation(summary = "모든 권한 조회", description = "현재 테넌트의 모든 권한을 조회합니다")
+    public ResponseEntity<ApiResponse<List<PermissionResponse>>> getAllPermissions() {
+        List<Permission> permissions = permissionService.getAllPermissions();
+        List<PermissionResponse> permissionResponses = permissions.stream()
+                .map(permissionService::toPermissionResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(permissionResponses));
+    }
+    
+    @GetMapping("/active")
+    @Operation(summary = "활성 권한 조회", description = "현재 테넌트의 활성 권한을 조회합니다")
+    public ResponseEntity<ApiResponse<List<PermissionResponse>>> getActivePermissions() {
+        List<Permission> permissions = permissionService.getActivePermissions();
+        List<PermissionResponse> permissionResponses = permissions.stream()
+                .map(permissionService::toPermissionResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(permissionResponses));
+    }
+    
+    @GetMapping("/system")
+    @Operation(summary = "시스템 권한 조회", description = "현재 테넌트의 시스템 권한을 조회합니다")
+    public ResponseEntity<ApiResponse<List<PermissionResponse>>> getSystemPermissions() {
+        List<Permission> permissions = permissionService.getSystemPermissions();
+        List<PermissionResponse> permissionResponses = permissions.stream()
+                .map(permissionService::toPermissionResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(permissionResponses));
+    }
+    
+    @GetMapping("/category/{category}")
+    @Operation(summary = "카테고리별 권한 조회", description = "특정 카테고리의 권한을 조회합니다")
+    public ResponseEntity<ApiResponse<List<PermissionResponse>>> getPermissionsByCategory(
+            @Parameter(description = "카테고리") @PathVariable String category) {
+        List<Permission> permissions = permissionService.getPermissionsByCategory(category);
+        List<PermissionResponse> permissionResponses = permissions.stream()
+                .map(permissionService::toPermissionResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(permissionResponses));
+    }
+    
+    @GetMapping("/resource/{resource}")
+    @Operation(summary = "리소스별 권한 조회", description = "특정 리소스의 권한을 조회합니다")
+    public ResponseEntity<ApiResponse<List<PermissionResponse>>> getPermissionsByResource(
+            @Parameter(description = "리소스") @PathVariable String resource) {
+        List<Permission> permissions = permissionService.getPermissionsByResource(resource);
+        List<PermissionResponse> permissionResponses = permissions.stream()
+                .map(permissionService::toPermissionResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(permissionResponses));
+    }
+    
+    @GetMapping("/action/{action}")
+    @Operation(summary = "액션별 권한 조회", description = "특정 액션의 권한을 조회합니다")
+    public ResponseEntity<ApiResponse<List<PermissionResponse>>> getPermissionsByAction(
+            @Parameter(description = "액션") @PathVariable String action) {
+        List<Permission> permissions = permissionService.getPermissionsByAction(action);
+        List<PermissionResponse> permissionResponses = permissions.stream()
+                .map(permissionService::toPermissionResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(permissionResponses));
+    }
+    
+    @GetMapping("/resource/{resource}/action/{action}")
+    @Operation(summary = "리소스와 액션으로 권한 조회", description = "특정 리소스와 액션의 권한을 조회합니다")
+    public ResponseEntity<ApiResponse<List<PermissionResponse>>> getPermissionsByResourceAndAction(
+            @Parameter(description = "리소스") @PathVariable String resource,
+            @Parameter(description = "액션") @PathVariable String action) {
+        List<Permission> permissions = permissionService.getPermissionsByResourceAndAction(resource, action);
+        List<PermissionResponse> permissionResponses = permissions.stream()
+                .map(permissionService::toPermissionResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(permissionResponses));
+    }
+    
+    @GetMapping("/search")
+    @Operation(summary = "권한 검색", description = "키워드로 권한을 검색합니다")
+    public ResponseEntity<ApiResponse<List<PermissionResponse>>> searchPermissions(
+            @Parameter(description = "검색 키워드") @RequestParam String keyword) {
+        List<Permission> permissions = permissionService.searchPermissions(keyword);
+        List<PermissionResponse> permissionResponses = permissions.stream()
+                .map(permissionService::toPermissionResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(permissionResponses));
+    }
+    
+    @GetMapping("/{permissionKey}")
+    @Operation(summary = "특정 권한 조회", description = "권한 키로 특정 권한을 조회합니다")
+    public ResponseEntity<ApiResponse<PermissionResponse>> getPermissionByKey(
+            @Parameter(description = "권한 키") @PathVariable String permissionKey) {
+        return permissionService.getPermissionByKey(permissionKey)
+                .map(permission -> ResponseEntity.ok(ApiResponse.success(permissionService.toPermissionResponse(permission))))
+                .orElse(ResponseEntity.notFound().build());
+    }
+    
+    @PostMapping
+    @Operation(summary = "권한 생성", description = "새로운 권한을 생성합니다")
+    public ResponseEntity<ApiResponse<PermissionResponse>> createPermission(
+            @Valid @RequestBody CreatePermissionRequest request) {
+        Permission permission = permissionService.createPermission(request);
+        PermissionResponse response = permissionService.toPermissionResponse(permission);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response, "권한이 생성되었습니다"));
+    }
+    
+    @PutMapping("/{permissionKey}")
+    @Operation(summary = "권한 수정", description = "기존 권한을 수정합니다")
+    public ResponseEntity<ApiResponse<PermissionResponse>> updatePermission(
+            @Parameter(description = "권한 키") @PathVariable String permissionKey,
+            @Valid @RequestBody UpdatePermissionRequest request) {
+        Permission permission = permissionService.updatePermission(permissionKey, request);
+        PermissionResponse response = permissionService.toPermissionResponse(permission);
+        return ResponseEntity.ok(ApiResponse.success(response, "권한이 수정되었습니다"));
+    }
+    
+    @DeleteMapping("/{permissionKey}")
+    @Operation(summary = "권한 삭제", description = "권한을 삭제합니다")
+    public ResponseEntity<ApiResponse<Void>> deletePermission(
+            @Parameter(description = "권한 키") @PathVariable String permissionKey) {
+        permissionService.deletePermission(permissionKey);
+        return ResponseEntity.ok(ApiResponse.success(null, "권한이 삭제되었습니다"));
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/user/controller/RoleController.java
+++ b/src/main/java/com/agenticcp/core/domain/user/controller/RoleController.java
@@ -1,0 +1,150 @@
+package com.agenticcp.core.domain.user.controller;
+
+import com.agenticcp.core.common.dto.ApiResponse;
+import com.agenticcp.core.domain.user.dto.CreateRoleRequest;
+import com.agenticcp.core.domain.user.dto.RoleResponse;
+import com.agenticcp.core.domain.user.dto.UpdateRoleRequest;
+import com.agenticcp.core.domain.user.entity.Role;
+import com.agenticcp.core.domain.user.service.RoleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 역할 관리 컨트롤러
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@RestController
+@RequestMapping("/roles")
+@RequiredArgsConstructor
+@Tag(name = "Role Management", description = "역할 관리 API")
+public class RoleController {
+    
+    private final RoleService roleService;
+    
+    @GetMapping
+    @Operation(summary = "모든 역할 조회", description = "현재 테넌트의 모든 역할을 조회합니다")
+    public ResponseEntity<ApiResponse<List<RoleResponse>>> getAllRoles() {
+        List<Role> roles = roleService.getAllRoles();
+        List<RoleResponse> roleResponses = roles.stream()
+                .map(roleService::toRoleResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(roleResponses));
+    }
+    
+    @GetMapping("/active")
+    @Operation(summary = "활성 역할 조회", description = "현재 테넌트의 활성 역할을 조회합니다")
+    public ResponseEntity<ApiResponse<List<RoleResponse>>> getActiveRoles() {
+        List<Role> roles = roleService.getActiveRoles();
+        List<RoleResponse> roleResponses = roles.stream()
+                .map(roleService::toRoleResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(roleResponses));
+    }
+    
+    @GetMapping("/system")
+    @Operation(summary = "시스템 역할 조회", description = "현재 테넌트의 시스템 역할을 조회합니다")
+    public ResponseEntity<ApiResponse<List<RoleResponse>>> getSystemRoles() {
+        List<Role> roles = roleService.getSystemRoles();
+        List<RoleResponse> roleResponses = roles.stream()
+                .map(roleService::toRoleResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(roleResponses));
+    }
+    
+    @GetMapping("/default")
+    @Operation(summary = "기본 역할 조회", description = "현재 테넌트의 기본 역할을 조회합니다")
+    public ResponseEntity<ApiResponse<List<RoleResponse>>> getDefaultRoles() {
+        List<Role> roles = roleService.getDefaultRoles();
+        List<RoleResponse> roleResponses = roles.stream()
+                .map(roleService::toRoleResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(roleResponses));
+    }
+    
+    @GetMapping("/search")
+    @Operation(summary = "역할 검색", description = "키워드로 역할을 검색합니다")
+    public ResponseEntity<ApiResponse<List<RoleResponse>>> searchRoles(
+            @Parameter(description = "검색 키워드") @RequestParam String keyword) {
+        List<Role> roles = roleService.searchRoles(keyword);
+        List<RoleResponse> roleResponses = roles.stream()
+                .map(roleService::toRoleResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(roleResponses));
+    }
+    
+    @GetMapping("/{roleKey}")
+    @Operation(summary = "특정 역할 조회", description = "역할 키로 특정 역할을 조회합니다")
+    public ResponseEntity<ApiResponse<RoleResponse>> getRoleByKey(
+            @Parameter(description = "역할 키") @PathVariable String roleKey) {
+        return roleService.getRoleByKey(roleKey)
+                .map(role -> ResponseEntity.ok(ApiResponse.success(roleService.toRoleResponse(role))))
+                .orElse(ResponseEntity.notFound().build());
+    }
+    
+    @PostMapping
+    @Operation(summary = "역할 생성", description = "새로운 역할을 생성합니다")
+    public ResponseEntity<ApiResponse<RoleResponse>> createRole(
+            @Valid @RequestBody CreateRoleRequest request) {
+        Role role = roleService.createRole(request);
+        RoleResponse response = roleService.toRoleResponse(role);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response, "역할이 생성되었습니다"));
+    }
+    
+    @PutMapping("/{roleKey}")
+    @Operation(summary = "역할 수정", description = "기존 역할을 수정합니다")
+    public ResponseEntity<ApiResponse<RoleResponse>> updateRole(
+            @Parameter(description = "역할 키") @PathVariable String roleKey,
+            @Valid @RequestBody UpdateRoleRequest request) {
+        Role role = roleService.updateRole(roleKey, request);
+        RoleResponse response = roleService.toRoleResponse(role);
+        return ResponseEntity.ok(ApiResponse.success(response, "역할이 수정되었습니다"));
+    }
+    
+    @DeleteMapping("/{roleKey}")
+    @Operation(summary = "역할 삭제", description = "역할을 삭제합니다")
+    public ResponseEntity<ApiResponse<Void>> deleteRole(
+            @Parameter(description = "역할 키") @PathVariable String roleKey) {
+        roleService.deleteRole(roleKey);
+        return ResponseEntity.ok(ApiResponse.success(null, "역할이 삭제되었습니다"));
+    }
+    
+    @PostMapping("/{roleId}/permissions")
+    @Operation(summary = "역할에 권한 할당", description = "역할에 권한을 할당합니다")
+    public ResponseEntity<ApiResponse<Void>> assignPermissionsToRole(
+            @Parameter(description = "역할 ID") @PathVariable Long roleId,
+            @Parameter(description = "권한 키 목록") @RequestBody List<String> permissionKeys) {
+        roleService.assignPermissionsToRole(roleId, permissionKeys);
+        return ResponseEntity.ok(ApiResponse.success(null, "권한이 할당되었습니다"));
+    }
+    
+    @PutMapping("/{roleId}/permissions")
+    @Operation(summary = "역할 권한 업데이트", description = "역할의 권한을 업데이트합니다")
+    public ResponseEntity<ApiResponse<Void>> updateRolePermissions(
+            @Parameter(description = "역할 ID") @PathVariable Long roleId,
+            @Parameter(description = "권한 키 목록") @RequestBody List<String> permissionKeys) {
+        roleService.updateRolePermissions(roleId, permissionKeys);
+        return ResponseEntity.ok(ApiResponse.success(null, "역할 권한이 업데이트되었습니다"));
+    }
+    
+    @DeleteMapping("/{roleId}/permissions/{permissionKey}")
+    @Operation(summary = "역할에서 권한 제거", description = "역할에서 특정 권한을 제거합니다")
+    public ResponseEntity<ApiResponse<Void>> removePermissionFromRole(
+            @Parameter(description = "역할 ID") @PathVariable Long roleId,
+            @Parameter(description = "권한 키") @PathVariable String permissionKey) {
+        roleService.removePermissionFromRole(roleId, permissionKey);
+        return ResponseEntity.ok(ApiResponse.success(null, "권한이 제거되었습니다"));
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/user/controller/UserController.java
+++ b/src/main/java/com/agenticcp/core/domain/user/controller/UserController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("/users")
 @RequiredArgsConstructor
 @Tag(name = "User Management", description = "사용자 관리 API")
 public class UserController {

--- a/src/main/java/com/agenticcp/core/domain/user/dto/CreatePermissionRequest.java
+++ b/src/main/java/com/agenticcp/core/domain/user/dto/CreatePermissionRequest.java
@@ -1,0 +1,48 @@
+package com.agenticcp.core.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 권한 생성 요청 DTO
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreatePermissionRequest {
+    
+    @NotBlank(message = "권한 키는 필수입니다")
+    @Size(min = 2, max = 50, message = "권한 키는 2-50자 사이여야 합니다")
+    private String permissionKey;
+    
+    @NotBlank(message = "권한명은 필수입니다")
+    @Size(min = 2, max = 100, message = "권한명은 2-100자 사이여야 합니다")
+    private String permissionName;
+    
+    @Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
+    private String description;
+    
+    @NotBlank(message = "리소스는 필수입니다")
+    @Size(max = 100, message = "리소스는 100자를 초과할 수 없습니다")
+    private String resource;
+    
+    @NotBlank(message = "액션은 필수입니다")
+    @Size(max = 50, message = "액션은 50자를 초과할 수 없습니다")
+    private String action;
+    
+    @Size(max = 50, message = "카테고리는 50자를 초과할 수 없습니다")
+    private String category;
+    
+    @NotNull(message = "우선순위는 필수입니다")
+    private Integer priority = 0;
+}

--- a/src/main/java/com/agenticcp/core/domain/user/dto/CreateRoleRequest.java
+++ b/src/main/java/com/agenticcp/core/domain/user/dto/CreateRoleRequest.java
@@ -1,0 +1,43 @@
+package com.agenticcp.core.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 역할 생성 요청 DTO
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateRoleRequest {
+    
+    @NotBlank(message = "역할 키는 필수입니다")
+    @Size(min = 2, max = 50, message = "역할 키는 2-50자 사이여야 합니다")
+    private String roleKey;
+    
+    @NotBlank(message = "역할명은 필수입니다")
+    @Size(min = 2, max = 100, message = "역할명은 2-100자 사이여야 합니다")
+    private String roleName;
+    
+    @Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
+    private String description;
+    
+    @NotNull(message = "우선순위는 필수입니다")
+    private Integer priority = 0;
+    
+    private List<String> permissionKeys;
+
+    private Boolean isSystem;
+}

--- a/src/main/java/com/agenticcp/core/domain/user/dto/PermissionResponse.java
+++ b/src/main/java/com/agenticcp/core/domain/user/dto/PermissionResponse.java
@@ -1,0 +1,40 @@
+package com.agenticcp.core.domain.user.dto;
+
+import com.agenticcp.core.common.enums.Status;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 권한 응답 DTO
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PermissionResponse {
+    
+    private Long id;
+    private String permissionKey;
+    private String permissionName;
+    private String description;
+    private String tenantKey;
+    private String tenantName;
+    private Status status;
+    private String resource;
+    private String action;
+    private Boolean isSystem;
+    private String category;
+    private Integer priority;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String createdBy;
+    private String updatedBy;
+}

--- a/src/main/java/com/agenticcp/core/domain/user/dto/RoleResponse.java
+++ b/src/main/java/com/agenticcp/core/domain/user/dto/RoleResponse.java
@@ -1,0 +1,41 @@
+package com.agenticcp.core.domain.user.dto;
+
+import com.agenticcp.core.common.enums.Status;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 역할 응답 DTO
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoleResponse {
+    
+    private Long id;
+    private String roleKey;
+    private String roleName;
+    private String description;
+    private String tenantKey;
+    private String tenantName;
+    private Status status;
+    private Boolean isSystem;
+    private Boolean isDefault;
+    private Integer priority;
+    private List<PermissionResponse> permissions;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String createdBy;
+    private String updatedBy;
+}

--- a/src/main/java/com/agenticcp/core/domain/user/dto/UpdatePermissionRequest.java
+++ b/src/main/java/com/agenticcp/core/domain/user/dto/UpdatePermissionRequest.java
@@ -1,0 +1,40 @@
+package com.agenticcp.core.domain.user.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 권한 수정 요청 DTO
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdatePermissionRequest {
+    
+    @Size(min = 2, max = 100, message = "권한명은 2-100자 사이여야 합니다")
+    private String permissionName;
+    
+    @Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
+    private String description;
+    
+    @Size(max = 100, message = "리소스는 100자를 초과할 수 없습니다")
+    private String resource;
+    
+    @Size(max = 50, message = "액션은 50자를 초과할 수 없습니다")
+    private String action;
+    
+    @Size(max = 50, message = "카테고리는 50자를 초과할 수 없습니다")
+    private String category;
+    
+    private Integer priority;
+    
+    private Boolean isSystem;
+}

--- a/src/main/java/com/agenticcp/core/domain/user/dto/UpdateRoleRequest.java
+++ b/src/main/java/com/agenticcp/core/domain/user/dto/UpdateRoleRequest.java
@@ -1,0 +1,35 @@
+package com.agenticcp.core.domain.user.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 역할 수정 요청 DTO
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateRoleRequest {
+    
+    @Size(min = 2, max = 100, message = "역할명은 2-100자 사이여야 합니다")
+    private String roleName;
+    
+    @Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
+    private String description;
+    
+    private Integer priority;
+    
+    private List<String> permissionKeys;
+    
+    private Boolean isSystem;
+}

--- a/src/main/java/com/agenticcp/core/domain/user/repository/PermissionRepository.java
+++ b/src/main/java/com/agenticcp/core/domain/user/repository/PermissionRepository.java
@@ -1,0 +1,257 @@
+package com.agenticcp.core.domain.user.repository;
+
+import com.agenticcp.core.common.enums.Status;
+import com.agenticcp.core.common.repository.TenantAwareRepository;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import com.agenticcp.core.domain.user.entity.Permission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 권한 저장소 인터페이스
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Repository
+public interface PermissionRepository extends TenantAwareRepository<Permission, Long> {
+    
+    /**
+     * 권한 키로 권한 조회
+     * 
+     * @param permissionKey 권한 키
+     * @return 권한 정보
+     */
+    Optional<Permission> findByPermissionKey(String permissionKey);
+    
+    /**
+     * 테넌트 포함 단건 조회 (LAZY 접근 없이 필터링)
+     */
+    @Query("SELECT p FROM Permission p WHERE p.permissionKey = :permissionKey AND p.tenant = :tenant AND p.isDeleted = false")
+    Optional<Permission> findByPermissionKeyAndTenant(@Param("permissionKey") String permissionKey,
+                                                     @Param("tenant") Tenant tenant);
+    
+    /**
+     * 테넌트별 권한 목록 조회
+     * 
+     * @param tenant 테넌트
+     * @return 권한 목록
+     */
+    List<Permission> findByTenant(Tenant tenant);
+    
+    /**
+     * 테넌트 키로 권한 목록 조회
+     * 
+     * @param tenantKey 테넌트 키
+     * @return 권한 목록
+     */
+    @Query("SELECT p FROM Permission p WHERE p.tenant.tenantKey = :tenantKey AND p.isDeleted = false")
+    List<Permission> findByTenantKey(@Param("tenantKey") String tenantKey);
+    
+    /**
+     * 테넌트별 활성 권한 목록 조회
+     * 
+     * @param tenant 테넌트
+     * @param status 상태
+     * @return 활성 권한 목록
+     */
+    @Query("SELECT p FROM Permission p WHERE p.tenant = :tenant AND p.status = :status AND p.isDeleted = false")
+    List<Permission> findActivePermissionsByTenant(@Param("tenant") Tenant tenant, @Param("status") Status status);
+    
+    /**
+     * 테넌트 키로 활성 권한 목록 조회
+     * 
+     * @param tenantKey 테넌트 키
+     * @param status 상태
+     * @return 활성 권한 목록
+     */
+    @Query("SELECT p FROM Permission p WHERE p.tenant.tenantKey = :tenantKey AND p.status = :status AND p.isDeleted = false")
+    List<Permission> findActivePermissionsByTenantKey(@Param("tenantKey") String tenantKey, @Param("status") Status status);
+    
+    /**
+     * 시스템 권한 목록 조회
+     * 
+     * @param isSystem 시스템 권한 여부
+     * @return 시스템 권한 목록
+     */
+    List<Permission> findByIsSystem(Boolean isSystem);
+    
+    /**
+     * 카테고리별 권한 목록 조회
+     * 
+     * @param category 카테고리
+     * @return 권한 목록
+     */
+    List<Permission> findByCategory(String category);
+    
+    /**
+     * 테넌트별 카테고리별 권한 목록 조회
+     * 
+     * @param tenant 테넌트
+     * @param category 카테고리
+     * @return 권한 목록
+     */
+    @Query("SELECT p FROM Permission p WHERE p.tenant = :tenant AND p.category = :category AND p.isDeleted = false")
+    List<Permission> findByTenantAndCategory(@Param("tenant") Tenant tenant, @Param("category") String category);
+    
+    /**
+     * 테넌트 키로 카테고리별 권한 목록 조회
+     * 
+     * @param tenantKey 테넌트 키
+     * @param category 카테고리
+     * @return 권한 목록
+     */
+    @Query("SELECT p FROM Permission p WHERE p.tenant.tenantKey = :tenantKey AND p.category = :category AND p.isDeleted = false")
+    List<Permission> findByTenantKeyAndCategory(@Param("tenantKey") String tenantKey, @Param("category") String category);
+    
+    /**
+     * 리소스별 권한 목록 조회
+     * 
+     * @param resource 리소스
+     * @return 권한 목록
+     */
+    List<Permission> findByResource(String resource);
+    
+    /**
+     * 액션별 권한 목록 조회
+     * 
+     * @param action 액션
+     * @return 권한 목록
+     */
+    List<Permission> findByAction(String action);
+    
+    /**
+     * 리소스와 액션으로 권한 조회
+     * 
+     * @param resource 리소스
+     * @param action 액션
+     * @return 권한 목록
+     */
+    List<Permission> findByResourceAndAction(String resource, String action);
+    
+    /**
+     * 테넌트별 리소스와 액션으로 권한 조회
+     * 
+     * @param tenant 테넌트
+     * @param resource 리소스
+     * @param action 액션
+     * @return 권한 목록
+     */
+    @Query("SELECT p FROM Permission p WHERE p.tenant = :tenant AND p.resource = :resource AND p.action = :action AND p.isDeleted = false")
+    List<Permission> findByTenantAndResourceAndAction(@Param("tenant") Tenant tenant, 
+                                                     @Param("resource") String resource, 
+                                                     @Param("action") String action);
+    
+    /**
+     * 권한 키 목록으로 권한 조회
+     * 
+     * @param permissionKeys 권한 키 목록
+     * @return 권한 목록
+     */
+    List<Permission> findByPermissionKeyIn(List<String> permissionKeys);
+    
+    /**
+     * 테넌트별 권한 키 목록으로 권한 조회
+     * 
+     * @param permissionKeys 권한 키 목록
+     * @param tenant 테넌트
+     * @return 권한 목록
+     */
+    @Query("SELECT p FROM Permission p WHERE p.permissionKey IN :permissionKeys AND p.tenant = :tenant AND p.isDeleted = false")
+    List<Permission> findByPermissionKeyInAndTenant(@Param("permissionKeys") List<String> permissionKeys, 
+                                                   @Param("tenant") Tenant tenant);
+    
+    /**
+     * 권한 키 중복 확인 (테넌트별)
+     * 
+     * @param permissionKey 권한 키
+     * @param tenant 테넌트
+     * @return 존재 여부
+     */
+    @Query("SELECT COUNT(p) > 0 FROM Permission p WHERE p.permissionKey = :permissionKey AND p.tenant = :tenant AND p.isDeleted = false")
+    boolean existsByPermissionKeyAndTenant(@Param("permissionKey") String permissionKey, @Param("tenant") Tenant tenant);
+    
+    /**
+     * 권한 키 중복 확인 (테넌트 키별)
+     * 
+     * @param permissionKey 권한 키
+     * @param tenantKey 테넌트 키
+     * @return 존재 여부
+     */
+    @Query("SELECT COUNT(p) > 0 FROM Permission p WHERE p.permissionKey = :permissionKey AND p.tenant.tenantKey = :tenantKey AND p.isDeleted = false")
+    boolean existsByPermissionKeyAndTenantKey(@Param("permissionKey") String permissionKey, @Param("tenantKey") String tenantKey);
+    
+    /**
+     * 권한을 사용하는 역할 수 조회
+     * 
+     * @param permission 권한
+     * @return 역할 수
+     */
+    @Query("SELECT COUNT(r) FROM Role r JOIN r.permissions p WHERE p = :permission AND r.isDeleted = false")
+    Long countRolesByPermission(@Param("permission") Permission permission);
+    
+    /**
+     * 테넌트별 권한 수 조회
+     * 
+     * @param tenant 테넌트
+     * @return 권한 수
+     */
+    @Query("SELECT COUNT(p) FROM Permission p WHERE p.tenant = :tenant AND p.isDeleted = false")
+    Long countPermissionsByTenant(@Param("tenant") Tenant tenant);
+    
+    /**
+     * 테넌트 키로 권한 수 조회
+     * 
+     * @param tenantKey 테넌트 키
+     * @return 권한 수
+     */
+    @Query("SELECT COUNT(p) FROM Permission p WHERE p.tenant.tenantKey = :tenantKey AND p.isDeleted = false")
+    Long countPermissionsByTenantKey(@Param("tenantKey") String tenantKey);
+    
+    /**
+     * 테넌트와 ID로 권한 조회
+     * 
+     * @param id 권한 ID
+     * @param tenant 테넌트
+     * @return 권한
+     */
+    @Query("SELECT p FROM Permission p WHERE p.id = :id AND p.tenant = :tenant AND p.isDeleted = false")
+    Optional<Permission> findByIdAndTenant(@Param("id") Long id, @Param("tenant") Tenant tenant);
+    
+    /**
+     * 테넌트와 ID로 권한 삭제
+     * 
+     * @param id 권한 ID
+     * @param tenant 테넌트
+     */
+    @Query("UPDATE Permission p SET p.isDeleted = true WHERE p.id = :id AND p.tenant = :tenant")
+    void deleteByIdAndTenant(@Param("id") Long id, @Param("tenant") Tenant tenant);
+    
+    /**
+     * 권한 검색 (이름, 설명, 키로 검색)
+     * 
+     * @param keyword 검색 키워드
+     * @param tenant 테넌트
+     * @return 검색된 권한 목록
+     */
+    @Query("SELECT p FROM Permission p WHERE p.tenant = :tenant AND p.isDeleted = false AND " +
+           "(p.permissionKey LIKE %:keyword% OR p.permissionName LIKE %:keyword% OR p.description LIKE %:keyword%)")
+    List<Permission> searchPermissionsByTenant(@Param("keyword") String keyword, @Param("tenant") Tenant tenant);
+    
+    /**
+     * 권한 검색 (이름, 설명, 키로 검색) - 테넌트 키로
+     * 
+     * @param keyword 검색 키워드
+     * @param tenantKey 테넌트 키
+     * @return 검색된 권한 목록
+     */
+    @Query("SELECT p FROM Permission p WHERE p.tenant.tenantKey = :tenantKey AND p.isDeleted = false AND " +
+           "(p.permissionKey LIKE %:keyword% OR p.permissionName LIKE %:keyword% OR p.description LIKE %:keyword%)")
+    List<Permission> searchPermissionsByTenantKey(@Param("keyword") String keyword, @Param("tenantKey") String tenantKey);
+}

--- a/src/main/java/com/agenticcp/core/domain/user/repository/RoleRepository.java
+++ b/src/main/java/com/agenticcp/core/domain/user/repository/RoleRepository.java
@@ -1,0 +1,219 @@
+package com.agenticcp.core.domain.user.repository;
+
+import com.agenticcp.core.common.enums.Status;
+import com.agenticcp.core.common.repository.TenantAwareRepository;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import com.agenticcp.core.domain.user.entity.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 역할 저장소 인터페이스
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Repository
+public interface RoleRepository extends TenantAwareRepository<Role, Long> {
+    
+    /**
+     * 역할 키로 역할 조회
+     * 
+     * @param roleKey 역할 키
+     * @return 역할 정보
+     */
+    Optional<Role> findByRoleKey(String roleKey);
+    
+    /**
+     * 테넌트별 역할 목록 조회
+     * 
+     * @param tenant 테넌트
+     * @return 역할 목록
+     */
+    List<Role> findByTenant(Tenant tenant);
+    
+    /**
+     * 현재 테넌트의 모든 역할을 권한까지 함께 로드
+     */
+    @Query("SELECT DISTINCT r FROM Role r JOIN FETCH r.tenant LEFT JOIN FETCH r.permissions WHERE r.tenant = :tenant AND r.isDeleted = false")
+    List<Role> findByTenantWithPermissions(@Param("tenant") Tenant tenant);
+    
+    /**
+     * 테넌트 키로 역할 목록 조회
+     * 
+     * @param tenantKey 테넌트 키
+     * @return 역할 목록
+     */
+    @Query("SELECT r FROM Role r WHERE r.tenant.tenantKey = :tenantKey AND r.isDeleted = false")
+    List<Role> findByTenantKey(@Param("tenantKey") String tenantKey);
+    
+    /**
+     * 테넌트별 활성 역할 목록 조회
+     * 
+     * @param tenant 테넌트
+     * @param status 상태
+     * @return 활성 역할 목록
+     */
+    @Query("SELECT r FROM Role r WHERE r.tenant = :tenant AND r.status = :status AND r.isDeleted = false")
+    List<Role> findActiveRolesByTenant(@Param("tenant") Tenant tenant, @Param("status") Status status);
+    
+    /**
+     * 테넌트 키로 활성 역할 목록 조회
+     * 
+     * @param tenantKey 테넌트 키
+     * @param status 상태
+     * @return 활성 역할 목록
+     */
+    @Query("SELECT r FROM Role r WHERE r.tenant.tenantKey = :tenantKey AND r.status = :status AND r.isDeleted = false")
+    List<Role> findActiveRolesByTenantKey(@Param("tenantKey") String tenantKey, @Param("status") Status status);
+    
+    /**
+     * 시스템 역할 목록 조회
+     * 
+     * @param isSystem 시스템 역할 여부
+     * @return 시스템 역할 목록
+     */
+    List<Role> findByIsSystem(Boolean isSystem);
+    
+    /**
+     * 기본 역할 목록 조회
+     * 
+     * @param isDefault 기본 역할 여부
+     * @return 기본 역할 목록
+     */
+    List<Role> findByIsDefault(Boolean isDefault);
+    
+    /**
+     * 테넌트별 시스템 역할 조회
+     * 
+     * @param tenant 테넌트
+     * @param isSystem 시스템 역할 여부
+     * @return 시스템 역할 목록
+     */
+    @Query("SELECT r FROM Role r WHERE r.tenant = :tenant AND r.isSystem = :isSystem AND r.isDeleted = false")
+    List<Role> findSystemRolesByTenant(@Param("tenant") Tenant tenant, @Param("isSystem") Boolean isSystem);
+    
+    /**
+     * 테넌트별 기본 역할 조회
+     * 
+     * @param tenant 테넌트
+     * @param isDefault 기본 역할 여부
+     * @return 기본 역할 목록
+     */
+    @Query("SELECT r FROM Role r WHERE r.tenant = :tenant AND r.isDefault = :isDefault AND r.isDeleted = false")
+    List<Role> findDefaultRolesByTenant(@Param("tenant") Tenant tenant, @Param("isDefault") Boolean isDefault);
+    
+    /**
+     * 역할 키 중복 확인 (테넌트별)
+     * 
+     * @param roleKey 역할 키
+     * @param tenant 테넌트
+     * @return 존재 여부
+     */
+    @Query("SELECT COUNT(r) > 0 FROM Role r WHERE r.roleKey = :roleKey AND r.tenant = :tenant AND r.isDeleted = false")
+    boolean existsByRoleKeyAndTenant(@Param("roleKey") String roleKey, @Param("tenant") Tenant tenant);
+    
+    /**
+     * 역할 키 중복 확인 (테넌트 키별)
+     * 
+     * @param roleKey 역할 키
+     * @param tenantKey 테넌트 키
+     * @return 존재 여부
+     */
+    @Query("SELECT COUNT(r) > 0 FROM Role r WHERE r.roleKey = :roleKey AND r.tenant.tenantKey = :tenantKey AND r.isDeleted = false")
+    boolean existsByRoleKeyAndTenantKey(@Param("roleKey") String roleKey, @Param("tenantKey") String tenantKey);
+    
+    /**
+     * 역할을 사용하는 사용자 수 조회
+     * 
+     * @param role 역할
+     * @return 사용자 수
+     */
+    @Query("SELECT COUNT(u) FROM User u JOIN u.roles r WHERE r = :role AND u.isDeleted = false")
+    Long countUsersByRole(@Param("role") Role role);
+    
+    /**
+     * 테넌트별 역할 수 조회
+     * 
+     * @param tenant 테넌트
+     * @return 역할 수
+     */
+    @Query("SELECT COUNT(r) FROM Role r WHERE r.tenant = :tenant AND r.isDeleted = false")
+    Long countRolesByTenant(@Param("tenant") Tenant tenant);
+    
+    /**
+     * 테넌트와 ID로 역할 조회
+     * 
+     * @param id 역할 ID
+     * @param tenant 테넌트
+     * @return 역할
+     */
+    @Query("SELECT r FROM Role r WHERE r.id = :id AND r.tenant = :tenant AND r.isDeleted = false")
+    Optional<Role> findByIdAndTenant(@Param("id") Long id, @Param("tenant") Tenant tenant);
+
+    /**
+     * 역할 키와 테넌트로 권한까지 함께 로드하여 단건 조회
+     *
+     * @param roleKey 역할 키
+     * @param tenant 테넌트
+     * @return 역할 (permissions fetch join)
+     */
+    @Query("SELECT r FROM Role r JOIN FETCH r.tenant LEFT JOIN FETCH r.permissions WHERE r.roleKey = :roleKey AND r.tenant = :tenant AND r.isDeleted = false")
+    Optional<Role> findByRoleKeyAndTenantWithPermissions(@Param("roleKey") String roleKey, @Param("tenant") Tenant tenant);
+
+    /**
+     * ID와 테넌트로 권한까지 함께 로드하여 단건 조회
+     *
+     * @param id 역할 ID
+     * @param tenant 테넌트
+     * @return 역할 (permissions fetch join)
+     */
+    @Query("SELECT r FROM Role r JOIN FETCH r.tenant LEFT JOIN FETCH r.permissions WHERE r.id = :id AND r.tenant = :tenant AND r.isDeleted = false")
+    Optional<Role> findByIdAndTenantWithPermissions(@Param("id") Long id, @Param("tenant") Tenant tenant);
+    
+    /**
+     * 테넌트와 ID로 역할 삭제
+     * 
+     * @param id 역할 ID
+     * @param tenant 테넌트
+     */
+    @Query("UPDATE Role r SET r.isDeleted = true WHERE r.id = :id AND r.tenant = :tenant")
+    void deleteByIdAndTenant(@Param("id") Long id, @Param("tenant") Tenant tenant);
+    
+    /**
+     * 테넌트 키로 역할 수 조회
+     * 
+     * @param tenantKey 테넌트 키
+     * @return 역할 수
+     */
+    @Query("SELECT COUNT(r) FROM Role r WHERE r.tenant.tenantKey = :tenantKey AND r.isDeleted = false")
+    Long countRolesByTenantKey(@Param("tenantKey") String tenantKey);
+    
+    /**
+     * 역할 검색 (이름, 설명, 키로 검색)
+     * 
+     * @param keyword 검색 키워드
+     * @param tenant 테넌트
+     * @return 검색된 역할 목록
+     */
+    @Query("SELECT r FROM Role r WHERE r.tenant = :tenant AND r.isDeleted = false AND " +
+           "(r.roleKey LIKE %:keyword% OR r.roleName LIKE %:keyword% OR r.description LIKE %:keyword%)")
+    List<Role> searchRolesByTenant(@Param("keyword") String keyword, @Param("tenant") Tenant tenant);
+    
+    /**
+     * 역할 검색 (이름, 설명, 키로 검색) - 테넌트 키로
+     * 
+     * @param keyword 검색 키워드
+     * @param tenantKey 테넌트 키
+     * @return 검색된 역할 목록
+     */
+    @Query("SELECT r FROM Role r WHERE r.tenant.tenantKey = :tenantKey AND r.isDeleted = false AND " +
+           "(r.roleKey LIKE %:keyword% OR r.roleName LIKE %:keyword% OR r.description LIKE %:keyword%)")
+    List<Role> searchRolesByTenantKey(@Param("keyword") String keyword, @Param("tenantKey") String tenantKey);
+}

--- a/src/main/java/com/agenticcp/core/domain/user/service/PermissionService.java
+++ b/src/main/java/com/agenticcp/core/domain/user/service/PermissionService.java
@@ -2,6 +2,7 @@ package com.agenticcp.core.domain.user.service;
 
 import com.agenticcp.core.common.context.TenantContextHolder;
 import com.agenticcp.core.common.enums.Status;
+import com.agenticcp.core.common.util.LogMaskingUtils;
 import com.agenticcp.core.common.exception.BusinessException;
 import com.agenticcp.core.common.exception.ResourceNotFoundException;
 import com.agenticcp.core.domain.tenant.entity.Tenant;
@@ -45,7 +46,10 @@ public class PermissionService {
      */
     public List<Permission> getAllPermissions() {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
-        return permissionRepository.findByTenant(currentTenant);
+        log.info("[PermissionService] getAllPermissions - tenantKey={}", LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        List<Permission> result = permissionRepository.findByTenant(currentTenant);
+        log.info("[PermissionService] getAllPermissions - success count={} tenantKey={}", result.size(), LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        return result;
     }
     
     /**
@@ -55,7 +59,10 @@ public class PermissionService {
      * @return 권한 목록
      */
     public List<Permission> getPermissionsByTenant(String tenantKey) {
-        return permissionRepository.findByTenantKey(tenantKey);
+        log.info("[PermissionService] getPermissionsByTenant - tenantKey={}", LogMaskingUtils.maskTenantKey(tenantKey));
+        List<Permission> result = permissionRepository.findByTenantKey(tenantKey);
+        log.info("[PermissionService] getPermissionsByTenant - success count={} tenantKey={}", result.size(), LogMaskingUtils.maskTenantKey(tenantKey));
+        return result;
     }
     
     /**
@@ -66,7 +73,15 @@ public class PermissionService {
      */
     public Optional<Permission> getPermissionByKey(String permissionKey) {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
-        return permissionRepository.findByPermissionKeyAndTenant(permissionKey, currentTenant);
+        log.info("[PermissionService] getPermissionByKey - permissionKey={} tenantKey={}",
+                LogMaskingUtils.maskPermissionKey(permissionKey),
+                LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        Optional<Permission> result = permissionRepository.findByPermissionKeyAndTenant(permissionKey, currentTenant);
+        log.info("[PermissionService] getPermissionByKey - found={} permissionKey={} tenantKey={}",
+                result.isPresent(),
+                LogMaskingUtils.maskPermissionKey(permissionKey),
+                LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        return result;
     }
     
     /**
@@ -77,8 +92,11 @@ public class PermissionService {
      * @throws ResourceNotFoundException 권한을 찾을 수 없는 경우
      */
     public Permission getPermissionByKeyOrThrow(String permissionKey) {
-        return getPermissionByKey(permissionKey)
+        log.info("[PermissionService] getPermissionByKeyOrThrow - permissionKey={}", LogMaskingUtils.maskPermissionKey(permissionKey));
+        Permission permission = getPermissionByKey(permissionKey)
                 .orElseThrow(() -> new ResourceNotFoundException("Permission", "permissionKey", permissionKey));
+        log.info("[PermissionService] getPermissionByKeyOrThrow - success permissionKey={}", LogMaskingUtils.maskPermissionKey(permissionKey));
+        return permission;
     }
     
     /**
@@ -88,7 +106,10 @@ public class PermissionService {
      */
     public List<Permission> getActivePermissions() {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
-        return permissionRepository.findActivePermissionsByTenant(currentTenant, Status.ACTIVE);
+        log.info("[PermissionService] getActivePermissions - tenantKey={}", LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        List<Permission> result = permissionRepository.findActivePermissionsByTenant(currentTenant, Status.ACTIVE);
+        log.info("[PermissionService] getActivePermissions - success count={} tenantKey={}", result.size(), LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        return result;
     }
     
     /**
@@ -98,9 +119,12 @@ public class PermissionService {
      */
     public List<Permission> getSystemPermissions() {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
-        return permissionRepository.findByTenant(currentTenant).stream()
+        log.info("[PermissionService] getSystemPermissions - tenantKey={}", LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        List<Permission> result = permissionRepository.findByTenant(currentTenant).stream()
                 .filter(permission -> Boolean.TRUE.equals(permission.getIsSystem()))
                 .collect(Collectors.toList());
+        log.info("[PermissionService] getSystemPermissions - success count={} tenantKey={}", result.size(), LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        return result;
     }
     
     /**
@@ -111,7 +135,10 @@ public class PermissionService {
      */
     public List<Permission> getPermissionsByCategory(String category) {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
-        return permissionRepository.findByTenantAndCategory(currentTenant, category);
+        log.info("[PermissionService] getPermissionsByCategory - category={} tenantKey={}", category, LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        List<Permission> result = permissionRepository.findByTenantAndCategory(currentTenant, category);
+        log.info("[PermissionService] getPermissionsByCategory - success count={} category={} tenantKey={}", result.size(), category, LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        return result;
     }
     
     /**
@@ -122,9 +149,12 @@ public class PermissionService {
      */
     public List<Permission> getPermissionsByResource(String resource) {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
-        return permissionRepository.findByTenant(currentTenant).stream()
+        log.info("[PermissionService] getPermissionsByResource - resource={} tenantKey={}", resource, LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        List<Permission> result = permissionRepository.findByTenant(currentTenant).stream()
                 .filter(permission -> resource.equals(permission.getResource()))
                 .collect(Collectors.toList());
+        log.info("[PermissionService] getPermissionsByResource - success count={} resource={} tenantKey={}", result.size(), resource, LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        return result;
     }
     
     /**
@@ -135,9 +165,12 @@ public class PermissionService {
      */
     public List<Permission> getPermissionsByAction(String action) {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
-        return permissionRepository.findByTenant(currentTenant).stream()
+        log.info("[PermissionService] getPermissionsByAction - action={} tenantKey={}", action, LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        List<Permission> result = permissionRepository.findByTenant(currentTenant).stream()
                 .filter(permission -> action.equals(permission.getAction()))
                 .collect(Collectors.toList());
+        log.info("[PermissionService] getPermissionsByAction - success count={} action={} tenantKey={}", result.size(), action, LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        return result;
     }
     
     /**
@@ -149,7 +182,10 @@ public class PermissionService {
      */
     public List<Permission> getPermissionsByResourceAndAction(String resource, String action) {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
-        return permissionRepository.findByTenantAndResourceAndAction(currentTenant, resource, action);
+        log.info("[PermissionService] getPermissionsByResourceAndAction - resource={} action={} tenantKey={}", resource, action, LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        List<Permission> result = permissionRepository.findByTenantAndResourceAndAction(currentTenant, resource, action);
+        log.info("[PermissionService] getPermissionsByResourceAndAction - success count={} resource={} action={} tenantKey={}", result.size(), resource, action, LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        return result;
     }
     
     /**
@@ -160,7 +196,10 @@ public class PermissionService {
      */
     public List<Permission> searchPermissions(String keyword) {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
-        return permissionRepository.searchPermissionsByTenant(keyword, currentTenant);
+        log.info("[PermissionService] searchPermissions - keyword={} tenantKey={}", LogMaskingUtils.mask(keyword, 2, 1), LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        List<Permission> result = permissionRepository.searchPermissionsByTenant(keyword, currentTenant);
+        log.info("[PermissionService] searchPermissions - success count={} tenantKey={}", result.size(), LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        return result;
     }
     
     /**
@@ -172,6 +211,13 @@ public class PermissionService {
     @Transactional
     public Permission createPermission(CreatePermissionRequest request) {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        log.info("[PermissionService] createPermission - tenantKey={} permissionKey={} resource={} action={} category={} priority={}",
+                LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()),
+                LogMaskingUtils.maskPermissionKey(request.getPermissionKey()),
+                request.getResource(),
+                request.getAction(),
+                request.getCategory(),
+                request.getPriority());
         
         // 권한 키 중복 확인
         if (permissionRepository.existsByPermissionKeyAndTenant(request.getPermissionKey(), currentTenant)) {
@@ -197,7 +243,9 @@ public class PermissionService {
         // 캐시 무효화
         evictPermissionCache();
         
-        log.info("Permission created: {} in tenant: {}", savedPermission.getPermissionKey(), currentTenant.getTenantKey());
+        log.info("[PermissionService] createPermission - success permissionKey={} tenantKey={}",
+                LogMaskingUtils.maskPermissionKey(savedPermission.getPermissionKey()),
+                LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
         return savedPermission;
     }
     
@@ -210,6 +258,14 @@ public class PermissionService {
      */
     @Transactional
     public Permission updatePermission(String permissionKey, UpdatePermissionRequest request) {
+        log.info("[PermissionService] updatePermission - permissionKey={} fields=[name:{}, desc:set?{}, resource:{}, action:{}, category:{}, priority:{}]",
+                LogMaskingUtils.maskPermissionKey(permissionKey),
+                request.getPermissionName(),
+                request.getDescription() != null,
+                request.getResource(),
+                request.getAction(),
+                request.getCategory(),
+                request.getPriority());
         Permission permission = getPermissionByKeyOrThrow(permissionKey);
         
         // 시스템 권한 수정 제한
@@ -243,7 +299,9 @@ public class PermissionService {
         evictPermissionCache();
         evictUserPermissionCache();
         
-        log.info("Permission updated: {} in tenant: {}", permissionKey, permission.getTenant().getTenantKey());
+        log.info("[PermissionService] updatePermission - success permissionKey={} tenantKey={}",
+                LogMaskingUtils.maskPermissionKey(permissionKey),
+                LogMaskingUtils.maskTenantKey(permission.getTenant().getTenantKey()));
         return updatedPermission;
     }
     
@@ -254,6 +312,7 @@ public class PermissionService {
      */
     @Transactional
     public void deletePermission(String permissionKey) {
+        log.info("[PermissionService] deletePermission - permissionKey={}", LogMaskingUtils.maskPermissionKey(permissionKey));
         Permission permission = getPermissionByKeyOrThrow(permissionKey);
         
         // 시스템 권한 삭제 방지
@@ -275,7 +334,9 @@ public class PermissionService {
         evictPermissionCache();
         evictUserPermissionCache();
         
-        log.info("Permission deleted: {} in tenant: {}", permissionKey, permission.getTenant().getTenantKey());
+        log.info("[PermissionService] deletePermission - success permissionKey={} tenantKey={}",
+                LogMaskingUtils.maskPermissionKey(permissionKey),
+                LogMaskingUtils.maskTenantKey(permission.getTenant().getTenantKey()));
     }
     
     /**

--- a/src/main/java/com/agenticcp/core/domain/user/service/PermissionService.java
+++ b/src/main/java/com/agenticcp/core/domain/user/service/PermissionService.java
@@ -1,0 +1,333 @@
+package com.agenticcp.core.domain.user.service;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.common.enums.Status;
+import com.agenticcp.core.common.exception.BusinessException;
+import com.agenticcp.core.common.exception.ResourceNotFoundException;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import com.agenticcp.core.domain.user.dto.CreatePermissionRequest;
+import com.agenticcp.core.domain.user.dto.PermissionResponse;
+import com.agenticcp.core.domain.user.dto.UpdatePermissionRequest;
+import com.agenticcp.core.domain.user.entity.Permission;
+import com.agenticcp.core.domain.user.repository.PermissionRepository;
+import com.agenticcp.core.domain.user.repository.RoleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * 권한 관리 서비스
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PermissionService {
+    
+    private final PermissionRepository permissionRepository;
+    private final RoleRepository roleRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+    
+    /**
+     * 모든 권한 조회 (현재 테넌트)
+     * 
+     * @return 권한 목록
+     */
+    public List<Permission> getAllPermissions() {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return permissionRepository.findByTenant(currentTenant);
+    }
+    
+    /**
+     * 테넌트별 권한 조회
+     * 
+     * @param tenantKey 테넌트 키
+     * @return 권한 목록
+     */
+    public List<Permission> getPermissionsByTenant(String tenantKey) {
+        return permissionRepository.findByTenantKey(tenantKey);
+    }
+    
+    /**
+     * 권한 키로 권한 조회
+     * 
+     * @param permissionKey 권한 키
+     * @return 권한 정보
+     */
+    public Optional<Permission> getPermissionByKey(String permissionKey) {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return permissionRepository.findByPermissionKeyAndTenant(permissionKey, currentTenant);
+    }
+    
+    /**
+     * 권한 키로 권한 조회 (예외 발생)
+     * 
+     * @param permissionKey 권한 키
+     * @return 권한 정보
+     * @throws ResourceNotFoundException 권한을 찾을 수 없는 경우
+     */
+    public Permission getPermissionByKeyOrThrow(String permissionKey) {
+        return getPermissionByKey(permissionKey)
+                .orElseThrow(() -> new ResourceNotFoundException("Permission", "permissionKey", permissionKey));
+    }
+    
+    /**
+     * 활성 권한 조회
+     * 
+     * @return 활성 권한 목록
+     */
+    public List<Permission> getActivePermissions() {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return permissionRepository.findActivePermissionsByTenant(currentTenant, Status.ACTIVE);
+    }
+    
+    /**
+     * 시스템 권한 조회
+     * 
+     * @return 시스템 권한 목록
+     */
+    public List<Permission> getSystemPermissions() {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return permissionRepository.findByTenant(currentTenant).stream()
+                .filter(permission -> Boolean.TRUE.equals(permission.getIsSystem()))
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * 카테고리별 권한 조회
+     * 
+     * @param category 카테고리
+     * @return 권한 목록
+     */
+    public List<Permission> getPermissionsByCategory(String category) {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return permissionRepository.findByTenantAndCategory(currentTenant, category);
+    }
+    
+    /**
+     * 리소스별 권한 조회
+     * 
+     * @param resource 리소스
+     * @return 권한 목록
+     */
+    public List<Permission> getPermissionsByResource(String resource) {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return permissionRepository.findByTenant(currentTenant).stream()
+                .filter(permission -> resource.equals(permission.getResource()))
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * 액션별 권한 조회
+     * 
+     * @param action 액션
+     * @return 권한 목록
+     */
+    public List<Permission> getPermissionsByAction(String action) {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return permissionRepository.findByTenant(currentTenant).stream()
+                .filter(permission -> action.equals(permission.getAction()))
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * 리소스와 액션으로 권한 조회
+     * 
+     * @param resource 리소스
+     * @param action 액션
+     * @return 권한 목록
+     */
+    public List<Permission> getPermissionsByResourceAndAction(String resource, String action) {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return permissionRepository.findByTenantAndResourceAndAction(currentTenant, resource, action);
+    }
+    
+    /**
+     * 권한 검색
+     * 
+     * @param keyword 검색 키워드
+     * @return 검색된 권한 목록
+     */
+    public List<Permission> searchPermissions(String keyword) {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return permissionRepository.searchPermissionsByTenant(keyword, currentTenant);
+    }
+    
+    /**
+     * 권한 생성
+     * 
+     * @param request 권한 생성 요청
+     * @return 생성된 권한
+     */
+    @Transactional
+    public Permission createPermission(CreatePermissionRequest request) {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        
+        // 권한 키 중복 확인
+        if (permissionRepository.existsByPermissionKeyAndTenant(request.getPermissionKey(), currentTenant)) {
+            throw new BusinessException("이미 존재하는 권한 키입니다: " + request.getPermissionKey());
+        }
+        
+        // 권한 생성
+        Permission permission = Permission.builder()
+                .permissionKey(request.getPermissionKey())
+                .permissionName(request.getPermissionName())
+                .description(request.getDescription())
+                .tenant(currentTenant)
+                .resource(request.getResource())
+                .action(request.getAction())
+                .isSystem(false)
+                .category(request.getCategory())
+                .priority(request.getPriority())
+                .status(Status.ACTIVE)
+                .build();
+        
+        Permission savedPermission = permissionRepository.save(permission);
+        
+        // 캐시 무효화
+        evictPermissionCache();
+        
+        log.info("Permission created: {} in tenant: {}", savedPermission.getPermissionKey(), currentTenant.getTenantKey());
+        return savedPermission;
+    }
+    
+    /**
+     * 권한 수정
+     * 
+     * @param permissionKey 권한 키
+     * @param request 권한 수정 요청
+     * @return 수정된 권한
+     */
+    @Transactional
+    public Permission updatePermission(String permissionKey, UpdatePermissionRequest request) {
+        Permission permission = getPermissionByKeyOrThrow(permissionKey);
+        
+        // 시스템 권한 수정 제한
+        if (permission.getIsSystem() && request.getIsSystem() != null && !request.getIsSystem()) {
+            throw new BusinessException("시스템 권한은 수정할 수 없습니다");
+        }
+        
+        // 권한 정보 업데이트
+        if (request.getPermissionName() != null) {
+            permission.setPermissionName(request.getPermissionName());
+        }
+        if (request.getDescription() != null) {
+            permission.setDescription(request.getDescription());
+        }
+        if (request.getResource() != null) {
+            permission.setResource(request.getResource());
+        }
+        if (request.getAction() != null) {
+            permission.setAction(request.getAction());
+        }
+        if (request.getCategory() != null) {
+            permission.setCategory(request.getCategory());
+        }
+        if (request.getPriority() != null) {
+            permission.setPriority(request.getPriority());
+        }
+        
+        Permission updatedPermission = permissionRepository.save(permission);
+        
+        // 캐시 무효화
+        evictPermissionCache();
+        evictUserPermissionCache();
+        
+        log.info("Permission updated: {} in tenant: {}", permissionKey, permission.getTenant().getTenantKey());
+        return updatedPermission;
+    }
+    
+    /**
+     * 권한 삭제
+     * 
+     * @param permissionKey 권한 키
+     */
+    @Transactional
+    public void deletePermission(String permissionKey) {
+        Permission permission = getPermissionByKeyOrThrow(permissionKey);
+        
+        // 시스템 권한 삭제 방지
+        if (permission.getIsSystem()) {
+            throw new BusinessException("시스템 권한은 삭제할 수 없습니다");
+        }
+        
+        // 권한을 사용하는 역할 확인
+        Long roleCount = permissionRepository.countRolesByPermission(permission);
+        if (roleCount > 0) {
+            throw new BusinessException("이 권한을 사용하는 역할이 있어 삭제할 수 없습니다");
+        }
+        
+        // 소프트 삭제
+        permission.setIsDeleted(true);
+        permissionRepository.save(permission);
+        
+        // 캐시 무효화
+        evictPermissionCache();
+        evictUserPermissionCache();
+        
+        log.info("Permission deleted: {} in tenant: {}", permissionKey, permission.getTenant().getTenantKey());
+    }
+    
+    /**
+     * 권한 응답 DTO 변환
+     * 
+     * @param permission 권한 엔티티
+     * @return 권한 응답 DTO
+     */
+    public PermissionResponse toPermissionResponse(Permission permission) {
+        // LazyInitializationException 방지를 위해 컨텍스트의 테넌트 정보를 사용
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return PermissionResponse.builder()
+                .id(permission.getId())
+                .permissionKey(permission.getPermissionKey())
+                .permissionName(permission.getPermissionName())
+                .description(permission.getDescription())
+                .tenantKey(currentTenant.getTenantKey())
+                .tenantName(currentTenant.getTenantName())
+                .status(permission.getStatus())
+                .resource(permission.getResource())
+                .action(permission.getAction())
+                .isSystem(permission.getIsSystem())
+                .category(permission.getCategory())
+                .priority(permission.getPriority())
+                .createdAt(permission.getCreatedAt())
+                .updatedAt(permission.getUpdatedAt())
+                .createdBy(permission.getCreatedBy())
+                .updatedBy(permission.getUpdatedBy())
+                .build();
+    }
+    
+    /**
+     * 권한 캐시 무효화
+     */
+    private void evictPermissionCache() {
+        try {
+            redisTemplate.delete("permissions:*");
+            log.debug("Permission cache evicted");
+        } catch (Exception e) {
+            log.warn("Failed to evict permission cache: {}", e.getMessage());
+        }
+    }
+    
+    /**
+     * 사용자 권한 캐시 무효화
+     */
+    private void evictUserPermissionCache() {
+        try {
+            redisTemplate.delete("user_permissions:*");
+            log.debug("User permission cache evicted");
+        } catch (Exception e) {
+            log.warn("Failed to evict user permission cache: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/user/service/RoleService.java
+++ b/src/main/java/com/agenticcp/core/domain/user/service/RoleService.java
@@ -2,6 +2,7 @@ package com.agenticcp.core.domain.user.service;
 
 import com.agenticcp.core.common.context.TenantContextHolder;
 import com.agenticcp.core.common.dto.ApiResponse;
+import com.agenticcp.core.common.util.LogMaskingUtils;
 import com.agenticcp.core.common.enums.Status;
 import com.agenticcp.core.common.exception.BusinessException;
 import com.agenticcp.core.common.exception.ResourceNotFoundException;
@@ -49,7 +50,10 @@ public class RoleService {
      */
     public List<Role> getAllRoles() {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
-        return roleRepository.findByTenantWithPermissions(currentTenant);
+        log.info("[RoleService] getAllRoles - tenantKey={}", LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        List<Role> result = roleRepository.findByTenantWithPermissions(currentTenant);
+        log.info("[RoleService] getAllRoles - success count={} tenantKey={}", result.size(), LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        return result;
     }
     
     /**
@@ -59,7 +63,10 @@ public class RoleService {
      * @return 역할 목록
      */
     public List<Role> getRolesByTenant(String tenantKey) {
-        return roleRepository.findByTenantKey(tenantKey);
+        log.info("[RoleService] getRolesByTenant - tenantKey={}", LogMaskingUtils.maskTenantKey(tenantKey));
+        List<Role> result = roleRepository.findByTenantKey(tenantKey);
+        log.info("[RoleService] getRolesByTenant - success count={} tenantKey={}", result.size(), LogMaskingUtils.maskTenantKey(tenantKey));
+        return result;
     }
     
     /**
@@ -70,7 +77,10 @@ public class RoleService {
      */
     public Optional<Role> getRoleByKey(String roleKey) {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
-        return roleRepository.findByRoleKeyAndTenantWithPermissions(roleKey, currentTenant);
+        log.info("[RoleService] getRoleByKey - roleKey={} tenantKey={}", LogMaskingUtils.mask(roleKey, 2, 2), LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        Optional<Role> result = roleRepository.findByRoleKeyAndTenantWithPermissions(roleKey, currentTenant);
+        log.info("[RoleService] getRoleByKey - found={} roleKey={} tenantKey={}", result.isPresent(), LogMaskingUtils.mask(roleKey, 2, 2), LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        return result;
     }
     
     /**
@@ -81,8 +91,11 @@ public class RoleService {
      * @throws ResourceNotFoundException 역할을 찾을 수 없는 경우
      */
     public Role getRoleByKeyOrThrow(String roleKey) {
-        return getRoleByKey(roleKey)
+        log.info("[RoleService] getRoleByKeyOrThrow - roleKey={}", LogMaskingUtils.mask(roleKey, 2, 2));
+        Role role = getRoleByKey(roleKey)
                 .orElseThrow(() -> new ResourceNotFoundException("Role", "roleKey", roleKey));
+        log.info("[RoleService] getRoleByKeyOrThrow - success roleKey={}", LogMaskingUtils.mask(roleKey, 2, 2));
+        return role;
     }
     
     /**
@@ -92,7 +105,10 @@ public class RoleService {
      */
     public List<Role> getActiveRoles() {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
-        return roleRepository.findActiveRolesByTenant(currentTenant, Status.ACTIVE);
+        log.info("[RoleService] getActiveRoles - tenantKey={}", LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        List<Role> result = roleRepository.findActiveRolesByTenant(currentTenant, Status.ACTIVE);
+        log.info("[RoleService] getActiveRoles - success count={} tenantKey={}", result.size(), LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        return result;
     }
     
     /**
@@ -102,7 +118,10 @@ public class RoleService {
      */
     public List<Role> getSystemRoles() {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
-        return roleRepository.findSystemRolesByTenant(currentTenant, true);
+        log.info("[RoleService] getSystemRoles - tenantKey={}", LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        List<Role> result = roleRepository.findSystemRolesByTenant(currentTenant, true);
+        log.info("[RoleService] getSystemRoles - success count={} tenantKey={}", result.size(), LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        return result;
     }
     
     /**
@@ -112,7 +131,10 @@ public class RoleService {
      */
     public List<Role> getDefaultRoles() {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
-        return roleRepository.findDefaultRolesByTenant(currentTenant, true);
+        log.info("[RoleService] getDefaultRoles - tenantKey={}", LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        List<Role> result = roleRepository.findDefaultRolesByTenant(currentTenant, true);
+        log.info("[RoleService] getDefaultRoles - success count={} tenantKey={}", result.size(), LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        return result;
     }
     
     /**
@@ -123,7 +145,10 @@ public class RoleService {
      */
     public List<Role> searchRoles(String keyword) {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
-        return roleRepository.searchRolesByTenant(keyword, currentTenant);
+        log.info("[RoleService] searchRoles - keyword={} tenantKey={}", LogMaskingUtils.mask(keyword, 2, 1), LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        List<Role> result = roleRepository.searchRolesByTenant(keyword, currentTenant);
+        log.info("[RoleService] searchRoles - success count={} tenantKey={}", result.size(), LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
+        return result;
     }
     
     /**
@@ -135,6 +160,11 @@ public class RoleService {
     @Transactional
     public Role createRole(CreateRoleRequest request) {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        log.info("[RoleService] createRole - tenantKey={} roleKey={} isSystem={} priority={}",
+                LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()),
+                LogMaskingUtils.mask(request.getRoleKey(), 2, 2),
+                request.getIsSystem(),
+                request.getPriority());
         
         // 역할 키 중복 확인
         if (roleRepository.existsByRoleKeyAndTenant(request.getRoleKey(), currentTenant)) {
@@ -163,7 +193,9 @@ public class RoleService {
         // 캐시 무효화
         evictRoleCache();
         
-        log.info("Role created: {} in tenant: {}", savedRole.getRoleKey(), currentTenant.getTenantKey());
+        log.info("[RoleService] createRole - success roleKey={} tenantKey={}",
+                LogMaskingUtils.mask(savedRole.getRoleKey(), 2, 2),
+                LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
         // 권한 포함하여 다시 로드해 반환
         return roleRepository.findByIdAndTenantWithPermissions(savedRole.getId(), currentTenant)
                 .orElse(savedRole);
@@ -178,6 +210,11 @@ public class RoleService {
      */
     @Transactional
     public Role updateRole(String roleKey, UpdateRoleRequest request) {
+        log.info("[RoleService] updateRole - roleKey={} fields=[name:{}, desc:set?{}, priority:{}]",
+                LogMaskingUtils.mask(roleKey, 2, 2),
+                request.getRoleName(),
+                request.getDescription() != null,
+                request.getPriority());
         Role role = getRoleByKeyOrThrow(roleKey);
         
         // 시스템 역할 수정 제한
@@ -206,7 +243,9 @@ public class RoleService {
         // 캐시 무효화
         evictRoleCache();
         
-        log.info("Role updated: {} in tenant: {}", roleKey, role.getTenant().getTenantKey());
+        log.info("[RoleService] updateRole - success roleKey={} tenantKey={}",
+                LogMaskingUtils.mask(roleKey, 2, 2),
+                LogMaskingUtils.maskTenantKey(role.getTenant().getTenantKey()));
         return updatedRole;
     }
     
@@ -217,6 +256,7 @@ public class RoleService {
      */
     @Transactional
     public void deleteRole(String roleKey) {
+        log.info("[RoleService] deleteRole - roleKey={}", LogMaskingUtils.mask(roleKey, 2, 2));
         Role role = getRoleByKeyOrThrow(roleKey);
         
         // 시스템 역할 삭제 방지
@@ -242,7 +282,9 @@ public class RoleService {
         // 캐시 무효화
         evictRoleCache();
         
-        log.info("Role deleted: {} in tenant: {}", roleKey, role.getTenant().getTenantKey());
+        log.info("[RoleService] deleteRole - success roleKey={} tenantKey={}",
+                LogMaskingUtils.mask(roleKey, 2, 2),
+                LogMaskingUtils.maskTenantKey(role.getTenant().getTenantKey()));
     }
     
     /**
@@ -254,6 +296,10 @@ public class RoleService {
     @Transactional
     public void assignPermissionsToRole(Long roleId, List<String> permissionKeys) {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        log.info("[RoleService] assignPermissionsToRole - roleId={} permissionKeys={} tenantKey={}",
+                roleId,
+                permissionKeys == null ? 0 : permissionKeys.size(),
+                LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
         
         Role role = roleRepository.findById(roleId)
                 .orElseThrow(() -> new ResourceNotFoundException("Role", "id", roleId));
@@ -275,7 +321,9 @@ public class RoleService {
         // 사용자 권한 캐시 무효화
         evictUserPermissionCache();
         
-        log.info("Permissions assigned to role: {} in tenant: {}", role.getRoleKey(), currentTenant.getTenantKey());
+        log.info("[RoleService] assignPermissionsToRole - success roleKey={} tenantKey={}",
+                LogMaskingUtils.mask(role.getRoleKey(), 2, 2),
+                LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
     }
     
     /**
@@ -298,6 +346,10 @@ public class RoleService {
     @Transactional
     public void removePermissionFromRole(Long roleId, String permissionKey) {
         Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        log.info("[RoleService] removePermissionFromRole - roleId={} permissionKey={} tenantKey={}",
+                roleId,
+                LogMaskingUtils.mask(permissionKey, 2, 2),
+                LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
         
         Role role = roleRepository.findById(roleId)
                 .orElseThrow(() -> new ResourceNotFoundException("Role", "id", roleId));
@@ -325,7 +377,9 @@ public class RoleService {
         // 사용자 권한 캐시 무효화
         evictUserPermissionCache();
         
-        log.info("Permission removed from role: {} in tenant: {}", role.getRoleKey(), currentTenant.getTenantKey());
+        log.info("[RoleService] removePermissionFromRole - success roleKey={} tenantKey={}",
+                LogMaskingUtils.mask(role.getRoleKey(), 2, 2),
+                LogMaskingUtils.maskTenantKey(currentTenant.getTenantKey()));
     }
     
     /**

--- a/src/main/java/com/agenticcp/core/domain/user/service/RoleService.java
+++ b/src/main/java/com/agenticcp/core/domain/user/service/RoleService.java
@@ -1,0 +1,410 @@
+package com.agenticcp.core.domain.user.service;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.common.dto.ApiResponse;
+import com.agenticcp.core.common.enums.Status;
+import com.agenticcp.core.common.exception.BusinessException;
+import com.agenticcp.core.common.exception.ResourceNotFoundException;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import com.agenticcp.core.domain.user.dto.CreateRoleRequest;
+import com.agenticcp.core.domain.user.dto.RoleResponse;
+import com.agenticcp.core.domain.user.dto.UpdateRoleRequest;
+import com.agenticcp.core.domain.user.entity.Permission;
+import com.agenticcp.core.domain.user.entity.Role;
+import com.agenticcp.core.domain.user.repository.PermissionRepository;
+import com.agenticcp.core.domain.user.repository.RoleRepository;
+import com.agenticcp.core.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * 역할 관리 서비스
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RoleService {
+    
+    private final RoleRepository roleRepository;
+    private final PermissionRepository permissionRepository;
+    private final UserRepository userRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+    
+    /**
+     * 모든 역할 조회 (현재 테넌트)
+     * 
+     * @return 역할 목록
+     */
+    public List<Role> getAllRoles() {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return roleRepository.findByTenantWithPermissions(currentTenant);
+    }
+    
+    /**
+     * 테넌트별 역할 조회
+     * 
+     * @param tenantKey 테넌트 키
+     * @return 역할 목록
+     */
+    public List<Role> getRolesByTenant(String tenantKey) {
+        return roleRepository.findByTenantKey(tenantKey);
+    }
+    
+    /**
+     * 역할 키로 역할 조회
+     * 
+     * @param roleKey 역할 키
+     * @return 역할 정보
+     */
+    public Optional<Role> getRoleByKey(String roleKey) {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return roleRepository.findByRoleKeyAndTenantWithPermissions(roleKey, currentTenant);
+    }
+    
+    /**
+     * 역할 키로 역할 조회 (예외 발생)
+     * 
+     * @param roleKey 역할 키
+     * @return 역할 정보
+     * @throws ResourceNotFoundException 역할을 찾을 수 없는 경우
+     */
+    public Role getRoleByKeyOrThrow(String roleKey) {
+        return getRoleByKey(roleKey)
+                .orElseThrow(() -> new ResourceNotFoundException("Role", "roleKey", roleKey));
+    }
+    
+    /**
+     * 활성 역할 조회
+     * 
+     * @return 활성 역할 목록
+     */
+    public List<Role> getActiveRoles() {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return roleRepository.findActiveRolesByTenant(currentTenant, Status.ACTIVE);
+    }
+    
+    /**
+     * 시스템 역할 조회
+     * 
+     * @return 시스템 역할 목록
+     */
+    public List<Role> getSystemRoles() {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return roleRepository.findSystemRolesByTenant(currentTenant, true);
+    }
+    
+    /**
+     * 기본 역할 조회
+     * 
+     * @return 기본 역할 목록
+     */
+    public List<Role> getDefaultRoles() {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return roleRepository.findDefaultRolesByTenant(currentTenant, true);
+    }
+    
+    /**
+     * 역할 검색
+     * 
+     * @param keyword 검색 키워드
+     * @return 검색된 역할 목록
+     */
+    public List<Role> searchRoles(String keyword) {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        return roleRepository.searchRolesByTenant(keyword, currentTenant);
+    }
+    
+    /**
+     * 역할 생성
+     * 
+     * @param request 역할 생성 요청
+     * @return 생성된 역할
+     */
+    @Transactional
+    public Role createRole(CreateRoleRequest request) {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        
+        // 역할 키 중복 확인
+        if (roleRepository.existsByRoleKeyAndTenant(request.getRoleKey(), currentTenant)) {
+            throw new BusinessException("이미 존재하는 역할 키입니다: " + request.getRoleKey());
+        }
+        
+        // 역할 생성
+        Role role = Role.builder()
+                .roleKey(request.getRoleKey())
+                .roleName(request.getRoleName())
+                .description(request.getDescription())
+                .tenant(currentTenant)
+                .isSystem(Boolean.TRUE.equals(request.getIsSystem()))
+                .isDefault(false)
+                .priority(request.getPriority())
+                .status(Status.ACTIVE)
+                .build();
+        
+        Role savedRole = roleRepository.save(role);
+        
+        // 권한 매핑
+        if (request.getPermissionKeys() != null && !request.getPermissionKeys().isEmpty()) {
+            assignPermissionsToRole(savedRole.getId(), request.getPermissionKeys());
+        }
+        
+        // 캐시 무효화
+        evictRoleCache();
+        
+        log.info("Role created: {} in tenant: {}", savedRole.getRoleKey(), currentTenant.getTenantKey());
+        // 권한 포함하여 다시 로드해 반환
+        return roleRepository.findByIdAndTenantWithPermissions(savedRole.getId(), currentTenant)
+                .orElse(savedRole);
+    }
+    
+    /**
+     * 역할 수정
+     * 
+     * @param roleKey 역할 키
+     * @param request 역할 수정 요청
+     * @return 수정된 역할
+     */
+    @Transactional
+    public Role updateRole(String roleKey, UpdateRoleRequest request) {
+        Role role = getRoleByKeyOrThrow(roleKey);
+        
+        // 시스템 역할 수정 제한
+        if (role.getIsSystem() && request.getIsSystem() != null && !request.getIsSystem()) {
+            throw new BusinessException("시스템 역할은 수정할 수 없습니다");
+        }
+        
+        // 역할 정보 업데이트
+        if (request.getRoleName() != null) {
+            role.setRoleName(request.getRoleName());
+        }
+        if (request.getDescription() != null) {
+            role.setDescription(request.getDescription());
+        }
+        if (request.getPriority() != null) {
+            role.setPriority(request.getPriority());
+        }
+        
+        Role updatedRole = roleRepository.save(role);
+        
+        // 권한 업데이트
+        if (request.getPermissionKeys() != null) {
+            updateRolePermissions(role.getId(), request.getPermissionKeys());
+        }
+        
+        // 캐시 무효화
+        evictRoleCache();
+        
+        log.info("Role updated: {} in tenant: {}", roleKey, role.getTenant().getTenantKey());
+        return updatedRole;
+    }
+    
+    /**
+     * 역할 삭제
+     * 
+     * @param roleKey 역할 키
+     */
+    @Transactional
+    public void deleteRole(String roleKey) {
+        Role role = getRoleByKeyOrThrow(roleKey);
+        
+        // 시스템 역할 삭제 방지
+        if (role.getIsSystem()) {
+            throw new BusinessException("시스템 역할은 삭제할 수 없습니다");
+        }
+        
+        // 기본 역할 삭제 방지
+        if (role.getIsDefault()) {
+            throw new BusinessException("기본 역할은 삭제할 수 없습니다");
+        }
+        
+        // 역할을 사용하는 사용자 확인
+        Long userCount = roleRepository.countUsersByRole(role);
+        if (userCount > 0) {
+            throw new BusinessException("이 역할을 사용하는 사용자가 있어 삭제할 수 없습니다");
+        }
+        
+        // 소프트 삭제
+        role.setIsDeleted(true);
+        roleRepository.save(role);
+        
+        // 캐시 무효화
+        evictRoleCache();
+        
+        log.info("Role deleted: {} in tenant: {}", roleKey, role.getTenant().getTenantKey());
+    }
+    
+    /**
+     * 역할에 권한 할당
+     * 
+     * @param roleId 역할 ID
+     * @param permissionKeys 권한 키 목록
+     */
+    @Transactional
+    public void assignPermissionsToRole(Long roleId, List<String> permissionKeys) {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        
+        Role role = roleRepository.findById(roleId)
+                .orElseThrow(() -> new ResourceNotFoundException("Role", "id", roleId));
+        
+        // 테넌트 확인
+        if (!role.getTenant().equals(currentTenant)) {
+            throw new BusinessException("다른 테넌트의 역할에 접근할 수 없습니다");
+        }
+        
+        List<Permission> permissions = permissionRepository.findByPermissionKeyInAndTenant(permissionKeys, currentTenant);
+        
+        if (permissions.size() != permissionKeys.size()) {
+            throw new BusinessException("일부 권한을 찾을 수 없습니다");
+        }
+        
+        role.setPermissions(permissions);
+        roleRepository.save(role);
+        
+        // 사용자 권한 캐시 무효화
+        evictUserPermissionCache();
+        
+        log.info("Permissions assigned to role: {} in tenant: {}", role.getRoleKey(), currentTenant.getTenantKey());
+    }
+    
+    /**
+     * 역할 권한 업데이트
+     * 
+     * @param roleId 역할 ID
+     * @param permissionKeys 권한 키 목록
+     */
+    @Transactional
+    public void updateRolePermissions(Long roleId, List<String> permissionKeys) {
+        assignPermissionsToRole(roleId, permissionKeys);
+    }
+    
+    /**
+     * 역할에서 권한 제거
+     * 
+     * @param roleId 역할 ID
+     * @param permissionKey 권한 키
+     */
+    @Transactional
+    public void removePermissionFromRole(Long roleId, String permissionKey) {
+        Tenant currentTenant = TenantContextHolder.getCurrentTenantOrThrow();
+        
+        Role role = roleRepository.findById(roleId)
+                .orElseThrow(() -> new ResourceNotFoundException("Role", "id", roleId));
+        
+        // 테넌트 확인
+        if (!role.getTenant().equals(currentTenant)) {
+            throw new BusinessException("다른 테넌트의 역할에 접근할 수 없습니다");
+        }
+        
+        Permission permission = permissionRepository.findByPermissionKey(permissionKey)
+                .orElseThrow(() -> new ResourceNotFoundException("Permission", "permissionKey", permissionKey));
+        
+        // 테넌트 확인
+        if (!permission.getTenant().equals(currentTenant)) {
+            throw new BusinessException("다른 테넌트의 권한에 접근할 수 없습니다");
+        }
+        
+        List<Permission> permissions = role.getPermissions();
+        if (permissions != null) {
+            permissions.removeIf(p -> p.getPermissionKey().equals(permissionKey));
+            role.setPermissions(permissions);
+            roleRepository.save(role);
+        }
+        
+        // 사용자 권한 캐시 무효화
+        evictUserPermissionCache();
+        
+        log.info("Permission removed from role: {} in tenant: {}", role.getRoleKey(), currentTenant.getTenantKey());
+    }
+    
+    /**
+     * 역할 응답 DTO 변환
+     * 
+     * @param role 역할 엔티티
+     * @return 역할 응답 DTO
+     */
+    public RoleResponse toRoleResponse(Role role) {
+        return RoleResponse.builder()
+                .id(role.getId())
+                .roleKey(role.getRoleKey())
+                .roleName(role.getRoleName())
+                .description(role.getDescription())
+                .tenantKey(role.getTenant().getTenantKey())
+                .tenantName(role.getTenant().getTenantName())
+                .status(role.getStatus())
+                .isSystem(role.getIsSystem())
+                .isDefault(role.getIsDefault())
+                .priority(role.getPriority())
+                .permissions(role.getPermissions() != null ? 
+                    role.getPermissions().stream()
+                        .map(this::toPermissionResponse)
+                        .collect(Collectors.toList()) : null)
+                .createdAt(role.getCreatedAt())
+                .updatedAt(role.getUpdatedAt())
+                .createdBy(role.getCreatedBy())
+                .updatedBy(role.getUpdatedBy())
+                .build();
+    }
+    
+    /**
+     * 권한 응답 DTO 변환
+     * 
+     * @param permission 권한 엔티티
+     * @return 권한 응답 DTO
+     */
+    private com.agenticcp.core.domain.user.dto.PermissionResponse toPermissionResponse(Permission permission) {
+        return com.agenticcp.core.domain.user.dto.PermissionResponse.builder()
+                .id(permission.getId())
+                .permissionKey(permission.getPermissionKey())
+                .permissionName(permission.getPermissionName())
+                .description(permission.getDescription())
+                .tenantKey(permission.getTenant().getTenantKey())
+                .tenantName(permission.getTenant().getTenantName())
+                .status(permission.getStatus())
+                .resource(permission.getResource())
+                .action(permission.getAction())
+                .isSystem(permission.getIsSystem())
+                .category(permission.getCategory())
+                .priority(permission.getPriority())
+                .createdAt(permission.getCreatedAt())
+                .updatedAt(permission.getUpdatedAt())
+                .createdBy(permission.getCreatedBy())
+                .updatedBy(permission.getUpdatedBy())
+                .build();
+    }
+    
+    /**
+     * 역할 캐시 무효화
+     */
+    private void evictRoleCache() {
+        try {
+            redisTemplate.delete("roles:*");
+            log.debug("Role cache evicted");
+        } catch (Exception e) {
+            log.warn("Failed to evict role cache: {}", e.getMessage());
+        }
+    }
+    
+    /**
+     * 사용자 권한 캐시 무효화
+     */
+    private void evictUserPermissionCache() {
+        try {
+            redisTemplate.delete("user_permissions:*");
+            log.debug("User permission cache evicted");
+        } catch (Exception e) {
+            log.warn("Failed to evict user permission cache: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/user/service/SystemRolePermissionInitializer.java
+++ b/src/main/java/com/agenticcp/core/domain/user/service/SystemRolePermissionInitializer.java
@@ -1,0 +1,209 @@
+package com.agenticcp.core.domain.user.service;
+
+import com.agenticcp.core.common.enums.Status;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import com.agenticcp.core.domain.user.entity.Permission;
+import com.agenticcp.core.domain.user.entity.Role;
+import com.agenticcp.core.domain.user.repository.PermissionRepository;
+import com.agenticcp.core.domain.user.repository.RoleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 시스템 역할 및 권한 초기화 서비스
+ * 애플리케이션 시작 시 기본 시스템 역할과 권한을 생성합니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SystemRolePermissionInitializer implements CommandLineRunner {
+    
+    private final RoleRepository roleRepository;
+    private final PermissionRepository permissionRepository;
+    
+    @Override
+    @Transactional
+    public void run(String... args) throws Exception {
+        log.info("Starting system role and permission initialization...");
+        
+        // 모든 테넌트에 대해 시스템 역할과 권한 초기화
+        initializeSystemRolesAndPermissions();
+        
+        log.info("System role and permission initialization completed");
+    }
+    
+    /**
+     * 시스템 역할과 권한 초기화
+     */
+    private void initializeSystemRolesAndPermissions() {
+        // TODO: 실제 구현에서는 모든 테넌트를 조회하여 각 테넌트별로 초기화
+        // 현재는 예시로 하나의 테넌트만 초기화
+        log.info("System roles and permissions will be initialized per tenant on first access");
+    }
+    
+    /**
+     * 특정 테넌트에 대한 시스템 역할과 권한 초기화
+     * 
+     * @param tenant 테넌트
+     */
+    @Transactional
+    public void initializeForTenant(Tenant tenant) {
+        log.info("Initializing system roles and permissions for tenant: {}", tenant.getTenantKey());
+        
+        // 시스템 권한 생성
+        List<Permission> systemPermissions = createSystemPermissions(tenant);
+        permissionRepository.saveAll(systemPermissions);
+        
+        // 시스템 역할 생성
+        List<Role> systemRoles = createSystemRoles(tenant, systemPermissions);
+        roleRepository.saveAll(systemRoles);
+        
+        log.info("System roles and permissions initialized for tenant: {}", tenant.getTenantKey());
+    }
+    
+    /**
+     * 시스템 권한 생성
+     * 
+     * @param tenant 테넌트
+     * @return 시스템 권한 목록
+     */
+    private List<Permission> createSystemPermissions(Tenant tenant) {
+        return Arrays.asList(
+            // 사용자 관리 권한
+            createPermission(tenant, "USER_CREATE", "사용자 생성", "사용자를 생성할 수 있는 권한", "USER", "CREATE", "USER_MANAGEMENT", 100, true),
+            createPermission(tenant, "USER_READ", "사용자 조회", "사용자 정보를 조회할 수 있는 권한", "USER", "READ", "USER_MANAGEMENT", 100, true),
+            createPermission(tenant, "USER_UPDATE", "사용자 수정", "사용자 정보를 수정할 수 있는 권한", "USER", "UPDATE", "USER_MANAGEMENT", 100, true),
+            createPermission(tenant, "USER_DELETE", "사용자 삭제", "사용자를 삭제할 수 있는 권한", "USER", "DELETE", "USER_MANAGEMENT", 100, true),
+            
+            // 역할 관리 권한
+            createPermission(tenant, "ROLE_CREATE", "역할 생성", "역할을 생성할 수 있는 권한", "ROLE", "CREATE", "ROLE_MANAGEMENT", 100, true),
+            createPermission(tenant, "ROLE_READ", "역할 조회", "역할 정보를 조회할 수 있는 권한", "ROLE", "READ", "ROLE_MANAGEMENT", 100, true),
+            createPermission(tenant, "ROLE_UPDATE", "역할 수정", "역할 정보를 수정할 수 있는 권한", "ROLE", "UPDATE", "ROLE_MANAGEMENT", 100, true),
+            createPermission(tenant, "ROLE_DELETE", "역할 삭제", "역할을 삭제할 수 있는 권한", "ROLE", "DELETE", "ROLE_MANAGEMENT", 100, true),
+            
+            // 권한 관리 권한
+            createPermission(tenant, "PERMISSION_CREATE", "권한 생성", "권한을 생성할 수 있는 권한", "PERMISSION", "CREATE", "PERMISSION_MANAGEMENT", 100, true),
+            createPermission(tenant, "PERMISSION_READ", "권한 조회", "권한 정보를 조회할 수 있는 권한", "PERMISSION", "READ", "PERMISSION_MANAGEMENT", 100, true),
+            createPermission(tenant, "PERMISSION_UPDATE", "권한 수정", "권한 정보를 수정할 수 있는 권한", "PERMISSION", "UPDATE", "PERMISSION_MANAGEMENT", 100, true),
+            createPermission(tenant, "PERMISSION_DELETE", "권한 삭제", "권한을 삭제할 수 있는 권한", "PERMISSION", "DELETE", "PERMISSION_MANAGEMENT", 100, true),
+            
+            // 테넌트 관리 권한
+            createPermission(tenant, "TENANT_CREATE", "테넌트 생성", "테넌트를 생성할 수 있는 권한", "TENANT", "CREATE", "TENANT_MANAGEMENT", 100, true),
+            createPermission(tenant, "TENANT_READ", "테넌트 조회", "테넌트 정보를 조회할 수 있는 권한", "TENANT", "READ", "TENANT_MANAGEMENT", 100, true),
+            createPermission(tenant, "TENANT_UPDATE", "테넌트 수정", "테넌트 정보를 수정할 수 있는 권한", "TENANT", "UPDATE", "TENANT_MANAGEMENT", 100, true),
+            createPermission(tenant, "TENANT_DELETE", "테넌트 삭제", "테넌트를 삭제할 수 있는 권한", "TENANT", "DELETE", "TENANT_MANAGEMENT", 100, true),
+            
+            // 클라우드 관리 권한
+            createPermission(tenant, "CLOUD_CREATE", "클라우드 리소스 생성", "클라우드 리소스를 생성할 수 있는 권한", "CLOUD", "CREATE", "CLOUD_MANAGEMENT", 90, true),
+            createPermission(tenant, "CLOUD_READ", "클라우드 리소스 조회", "클라우드 리소스를 조회할 수 있는 권한", "CLOUD", "READ", "CLOUD_MANAGEMENT", 90, true),
+            createPermission(tenant, "CLOUD_UPDATE", "클라우드 리소스 수정", "클라우드 리소스를 수정할 수 있는 권한", "CLOUD", "UPDATE", "CLOUD_MANAGEMENT", 90, true),
+            createPermission(tenant, "CLOUD_DELETE", "클라우드 리소스 삭제", "클라우드 리소스를 삭제할 수 있는 권한", "CLOUD", "DELETE", "CLOUD_MANAGEMENT", 90, true),
+            
+            // 모니터링 권한
+            createPermission(tenant, "MONITORING_READ", "모니터링 조회", "모니터링 정보를 조회할 수 있는 권한", "MONITORING", "READ", "MONITORING", 80, true),
+            createPermission(tenant, "MONITORING_UPDATE", "모니터링 설정", "모니터링 설정을 변경할 수 있는 권한", "MONITORING", "UPDATE", "MONITORING", 80, true),
+            
+            // 비용 관리 권한
+            createPermission(tenant, "COST_READ", "비용 조회", "비용 정보를 조회할 수 있는 권한", "COST", "READ", "COST_MANAGEMENT", 70, true),
+            createPermission(tenant, "COST_UPDATE", "비용 설정", "비용 설정을 변경할 수 있는 권한", "COST", "UPDATE", "COST_MANAGEMENT", 70, true)
+        );
+    }
+    
+    /**
+     * 시스템 역할 생성
+     * 
+     * @param tenant 테넌트
+     * @param systemPermissions 시스템 권한 목록
+     * @return 시스템 역할 목록
+     */
+    private List<Role> createSystemRoles(Tenant tenant, List<Permission> systemPermissions) {
+        return Arrays.asList(
+            // SUPER_ADMIN 역할
+            createRole(tenant, "SUPER_ADMIN", "최고 관리자", "모든 권한을 가진 최고 관리자 역할", 
+                      systemPermissions, 100, true, false),
+            
+            // TENANT_ADMIN 역할
+            createRole(tenant, "TENANT_ADMIN", "테넌트 관리자", "테넌트 내 모든 권한을 가진 관리자 역할", 
+                      systemPermissions.stream()
+                          .filter(p -> !p.getPermissionKey().startsWith("TENANT_"))
+                          .collect(java.util.stream.Collectors.toList()), 90, true, false),
+            
+            // CLOUD_ADMIN 역할
+            createRole(tenant, "CLOUD_ADMIN", "클라우드 관리자", "클라우드 리소스 관리 권한을 가진 역할", 
+                      systemPermissions.stream()
+                          .filter(p -> p.getPermissionKey().startsWith("CLOUD_") || 
+                                     p.getPermissionKey().startsWith("MONITORING_") ||
+                                     p.getPermissionKey().startsWith("COST_"))
+                          .collect(java.util.stream.Collectors.toList()), 80, true, false),
+            
+            // DEVELOPER 역할
+            createRole(tenant, "DEVELOPER", "개발자", "개발 관련 권한을 가진 역할", 
+                      systemPermissions.stream()
+                          .filter(p -> p.getPermissionKey().startsWith("CLOUD_") || 
+                                     p.getPermissionKey().startsWith("MONITORING_"))
+                          .collect(java.util.stream.Collectors.toList()), 70, true, false),
+            
+            // VIEWER 역할
+            createRole(tenant, "VIEWER", "조회자", "조회 권한만을 가진 역할", 
+                      systemPermissions.stream()
+                          .filter(p -> p.getAction().equals("READ"))
+                          .collect(java.util.stream.Collectors.toList()), 60, true, true),
+            
+            // AUDITOR 역할
+            createRole(tenant, "AUDITOR", "감사자", "감사 및 모니터링 권한을 가진 역할", 
+                      systemPermissions.stream()
+                          .filter(p -> p.getPermissionKey().startsWith("MONITORING_") || 
+                                     p.getPermissionKey().startsWith("COST_") ||
+                                     p.getAction().equals("READ"))
+                          .collect(java.util.stream.Collectors.toList()), 50, true, false)
+        );
+    }
+    
+    /**
+     * 권한 생성 헬퍼 메서드
+     */
+    private Permission createPermission(Tenant tenant, String key, String name, String description, 
+                                      String resource, String action, String category, 
+                                      Integer priority, Boolean isSystem) {
+        return Permission.builder()
+                .permissionKey(key)
+                .permissionName(name)
+                .description(description)
+                .tenant(tenant)
+                .resource(resource)
+                .action(action)
+                .isSystem(isSystem)
+                .category(category)
+                .priority(priority)
+                .status(Status.ACTIVE)
+                .build();
+    }
+    
+    /**
+     * 역할 생성 헬퍼 메서드
+     */
+    private Role createRole(Tenant tenant, String key, String name, String description, 
+                           List<Permission> permissions, Integer priority, Boolean isSystem, Boolean isDefault) {
+        return Role.builder()
+                .roleKey(key)
+                .roleName(name)
+                .description(description)
+                .tenant(tenant)
+                .permissions(permissions)
+                .isSystem(isSystem)
+                .isDefault(isDefault)
+                .priority(priority)
+                .status(Status.ACTIVE)
+                .build();
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/user/service/UserService.java
+++ b/src/main/java/com/agenticcp/core/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.agenticcp.core.domain.user.repository.UserRepository;
 import com.agenticcp.core.common.enums.Status;
 import com.agenticcp.core.common.enums.UserRole;
 import com.agenticcp.core.domain.tenant.entity.Tenant;
+import com.agenticcp.core.common.util.LogMaskingUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -16,6 +17,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * 사용자 관리 서비스
+ *
+ * 사용자 조회/생성/수정/상태변경 등 사용자 수명주기 기능을 제공합니다.
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -26,67 +35,108 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
 
     public List<User> getAllUsers() {
-        return userRepository.findAll();
+        log.info("[UserService] getAllUsers");
+        List<User> result = userRepository.findAll();
+        log.info("[UserService] getAllUsers - success count={}", result.size());
+        return result;
     }
 
     public List<User> getActiveUsers() {
-        return userRepository.findByStatus(Status.ACTIVE);
+        log.info("[UserService] getActiveUsers");
+        List<User> result = userRepository.findByStatus(Status.ACTIVE);
+        log.info("[UserService] getActiveUsers - success count={}", result.size());
+        return result;
     }
 
     public Optional<User> getUserByUsername(String username) {
-        return userRepository.findByUsername(username);
+        log.info("[UserService] getUserByUsername - username={}", LogMaskingUtils.mask(username, 2, 2));
+        Optional<User> result = userRepository.findByUsername(username);
+        log.info("[UserService] getUserByUsername - found={} username={}", result.isPresent(), LogMaskingUtils.mask(username, 2, 2));
+        return result;
     }
 
     public User getUserByUsernameOrThrow(String username) {
-        return userRepository.findByUsername(username)
+        log.info("[UserService] getUserByUsernameOrThrow - username={}", LogMaskingUtils.mask(username, 2, 2));
+        User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new ResourceNotFoundException("User", "username", username));
+        log.info("[UserService] getUserByUsernameOrThrow - success username={}", LogMaskingUtils.mask(username, 2, 2));
+        return user;
     }
 
     public Optional<User> getUserByEmail(String email) {
-        return userRepository.findByEmail(email);
+        log.info("[UserService] getUserByEmail - email={}", LogMaskingUtils.mask(email, 2, 2));
+        Optional<User> result = userRepository.findByEmail(email);
+        log.info("[UserService] getUserByEmail - found={} email={}", result.isPresent(), LogMaskingUtils.mask(email, 2, 2));
+        return result;
     }
 
     public List<User> getUsersByTenant(Tenant tenant) {
-        return userRepository.findByTenant(tenant);
+        log.info("[UserService] getUsersByTenant - tenantKey={}", LogMaskingUtils.maskTenantKey(tenant.getTenantKey()));
+        List<User> result = userRepository.findByTenant(tenant);
+        log.info("[UserService] getUsersByTenant - success count={} tenantKey={}", result.size(), LogMaskingUtils.maskTenantKey(tenant.getTenantKey()));
+        return result;
     }
 
     public List<User> getActiveUsersByTenant(Tenant tenant) {
-        return userRepository.findActiveUsersByTenant(tenant, Status.ACTIVE);
+        log.info("[UserService] getActiveUsersByTenant - tenantKey={}", LogMaskingUtils.maskTenantKey(tenant.getTenantKey()));
+        List<User> result = userRepository.findActiveUsersByTenant(tenant, Status.ACTIVE);
+        log.info("[UserService] getActiveUsersByTenant - success count={} tenantKey={}", result.size(), LogMaskingUtils.maskTenantKey(tenant.getTenantKey()));
+        return result;
     }
 
     public List<User> getUsersByRole(UserRole role) {
-        return userRepository.findByRole(role);
+        log.info("[UserService] getUsersByRole - role={}", role);
+        List<User> result = userRepository.findByRole(role);
+        log.info("[UserService] getUsersByRole - success count={} role={}", result.size(), role);
+        return result;
     }
 
     public List<User> getInactiveUsers(int daysSinceLastLogin) {
         LocalDateTime before = LocalDateTime.now().minusDays(daysSinceLastLogin);
-        return userRepository.findInactiveUsers(before, Status.ACTIVE);
+        log.info("[UserService] getInactiveUsers - daysSinceLastLogin={}", daysSinceLastLogin);
+        List<User> result = userRepository.findInactiveUsers(before, Status.ACTIVE);
+        log.info("[UserService] getInactiveUsers - success count={} daysSinceLastLogin={}", result.size(), daysSinceLastLogin);
+        return result;
     }
 
     public List<User> getLockedUsers(int maxFailedAttempts) {
-        return userRepository.findLockedUsers(maxFailedAttempts, Status.ACTIVE);
+        log.info("[UserService] getLockedUsers - maxFailedAttempts={}", maxFailedAttempts);
+        List<User> result = userRepository.findLockedUsers(maxFailedAttempts, Status.ACTIVE);
+        log.info("[UserService] getLockedUsers - success count={} maxFailedAttempts={}", result.size(), maxFailedAttempts);
+        return result;
     }
 
     public Long getActiveUserCountByTenant(Tenant tenant) {
-        return userRepository.countActiveUsersByTenant(tenant, Status.ACTIVE);
+        log.info("[UserService] getActiveUserCountByTenant - tenantKey={}", LogMaskingUtils.maskTenantKey(tenant.getTenantKey()));
+        Long count = userRepository.countActiveUsersByTenant(tenant, Status.ACTIVE);
+        log.info("[UserService] getActiveUserCountByTenant - success count={} tenantKey={}", count, LogMaskingUtils.maskTenantKey(tenant.getTenantKey()));
+        return count;
     }
 
     public List<User> searchUsers(String keyword) {
-        return userRepository.searchUsers(keyword);
+        log.info("[UserService] searchUsers - keyword={}", LogMaskingUtils.mask(keyword, 2, 1));
+        List<User> result = userRepository.searchUsers(keyword);
+        log.info("[UserService] searchUsers - success count={}", result.size());
+        return result;
     }
 
     @Transactional
     public User createUser(User user) {
+        log.info("[UserService] createUser - username={} email={}",
+                LogMaskingUtils.mask(user.getUsername(), 2, 2),
+                LogMaskingUtils.mask(user.getEmail(), 2, 2));
         if (user.getPasswordHash() != null) {
             user.setPasswordHash(passwordEncoder.encode(user.getPasswordHash()));
         }
         user.setPasswordChangedAt(LocalDateTime.now());
-        log.info("Creating user: {}", user.getUsername());
-        return userRepository.save(user);
+        User saved = userRepository.save(user);
+        log.info("[UserService] createUser - success username={}", LogMaskingUtils.mask(saved.getUsername(), 2, 2));
+        return saved;
     }
 
     @Transactional
     public User updateUser(String username, User updatedUser) {
+        log.info("[UserService] updateUser - username={}", LogMaskingUtils.mask(username, 2, 2));
         User existingUser = getUserByUsernameOrThrow(username);
         
         existingUser.setName(updatedUser.getName());
@@ -103,31 +153,37 @@ public class UserService {
         existingUser.setPreferences(updatedUser.getPreferences());
         existingUser.setProfileImageUrl(updatedUser.getProfileImageUrl());
         
-        log.info("Updating user: {}", username);
-        return userRepository.save(existingUser);
+        User saved = userRepository.save(existingUser);
+        log.info("[UserService] updateUser - success username={}", LogMaskingUtils.mask(username, 2, 2));
+        return saved;
     }
 
     @Transactional
     public User changePassword(String username, String newPassword) {
+        log.info("[UserService] changePassword - username={}", LogMaskingUtils.mask(username, 2, 2));
         User user = getUserByUsernameOrThrow(username);
         user.setPasswordHash(passwordEncoder.encode(newPassword));
         user.setPasswordChangedAt(LocalDateTime.now());
         user.resetFailedLoginAttempts();
-        log.info("Password changed for user: {}", username);
-        return userRepository.save(user);
+        User saved = userRepository.save(user);
+        log.info("[UserService] changePassword - success username={}", LogMaskingUtils.mask(username, 2, 2));
+        return saved;
     }
 
     @Transactional
     public User updateLastLogin(String username) {
+        log.info("[UserService] updateLastLogin - username={}", LogMaskingUtils.mask(username, 2, 2));
         User user = getUserByUsernameOrThrow(username);
         user.setLastLogin(LocalDateTime.now());
         user.resetFailedLoginAttempts();
-        log.info("Last login updated for user: {}", username);
-        return userRepository.save(user);
+        User saved = userRepository.save(user);
+        log.info("[UserService] updateLastLogin - success username={}", LogMaskingUtils.mask(username, 2, 2));
+        return saved;
     }
 
     @Transactional
     public User handleFailedLogin(String username) {
+        log.info("[UserService] handleFailedLogin - username={}", LogMaskingUtils.mask(username, 2, 2));
         User user = getUserByUsernameOrThrow(username);
         user.incrementFailedLoginAttempts();
         
@@ -136,39 +192,46 @@ public class UserService {
             user.lockAccount(30);
         }
         
-        log.warn("Failed login attempt for user: {} (attempts: {})", username, user.getFailedLoginAttempts());
+        log.warn("[UserService] handleFailedLogin - attempts={} username={}", user.getFailedLoginAttempts(), LogMaskingUtils.mask(username, 2, 2));
         return userRepository.save(user);
     }
 
     @Transactional
     public User unlockUser(String username) {
+        log.info("[UserService] unlockUser - username={}", LogMaskingUtils.mask(username, 2, 2));
         User user = getUserByUsernameOrThrow(username);
         user.resetFailedLoginAttempts();
-        log.info("User unlocked: {}", username);
-        return userRepository.save(user);
+        User saved = userRepository.save(user);
+        log.info("[UserService] unlockUser - success username={}", LogMaskingUtils.mask(username, 2, 2));
+        return saved;
     }
 
     @Transactional
     public User suspendUser(String username) {
+        log.info("[UserService] suspendUser - username={}", LogMaskingUtils.mask(username, 2, 2));
         User user = getUserByUsernameOrThrow(username);
         user.setStatus(Status.SUSPENDED);
-        log.info("User suspended: {}", username);
-        return userRepository.save(user);
+        User saved = userRepository.save(user);
+        log.info("[UserService] suspendUser - success username={}", LogMaskingUtils.mask(username, 2, 2));
+        return saved;
     }
 
     @Transactional
     public User activateUser(String username) {
+        log.info("[UserService] activateUser - username={}", LogMaskingUtils.mask(username, 2, 2));
         User user = getUserByUsernameOrThrow(username);
         user.setStatus(Status.ACTIVE);
-        log.info("User activated: {}", username);
-        return userRepository.save(user);
+        User saved = userRepository.save(user);
+        log.info("[UserService] activateUser - success username={}", LogMaskingUtils.mask(username, 2, 2));
+        return saved;
     }
 
     @Transactional
     public void deleteUser(String username) {
+        log.info("[UserService] deleteUser - username={}", LogMaskingUtils.mask(username, 2, 2));
         User user = getUserByUsernameOrThrow(username);
         user.setIsDeleted(true);
         userRepository.save(user);
-        log.info("Soft deleted user: {}", username);
+        log.info("[UserService] deleteUser - success username={}", LogMaskingUtils.mask(username, 2, 2));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,16 @@ spring:
       enabled: true
     livereload:
       enabled: true
+      
+  redis:
+    host: localhost
+    port: 6379
+    timeout: 2000ms
+    lettuce:
+      pool:
+        max-active: 8
+        max-idle: 8
+        min-idle: 0
 
 server:
   port: 8080
@@ -62,6 +72,9 @@ spring:
     url: jdbc:mysql://mysql:3306/agenticcp?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
     username: agenticcp
     password: agenticcppassword
+  redis:
+    host: redis
+    port: 6379
 
 ---
 spring:

--- a/src/test/java/com/agenticcp/core/domain/user/Feature1ScenarioTest.java
+++ b/src/test/java/com/agenticcp/core/domain/user/Feature1ScenarioTest.java
@@ -25,6 +25,8 @@ import static org.assertj.core.api.Assertions.*;
 /**
  * Feature 1 시나리오 테스트
  * 
+ * 관련 이슈: #13 - https://github.com/your-org/AgenticCP-Core/issues/13
+ * 
  * @author AgenticCP Team
  * @version 1.0.0
  * @since 2024-01-01

--- a/src/test/java/com/agenticcp/core/domain/user/Feature1ScenarioTest.java
+++ b/src/test/java/com/agenticcp/core/domain/user/Feature1ScenarioTest.java
@@ -1,0 +1,291 @@
+package com.agenticcp.core.domain.user;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.common.enums.Status;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import com.agenticcp.core.domain.user.dto.CreateRoleRequest;
+import com.agenticcp.core.domain.user.entity.Permission;
+import com.agenticcp.core.domain.user.entity.Role;
+import com.agenticcp.core.domain.user.repository.PermissionRepository;
+import com.agenticcp.core.domain.user.repository.RoleRepository;
+import com.agenticcp.core.domain.user.service.RoleService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Feature 1 시나리오 테스트
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class Feature1ScenarioTest {
+    
+    @Autowired
+    private RoleService roleService;
+    
+    @Autowired
+    private RoleRepository roleRepository;
+    
+    @Autowired
+    private PermissionRepository permissionRepository;
+    
+    private Tenant testTenant;
+    
+    @BeforeEach
+    void setUp() {
+        // 테스트용 테넌트 생성
+        testTenant = Tenant.builder()
+                .tenantKey("test-tenant")
+                .tenantName("Test Tenant")
+                .description("Test tenant for feature 1 scenarios")
+                .status(Status.ACTIVE)
+                .build();
+        
+        // 테넌트 컨텍스트 설정
+        TenantContextHolder.setTenant(testTenant);
+        
+        // 테스트용 권한 생성
+        createTestPermissions();
+    }
+    
+    /**
+     * 시나리오 1: 역할 생성
+     * Given: 관리자가 새로운 역할을 생성하려고 함
+     * When: 역할명, 설명, 권한 목록을 입력하여 생성 요청
+     * Then: 역할이 생성되고 지정된 권한들이 자동으로 매핑됨
+     */
+    @Test
+    void scenario1_createRole() {
+        // Given: 관리자가 새로운 역할을 생성하려고 함
+        CreateRoleRequest request = CreateRoleRequest.builder()
+                .roleKey("TEST_ROLE")
+                .roleName("테스트 역할")
+                .description("테스트용 역할입니다")
+                .priority(50)
+                .permissionKeys(Arrays.asList("USER_READ", "USER_CREATE"))
+                .build();
+        
+        // When: 역할명, 설명, 권한 목록을 입력하여 생성 요청
+        Role createdRole = roleService.createRole(request);
+        
+        // Then: 역할이 생성되고 지정된 권한들이 자동으로 매핑됨
+        assertThat(createdRole).isNotNull();
+        assertThat(createdRole.getRoleKey()).isEqualTo("TEST_ROLE");
+        assertThat(createdRole.getRoleName()).isEqualTo("테스트 역할");
+        assertThat(createdRole.getDescription()).isEqualTo("테스트용 역할입니다");
+        assertThat(createdRole.getPriority()).isEqualTo(50);
+        assertThat(createdRole.getTenant()).isEqualTo(testTenant);
+        assertThat(createdRole.getIsSystem()).isFalse();
+        assertThat(createdRole.getIsDefault()).isFalse();
+        assertThat(createdRole.getStatus()).isEqualTo(Status.ACTIVE);
+        
+        // 권한 매핑 확인
+        assertThat(createdRole.getPermissions()).isNotNull();
+        assertThat(createdRole.getPermissions()).hasSize(2);
+        assertThat(createdRole.getPermissions().stream()
+                .map(Permission::getPermissionKey))
+                .containsExactlyInAnyOrder("USER_READ", "USER_CREATE");
+        
+        // 데이터베이스에 저장되었는지 확인
+        Optional<Role> savedRole = roleRepository.findByRoleKey("TEST_ROLE");
+        assertThat(savedRole).isPresent();
+        assertThat(savedRole.get().getRoleKey()).isEqualTo("TEST_ROLE");
+    }
+    
+    /**
+     * 시나리오 2: 권한 할당
+     * Given: 기존 역할에 권한을 추가하려고 함
+     * When: 역할에 새로운 권한을 할당
+     * Then: 해당 역할을 가진 모든 사용자가 자동으로 새 권한을 획득함
+     */
+    @Test
+    void scenario2_assignPermissions() {
+        // Given: 기존 역할에 권한을 추가하려고 함
+        Role existingRole = createTestRole();
+        
+        // When: 역할에 새로운 권한을 할당
+        List<String> newPermissionKeys = Arrays.asList("USER_UPDATE", "USER_DELETE");
+        roleService.assignPermissionsToRole(existingRole.getId(), newPermissionKeys);
+        
+        // Then: 해당 역할을 가진 모든 사용자가 자동으로 새 권한을 획득함
+        Role updatedRole = roleService.getRoleByKeyOrThrow(existingRole.getRoleKey());
+        assertThat(updatedRole.getPermissions()).isNotNull();
+        assertThat(updatedRole.getPermissions()).hasSize(2);
+        assertThat(updatedRole.getPermissions().stream()
+                .map(Permission::getPermissionKey))
+                .containsExactlyInAnyOrder("USER_UPDATE", "USER_DELETE");
+        
+        // 권한이 올바르게 저장되었는지 확인
+        Optional<Role> savedRole = roleRepository.findByRoleKey(existingRole.getRoleKey());
+        assertThat(savedRole).isPresent();
+        assertThat(savedRole.get().getPermissions()).hasSize(2);
+    }
+    
+    /**
+     * 시나리오 3: 시스템 역할 보호
+     * Given: 시스템 역할(SUPER_ADMIN)을 삭제하려고 함
+     * When: 삭제 요청
+     * Then: "시스템 역할은 삭제할 수 없습니다" 오류 반환
+     */
+    @Test
+    void scenario3_systemRoleProtection() {
+        // Given: 시스템 역할(SUPER_ADMIN)을 삭제하려고 함
+        Role systemRole = createSystemRole();
+        
+        // When: 삭제 요청
+        // Then: "시스템 역할은 삭제할 수 없습니다" 오류 반환
+        assertThatThrownBy(() -> roleService.deleteRole(systemRole.getRoleKey()))
+                .isInstanceOf(com.agenticcp.core.common.exception.BusinessException.class)
+                .hasMessage("시스템 역할은 삭제할 수 없습니다");
+        
+        // 시스템 역할이 삭제되지 않았는지 확인
+        Optional<Role> notDeletedRole = roleRepository.findByRoleKey(systemRole.getRoleKey());
+        assertThat(notDeletedRole).isPresent();
+        assertThat(notDeletedRole.get().getIsDeleted()).isFalse();
+    }
+    
+    /**
+     * 추가 테스트: 기본 역할 삭제 방지
+     */
+    @Test
+    void test_defaultRoleProtection() {
+        // Given: 기본 역할을 삭제하려고 함
+        Role defaultRole = createDefaultRole();
+        
+        // When: 삭제 요청
+        // Then: "기본 역할은 삭제할 수 없습니다" 오류 반환
+        assertThatThrownBy(() -> roleService.deleteRole(defaultRole.getRoleKey()))
+                .isInstanceOf(com.agenticcp.core.common.exception.BusinessException.class)
+                .hasMessage("기본 역할은 삭제할 수 없습니다");
+    }
+    
+    /**
+     * 추가 테스트: 테넌트 격리 확인
+     */
+    @Test
+    void test_tenantIsolation() {
+        // Given: 다른 테넌트의 역할이 존재함
+        Tenant otherTenant = Tenant.builder()
+                .tenantKey("other-tenant")
+                .tenantName("Other Tenant")
+                .status(Status.ACTIVE)
+                .build();
+        
+        Role otherTenantRole = Role.builder()
+                .roleKey("OTHER_ROLE")
+                .roleName("다른 테넌트 역할")
+                .tenant(otherTenant)
+                .isSystem(false)
+                .isDefault(false)
+                .priority(50)
+                .status(Status.ACTIVE)
+                .build();
+        roleRepository.save(otherTenantRole);
+        
+        // When: 현재 테넌트에서 모든 역할을 조회
+        List<Role> currentTenantRoles = roleService.getAllRoles();
+        
+        // Then: 다른 테넌트의 역할은 조회되지 않음
+        assertThat(currentTenantRoles).isNotEmpty();
+        assertThat(currentTenantRoles.stream()
+                .anyMatch(role -> "OTHER_ROLE".equals(role.getRoleKey())))
+                .isFalse();
+    }
+    
+    /**
+     * 테스트용 권한 생성
+     */
+    private void createTestPermissions() {
+        List<Permission> permissions = Arrays.asList(
+                createPermission("USER_READ", "사용자 조회", "사용자 정보를 조회할 수 있는 권한", "USER", "READ", "USER_MANAGEMENT", 100),
+                createPermission("USER_CREATE", "사용자 생성", "사용자를 생성할 수 있는 권한", "USER", "CREATE", "USER_MANAGEMENT", 100),
+                createPermission("USER_UPDATE", "사용자 수정", "사용자 정보를 수정할 수 있는 권한", "USER", "UPDATE", "USER_MANAGEMENT", 100),
+                createPermission("USER_DELETE", "사용자 삭제", "사용자를 삭제할 수 있는 권한", "USER", "DELETE", "USER_MANAGEMENT", 100)
+        );
+        permissionRepository.saveAll(permissions);
+    }
+    
+    /**
+     * 테스트용 역할 생성
+     */
+    private Role createTestRole() {
+        Role role = Role.builder()
+                .roleKey("TEST_ROLE_2")
+                .roleName("테스트 역할 2")
+                .description("테스트용 역할 2입니다")
+                .tenant(testTenant)
+                .isSystem(false)
+                .isDefault(false)
+                .priority(50)
+                .status(Status.ACTIVE)
+                .build();
+        return roleRepository.save(role);
+    }
+    
+    /**
+     * 테스트용 시스템 역할 생성
+     */
+    private Role createSystemRole() {
+        Role role = Role.builder()
+                .roleKey("SUPER_ADMIN")
+                .roleName("최고 관리자")
+                .description("모든 권한을 가진 최고 관리자 역할")
+                .tenant(testTenant)
+                .isSystem(true)
+                .isDefault(false)
+                .priority(100)
+                .status(Status.ACTIVE)
+                .build();
+        return roleRepository.save(role);
+    }
+    
+    /**
+     * 테스트용 기본 역할 생성
+     */
+    private Role createDefaultRole() {
+        Role role = Role.builder()
+                .roleKey("DEFAULT_ROLE")
+                .roleName("기본 역할")
+                .description("기본 역할입니다")
+                .tenant(testTenant)
+                .isSystem(false)
+                .isDefault(true)
+                .priority(50)
+                .status(Status.ACTIVE)
+                .build();
+        return roleRepository.save(role);
+    }
+    
+    /**
+     * 테스트용 권한 생성 헬퍼
+     */
+    private Permission createPermission(String key, String name, String description, 
+                                      String resource, String action, String category, Integer priority) {
+        return Permission.builder()
+                .permissionKey(key)
+                .permissionName(name)
+                .description(description)
+                .tenant(testTenant)
+                .resource(resource)
+                .action(action)
+                .isSystem(false)
+                .category(category)
+                .priority(priority)
+                .status(Status.ACTIVE)
+                .build();
+    }
+}


### PR DESCRIPTION
## 개요

- 멀티 테넌트 환경에서 **역할/권한(RBAC) CRUD, 권한 매핑, 시스템 역할 보호** 구현
- 시나리오 3건 (역할 생성 / 권한 할당 / 시스템 역할 보호) 재현 및 통과 검증
- **테넌트 완전 격리**: `TenantContextFilter/Holder`, Repository 테넌트 스코프 적용
- 성능/안정화: **Redis 캐시 적용 + fetch join으로 LAZY 예외 제거**

---

## 관련 이슈

- #13 멀티 테넌시 기반 RBAC 설계 보완
- #20 Feature 1 — Role & Permission CRUD 관리 시스템 구현

---

## 주요 변경 사항

### 공통/인프라

- `TenantContextHolder` → ThreadLocal 기반 테넌트 컨텍스트 관리
- `TenantContextFilter` → `X-Tenant-Key` 헤더 기반 테넌트 추출
- `TenantAwareRepository` → 테넌트 스코프 CRUD 인터페이스 정의
- `RedisConfig` → Lettuce + JSON 직렬화 템플릿 설정
- `docker-compose.yml` → Redis 추가, healthcheck 보강
- `application.yml(docker)` → `spring.redis.host=redis`

### 도메인 (사용자 접근 제어)

- **컨트롤러**
    - `RoleController`: 역할 CRUD + 권한 매핑
    - `PermissionController`: 권한 CRUD + 검색/필터
    - `UserController`: 사용자 CRUD (참고용)
- **리포지토리**
    - `RoleRepository`: 테넌트 스코프, fetch join 쿼리
    - `PermissionRepository`: 키+테넌트 단건 조회
- **서비스**
    - `RoleService`: 생성/삭제/권한 매핑 + 캐시 무효화
    - `PermissionService`: 키+테넌트 단건 조회, 검색
- **DTO**
    - `CreateRoleRequest`: `isSystem` 추가 (테스트용)
- **초기화**
    - `SystemRolePermissionInitializer`: 최초 접근 시 `SUPER_ADMIN` 생성

---

## 시나리오 검증

[[Feature 1 시나리오](https://www.notion.so/Feature-1-27214abed52780e79199eb3638cbf0c9?pvs=21)](https://www.notion.so/Feature-1-27214abed52780e79199eb3638cbf0c9?pvs=21) 

### 시나리오 1: 역할 생성

- 권한 `USER_READ`, `USER_CREATE` 준비
- 역할 생성 시 `permissionKeys` 전달
- 단건/목록 조회 검증

### 시나리오 2: 권한 할당

- 권한 `USER_UPDATE` 생성
- 역할에 권한 세트 업데이트
- 단건 조회 시 권한 개수 = 3 확인

### 시나리오 3: 시스템 역할 보호

- `isSystem=true` 역할 생성
- 삭제 요청 시 `BUSINESS_ERROR` 발생
- 역할 존재 확인 → **OK**

---

## 주의/리스크/보안

- 모든 API 요청에 **`X-Tenant-Key` 헤더 필수**
- `isSystem` 입력은 테스트용 → 운영 시 관리자 한정
- 보안: 현재 `permitAll` / 운영 전환 시 **JWT + @PreAuthorize** 적용 권장
- Redis 캐시 삭제: `roles:*`, `user_permissions:*` → **scan 기반 개선 필요**
- 빈 목록 → 항상 **빈 배열 보장**

---

## 테스트

- 통합 테스트: `Feature1ScenarioTest.java`
- 시나리오 1/2/3 **전부 통과**
- 실행 전제: DB/Redis 구동 + `X-Tenant-Key` 헤더

---

## 후속 작업 권고

- 보안: `isSystem` 차단, prod 보안 전환
- 캐시: scan 기반 삭제, 키 네이밍 표준화
- 안정성: fetch join 확대, 빈 배열 보장
- 문서: README / API 문서 업데이트

---

## 변경 파일

- 공통: `TenantContextHolder.java`, `TenantContextFilter.java`, `TenantAwareRepository.java`, `RedisConfig.java`
- 설정: `docker-compose.yml`, `application.yml(docker)`
- 컨트롤러: `RoleController.java`, `PermissionController.java`, `UserController.java`
- 리포지토리: `RoleRepository.java`, `PermissionRepository.java`
- 서비스: `RoleService.java`, `PermissionService.java`, `SystemRolePermissionInitializer.java`
- 테스트: `Feature1ScenarioTest.java`

---

## 배포/검증 체크리스트

- Docker: `mysql`, `redis`, `app` 구동
- `/api/actuator/health` 확인
- 테넌트 생성 후 `X-Tenant-Key` 헤더 요청
- 시나리오 1 → 2 → 3 실행 후 검증
- prod 전환 시 보안/캐시 전략 반영

---

## **v2 보안사항**

- **서비스 로깅/마스킹 적용**
    - LogMaskingUtils 도입: `tenantKey`/`roleKey`/`permissionKey`/`username`/`email`/`keyword` 부분 마스킹
    - 대상: `Permission`/`Role`/`User`/`Tenant`/`SecurityPolicy`/`FeatureFlag`/`PlatformConfig`/`CloudProvider` Service
    - 목적: 운영 관측성 향상, 개인정보 노출 방지
- **Swagger/OpenAPI 보강**
    - 전역 헤더 `X-Tenant-Key` 보안 스키마 추가
    - Swagger UI Try it out에서 헤더 선택 가능
- **문서/주석 정비**
    - 주요 서비스 클래스 JavaDoc 보강(역할/기능/버전)
    - `Feature1ScenarioTest` 상단에 이슈 링크 주석 추가(`[#13]`)
    - `TenantContextHolder` Javadoc `@since` 최신화
- **동작 영향**
    - 런타임 로직 변경 없음(주로 로깅/문서)
    - 존재하지 않는 역할 키 조회 시 404 동작 유지(REST 원칙)
- **테스트**
    - 수동: `/api/permissions`, `/api/roles/{roleKey}` 호출 → info 로그 및 마스킹 확인
    - Swagger UI: `/api/swagger-ui/index.html` → `X-Tenant-Key` 입력 후 검증
- **후속 권고**
    - 마스킹 규칙 중앙 정책화
    - 로그 레벨/샘플링 전략 수립
    - 필요 시 404 본문 `ApiResponse.error`로 UX 개선