### PR TITLE
feat : 설정 타입별 값 검증 기능

### DIFF
--- a/src/main/java/com/agenticcp/core/domain/platform/enums/PlatformConfigErrorCode.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/enums/PlatformConfigErrorCode.java
@@ -1,0 +1,54 @@
+package com.agenticcp.core.domain.platform.enums;
+
+import com.agenticcp.core.common.dto.BaseErrorCode;
+import com.agenticcp.core.common.enums.ErrorCategory;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 플랫폼 설정 관련 에러 코드를 정의하는 Enum 클래스입니다.
+ * <p>
+ * 플랫폼 설정 검증, 생성, 수정, 삭제 과정에서 발생할 수 있는 
+ * 비즈니스 예외 상황에 대한 에러 코드를 제공합니다.
+ * </p>
+ *
+ * @author AgenticCP Team
+ * @since 2025-09-26
+ */
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum PlatformConfigErrorCode implements BaseErrorCode {
+
+    // 설정 검증 관련 에러
+    CONFIG_KEY_REQUIRED(HttpStatus.BAD_REQUEST, 6001, "설정 키는 필수입니다."),
+    CONFIG_KEY_INVALID_FORMAT(HttpStatus.BAD_REQUEST, 6002, "설정 키 형식이 올바르지 않습니다."),
+    CONFIG_KEY_TOO_LONG(HttpStatus.BAD_REQUEST, 6003, "설정 키는 255자를 초과할 수 없습니다."),
+    CONFIG_KEY_TOO_SHORT(HttpStatus.BAD_REQUEST, 6004, "설정 키는 최소 3자 이상이어야 합니다."),
+    
+    CONFIG_VALUE_REQUIRED(HttpStatus.BAD_REQUEST, 6005, "설정 값은 필수입니다."),
+    STRING_VALUE_EMPTY(HttpStatus.BAD_REQUEST, 6006, "문자열 값은 비어있을 수 없습니다."),
+    NUMBER_VALUE_INVALID_FORMAT(HttpStatus.BAD_REQUEST, 6007, "유효한 숫자 형식이 아닙니다."),
+    BOOLEAN_VALUE_INVALID(HttpStatus.BAD_REQUEST, 6008, "불린 값은 'true' 또는 'false'만 허용됩니다."),
+    JSON_VALUE_INVALID_FORMAT(HttpStatus.BAD_REQUEST, 6009, "유효한 JSON 형식이 아닙니다."),
+    ENCRYPTED_VALUE_EMPTY(HttpStatus.BAD_REQUEST, 6010, "암호화된 값은 비어있을 수 없습니다."),
+    
+    // 설정 관리 관련 에러
+    CONFIG_NOT_FOUND(HttpStatus.NOT_FOUND, 6011, "요청한 설정을 찾을 수 없습니다."),
+    CONFIG_ALREADY_EXISTS(HttpStatus.CONFLICT, 6012, "이미 존재하는 설정 키입니다."),
+    SYSTEM_CONFIG_CANNOT_DELETE(HttpStatus.FORBIDDEN, 6013, "시스템 설정은 삭제할 수 없습니다."),
+    SYSTEM_CONFIG_CANNOT_MODIFY(HttpStatus.FORBIDDEN, 6014, "시스템 설정은 수정할 수 없습니다."),
+    
+    // 검증 서비스 관련 에러
+    VALIDATION_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 6015, "설정 검증 중 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final int codeNumber;
+    private final String message;
+    
+    @Override
+    public String getCode() {
+        return ErrorCategory.PLATFORM.generate(codeNumber);
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/platform/exception/ConfigValidationException.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/exception/ConfigValidationException.java
@@ -1,0 +1,25 @@
+package com.agenticcp.core.domain.platform.exception;
+
+import com.agenticcp.core.common.exception.BusinessException;
+import com.agenticcp.core.domain.platform.enums.PlatformConfigErrorCode;
+
+/**
+ * 플랫폼 설정 검증 과정에서 발생하는 예외입니다.
+ * <p>
+ * 설정 키, 값, 타입 등의 검증 실패 시 발생하며, 
+ * 클라이언트에게 구체적인 검증 오류 정보를 제공합니다.
+ * </p>
+ *
+ * @author AgenticCP Team
+ * @since 2025-09-26
+ */
+public class ConfigValidationException extends BusinessException {
+
+    public ConfigValidationException(PlatformConfigErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ConfigValidationException(PlatformConfigErrorCode errorCode, String customMessage) {
+        super(errorCode, customMessage);
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/platform/validation/ConfigValidator.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/validation/ConfigValidator.java
@@ -1,0 +1,41 @@
+package com.agenticcp.core.domain.platform.validation;
+
+import com.agenticcp.core.domain.platform.entity.PlatformConfig;
+
+/**
+ * 플랫폼 설정 검증을 위한 인터페이스입니다.
+ * <p>
+ * 각 설정 타입별로 특화된 검증 로직을 구현하며,
+ * 설정 키와 값의 유효성을 검증합니다.
+ * </p>
+ *
+ * @author AgenticCP Team
+ * @since 2025-09-26
+ */
+public interface ConfigValidator {
+
+    /**
+     * 설정 키의 유효성을 검증합니다.
+     *
+     * @param configKey 검증할 설정 키
+     * @throws com.agenticcp.core.domain.platform.exception.ConfigValidationException 검증 실패 시
+     */
+    void validateKey(String configKey);
+
+    /**
+     * 설정 값의 유효성을 검증합니다.
+     *
+     * @param configValue 검증할 설정 값
+     * @param configType 설정 타입
+     * @throws com.agenticcp.core.domain.platform.exception.ConfigValidationException 검증 실패 시
+     */
+    void validateValue(String configValue, PlatformConfig.ConfigType configType);
+
+    /**
+     * 전체 설정 객체의 유효성을 검증합니다.
+     *
+     * @param platformConfig 검증할 설정 객체
+     * @throws com.agenticcp.core.domain.platform.exception.ConfigValidationException 검증 실패 시
+     */
+    void validate(PlatformConfig platformConfig);
+}

--- a/src/main/java/com/agenticcp/core/domain/platform/validation/impl/BaseConfigValidator.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/validation/impl/BaseConfigValidator.java
@@ -1,0 +1,82 @@
+package com.agenticcp.core.domain.platform.validation.impl;
+
+import com.agenticcp.core.domain.platform.entity.PlatformConfig;
+import com.agenticcp.core.domain.platform.enums.PlatformConfigErrorCode;
+import com.agenticcp.core.domain.platform.exception.ConfigValidationException;
+import com.agenticcp.core.domain.platform.validation.ConfigValidator;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+
+/**
+ * 플랫폼 설정 검증의 기본 구현체입니다.
+ * <p>
+ * 공통적인 검증 로직(키 검증, 기본값 검증 등)을 제공하며,
+ * 타입별 특화 검증은 하위 클래스에서 구현합니다.
+ * </p>
+ *
+ * @author AgenticCP Team
+ * @since 2025-09-26
+ */
+@Slf4j
+public abstract class BaseConfigValidator implements ConfigValidator {
+
+    private static final int MIN_KEY_LENGTH = 3;
+    private static final int MAX_KEY_LENGTH = 255;
+    private static final String KEY_PATTERN = "^[a-zA-Z][a-zA-Z0-9._-]*$";
+
+    @Override
+    public void validateKey(String configKey) {
+        log.debug("[BaseConfigValidator] validateKey - configKey={}", configKey);
+
+        if (!StringUtils.hasText(configKey)) {
+            throw new ConfigValidationException(PlatformConfigErrorCode.CONFIG_KEY_REQUIRED);
+        }
+
+        if (configKey.length() < MIN_KEY_LENGTH) {
+            throw new ConfigValidationException(PlatformConfigErrorCode.CONFIG_KEY_TOO_SHORT);
+        }
+
+        if (configKey.length() > MAX_KEY_LENGTH) {
+            throw new ConfigValidationException(PlatformConfigErrorCode.CONFIG_KEY_TOO_LONG);
+        }
+
+        if (!configKey.matches(KEY_PATTERN)) {
+            throw new ConfigValidationException(PlatformConfigErrorCode.CONFIG_KEY_INVALID_FORMAT);
+        }
+
+        log.debug("[BaseConfigValidator] validateKey - success");
+    }
+
+    @Override
+    public void validateValue(String configValue, PlatformConfig.ConfigType configType) {
+        log.debug("[BaseConfigValidator] validateValue - configType={}", configType);
+
+        if (!StringUtils.hasText(configValue)) {
+            throw new ConfigValidationException(PlatformConfigErrorCode.CONFIG_VALUE_REQUIRED);
+        }
+
+        // 타입별 특화 검증은 하위 클래스에서 구현
+        validateValueByType(configValue, configType);
+
+        log.debug("[BaseConfigValidator] validateValue - success");
+    }
+
+    @Override
+    public void validate(PlatformConfig platformConfig) {
+        log.debug("[BaseConfigValidator] validate - configKey={}", platformConfig.getConfigKey());
+
+        validateKey(platformConfig.getConfigKey());
+        validateValue(platformConfig.getConfigValue(), platformConfig.getConfigType());
+
+        log.debug("[BaseConfigValidator] validate - success");
+    }
+
+    /**
+     * 설정 타입별 특화 검증을 수행합니다.
+     * 하위 클래스에서 구현해야 합니다.
+     *
+     * @param configValue 검증할 설정 값
+     * @param configType 설정 타입
+     */
+    protected abstract void validateValueByType(String configValue, PlatformConfig.ConfigType configType);
+}

--- a/src/main/java/com/agenticcp/core/domain/platform/validation/impl/BaseConfigValidator.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/validation/impl/BaseConfigValidator.java
@@ -51,7 +51,8 @@ public abstract class BaseConfigValidator implements ConfigValidator {
     public void validateValue(String configValue, PlatformConfig.ConfigType configType) {
         log.debug("[BaseConfigValidator] validateValue - configType={}", configType);
 
-        if (!StringUtils.hasText(configValue)) {
+        // null 체크만 수행하고, 빈 문자열 체크는 타입별 검증기에서 처리
+        if (configValue == null) {
             throw new ConfigValidationException(PlatformConfigErrorCode.CONFIG_VALUE_REQUIRED);
         }
 

--- a/src/main/java/com/agenticcp/core/domain/platform/validation/impl/BooleanConfigValidator.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/validation/impl/BooleanConfigValidator.java
@@ -27,6 +27,10 @@ public class BooleanConfigValidator extends BaseConfigValidator {
 
         log.debug("[BooleanConfigValidator] validateValueByType - BOOLEAN type validation");
 
+        if (configValue == null || configValue.trim().isEmpty()) {
+            throw new ConfigValidationException(PlatformConfigErrorCode.CONFIG_VALUE_REQUIRED);
+        }
+
         String trimmedValue = configValue.trim().toLowerCase();
         if (!"true".equals(trimmedValue) && !"false".equals(trimmedValue)) {
             log.warn("[BooleanConfigValidator] Invalid boolean value: {}", configValue);

--- a/src/main/java/com/agenticcp/core/domain/platform/validation/impl/BooleanConfigValidator.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/validation/impl/BooleanConfigValidator.java
@@ -1,0 +1,38 @@
+package com.agenticcp.core.domain.platform.validation.impl;
+
+import com.agenticcp.core.domain.platform.entity.PlatformConfig;
+import com.agenticcp.core.domain.platform.enums.PlatformConfigErrorCode;
+import com.agenticcp.core.domain.platform.exception.ConfigValidationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * BOOLEAN 타입 설정 검증을 담당하는 구현체입니다.
+ * <p>
+ * 불린 값의 유효성을 검증하며, 'true' 또는 'false' 문자열만 허용합니다.
+ * </p>
+ *
+ * @author AgenticCP Team
+ * @since 2025-09-26
+ */
+@Slf4j
+@Component
+public class BooleanConfigValidator extends BaseConfigValidator {
+
+    @Override
+    protected void validateValueByType(String configValue, PlatformConfig.ConfigType configType) {
+        if (configType != PlatformConfig.ConfigType.BOOLEAN) {
+            return;
+        }
+
+        log.debug("[BooleanConfigValidator] validateValueByType - BOOLEAN type validation");
+
+        String trimmedValue = configValue.trim().toLowerCase();
+        if (!"true".equals(trimmedValue) && !"false".equals(trimmedValue)) {
+            log.warn("[BooleanConfigValidator] Invalid boolean value: {}", configValue);
+            throw new ConfigValidationException(PlatformConfigErrorCode.BOOLEAN_VALUE_INVALID);
+        }
+
+        log.debug("[BooleanConfigValidator] validateValueByType - success");
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/platform/validation/impl/EncryptedConfigValidator.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/validation/impl/EncryptedConfigValidator.java
@@ -1,0 +1,41 @@
+package com.agenticcp.core.domain.platform.validation.impl;
+
+import com.agenticcp.core.domain.platform.entity.PlatformConfig;
+import com.agenticcp.core.domain.platform.enums.PlatformConfigErrorCode;
+import com.agenticcp.core.domain.platform.exception.ConfigValidationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * ENCRYPTED 타입 설정 검증을 담당하는 구현체입니다.
+ * <p>
+ * 암호화된 값의 유효성을 검증하며, 빈 값이나 공백만 있는 값을 허용하지 않습니다.
+ * 실제 암호화 검증은 별도의 암호화 서비스에서 수행됩니다.
+ * </p>
+ *
+ * @author AgenticCP Team
+ * @since 2025-09-26
+ */
+@Slf4j
+@Component
+public class EncryptedConfigValidator extends BaseConfigValidator {
+
+    @Override
+    protected void validateValueByType(String configValue, PlatformConfig.ConfigType configType) {
+        if (configType != PlatformConfig.ConfigType.ENCRYPTED) {
+            return;
+        }
+
+        log.debug("[EncryptedConfigValidator] validateValueByType - ENCRYPTED type validation");
+
+        if (!StringUtils.hasText(configValue.trim())) {
+            throw new ConfigValidationException(PlatformConfigErrorCode.ENCRYPTED_VALUE_EMPTY);
+        }
+
+        // TODO: 향후 실제 암호화 형식 검증 로직 추가 가능
+        // 예: Base64 인코딩 검증, 특정 암호화 알고리즘 형식 검증 등
+
+        log.debug("[EncryptedConfigValidator] validateValueByType - success");
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/platform/validation/impl/EncryptedConfigValidator.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/validation/impl/EncryptedConfigValidator.java
@@ -29,7 +29,7 @@ public class EncryptedConfigValidator extends BaseConfigValidator {
 
         log.debug("[EncryptedConfigValidator] validateValueByType - ENCRYPTED type validation");
 
-        if (!StringUtils.hasText(configValue.trim())) {
+        if (configValue == null || configValue.trim().isEmpty()) {
             throw new ConfigValidationException(PlatformConfigErrorCode.ENCRYPTED_VALUE_EMPTY);
         }
 

--- a/src/main/java/com/agenticcp/core/domain/platform/validation/impl/JsonConfigValidator.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/validation/impl/JsonConfigValidator.java
@@ -1,0 +1,46 @@
+package com.agenticcp.core.domain.platform.validation.impl;
+
+import com.agenticcp.core.domain.platform.entity.PlatformConfig;
+import com.agenticcp.core.domain.platform.enums.PlatformConfigErrorCode;
+import com.agenticcp.core.domain.platform.exception.ConfigValidationException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * JSON 타입 설정 검증을 담당하는 구현체입니다.
+ * <p>
+ * JSON 값의 유효성을 검증하며, 유효한 JSON 형식인지 확인합니다.
+ * </p>
+ *
+ * @author AgenticCP Team
+ * @since 2025-09-26
+ */
+@Slf4j
+@Component
+public class JsonConfigValidator extends BaseConfigValidator {
+
+    private final ObjectMapper objectMapper;
+
+    public JsonConfigValidator() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    protected void validateValueByType(String configValue, PlatformConfig.ConfigType configType) {
+        if (configType != PlatformConfig.ConfigType.JSON) {
+            return;
+        }
+
+        log.debug("[JsonConfigValidator] validateValueByType - JSON type validation");
+
+        try {
+            objectMapper.readTree(configValue.trim());
+        } catch (Exception e) {
+            log.warn("[JsonConfigValidator] Invalid JSON format: {}", configValue, e);
+            throw new ConfigValidationException(PlatformConfigErrorCode.JSON_VALUE_INVALID_FORMAT);
+        }
+
+        log.debug("[JsonConfigValidator] validateValueByType - success");
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/platform/validation/impl/JsonConfigValidator.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/validation/impl/JsonConfigValidator.java
@@ -34,6 +34,10 @@ public class JsonConfigValidator extends BaseConfigValidator {
 
         log.debug("[JsonConfigValidator] validateValueByType - JSON type validation");
 
+        if (configValue == null || configValue.trim().isEmpty()) {
+            throw new ConfigValidationException(PlatformConfigErrorCode.CONFIG_VALUE_REQUIRED);
+        }
+
         try {
             objectMapper.readTree(configValue.trim());
         } catch (Exception e) {

--- a/src/main/java/com/agenticcp/core/domain/platform/validation/impl/NumberConfigValidator.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/validation/impl/NumberConfigValidator.java
@@ -30,6 +30,10 @@ public class NumberConfigValidator extends BaseConfigValidator {
 
         log.debug("[NumberConfigValidator] validateValueByType - NUMBER type validation");
 
+        if (configValue == null || configValue.trim().isEmpty()) {
+            throw new ConfigValidationException(PlatformConfigErrorCode.CONFIG_VALUE_REQUIRED);
+        }
+
         try {
             // 정수 검증
             new BigInteger(configValue.trim());

--- a/src/main/java/com/agenticcp/core/domain/platform/validation/impl/NumberConfigValidator.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/validation/impl/NumberConfigValidator.java
@@ -1,0 +1,48 @@
+package com.agenticcp.core.domain.platform.validation.impl;
+
+import com.agenticcp.core.domain.platform.entity.PlatformConfig;
+import com.agenticcp.core.domain.platform.enums.PlatformConfigErrorCode;
+import com.agenticcp.core.domain.platform.exception.ConfigValidationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * NUMBER 타입 설정 검증을 담당하는 구현체입니다.
+ * <p>
+ * 숫자 값의 유효성을 검증하며, 정수, 실수, BigInteger, BigDecimal 등을 지원합니다.
+ * </p>
+ *
+ * @author AgenticCP Team
+ * @since 2025-09-26
+ */
+@Slf4j
+@Component
+public class NumberConfigValidator extends BaseConfigValidator {
+
+    @Override
+    protected void validateValueByType(String configValue, PlatformConfig.ConfigType configType) {
+        if (configType != PlatformConfig.ConfigType.NUMBER) {
+            return;
+        }
+
+        log.debug("[NumberConfigValidator] validateValueByType - NUMBER type validation");
+
+        try {
+            // 정수 검증
+            new BigInteger(configValue.trim());
+        } catch (NumberFormatException e1) {
+            try {
+                // 실수 검증
+                new BigDecimal(configValue.trim());
+            } catch (NumberFormatException e2) {
+                log.warn("[NumberConfigValidator] Invalid number format: {}", configValue);
+                throw new ConfigValidationException(PlatformConfigErrorCode.NUMBER_VALUE_INVALID_FORMAT);
+            }
+        }
+
+        log.debug("[NumberConfigValidator] validateValueByType - success");
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/platform/validation/impl/StringConfigValidator.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/validation/impl/StringConfigValidator.java
@@ -28,7 +28,7 @@ public class StringConfigValidator extends BaseConfigValidator {
 
         log.debug("[StringConfigValidator] validateValueByType - STRING type validation");
 
-        if (!StringUtils.hasText(configValue.trim())) {
+        if (configValue == null || configValue.trim().isEmpty()) {
             throw new ConfigValidationException(PlatformConfigErrorCode.STRING_VALUE_EMPTY);
         }
 

--- a/src/main/java/com/agenticcp/core/domain/platform/validation/impl/StringConfigValidator.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/validation/impl/StringConfigValidator.java
@@ -1,0 +1,37 @@
+package com.agenticcp.core.domain.platform.validation.impl;
+
+import com.agenticcp.core.domain.platform.entity.PlatformConfig;
+import com.agenticcp.core.domain.platform.enums.PlatformConfigErrorCode;
+import com.agenticcp.core.domain.platform.exception.ConfigValidationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * STRING 타입 설정 검증을 담당하는 구현체입니다.
+ * <p>
+ * 문자열 값의 유효성을 검증하며, 빈 문자열이나 공백만 있는 문자열을 허용하지 않습니다.
+ * </p>
+ *
+ * @author AgenticCP Team
+ * @since 2025-09-26
+ */
+@Slf4j
+@Component
+public class StringConfigValidator extends BaseConfigValidator {
+
+    @Override
+    protected void validateValueByType(String configValue, PlatformConfig.ConfigType configType) {
+        if (configType != PlatformConfig.ConfigType.STRING) {
+            return;
+        }
+
+        log.debug("[StringConfigValidator] validateValueByType - STRING type validation");
+
+        if (!StringUtils.hasText(configValue.trim())) {
+            throw new ConfigValidationException(PlatformConfigErrorCode.STRING_VALUE_EMPTY);
+        }
+
+        log.debug("[StringConfigValidator] validateValueByType - success");
+    }
+}

--- a/src/test/java/com/agenticcp/core/domain/platform/controller/PlatformConfigControllerIntegrationTest.java
+++ b/src/test/java/com/agenticcp/core/domain/platform/controller/PlatformConfigControllerIntegrationTest.java
@@ -89,7 +89,7 @@ class PlatformConfigControllerIntegrationTest {
                         .content(objectMapper.writeValueAsString(config)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("PLATFORM_6002"));
+                .andExpect(jsonPath("$.errorCode").value("PLATFORM_6002"));
     }
 
     @Test
@@ -108,7 +108,7 @@ class PlatformConfigControllerIntegrationTest {
                         .content(objectMapper.writeValueAsString(config)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("PLATFORM_6006"));
+                .andExpect(jsonPath("$.errorCode").value("PLATFORM_6006"));
     }
 
     @Test
@@ -127,7 +127,7 @@ class PlatformConfigControllerIntegrationTest {
                         .content(objectMapper.writeValueAsString(config)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("PLATFORM_6009"));
+                .andExpect(jsonPath("$.errorCode").value("PLATFORM_6009"));
     }
 
     @Test
@@ -146,7 +146,7 @@ class PlatformConfigControllerIntegrationTest {
                         .content(objectMapper.writeValueAsString(config)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("PLATFORM_6008"));
+                .andExpect(jsonPath("$.errorCode").value("PLATFORM_6008"));
     }
 
     @Test
@@ -165,7 +165,7 @@ class PlatformConfigControllerIntegrationTest {
                         .content(objectMapper.writeValueAsString(config)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("PLATFORM_6007"));
+                .andExpect(jsonPath("$.errorCode").value("PLATFORM_6007"));
     }
 
     @Test
@@ -191,7 +191,7 @@ class PlatformConfigControllerIntegrationTest {
                         .content(objectMapper.writeValueAsString(newConfig)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("PLATFORM_6012"));
+                .andExpect(jsonPath("$.errorCode").value("PLATFORM_6012"));
     }
 
     @Test
@@ -217,7 +217,7 @@ class PlatformConfigControllerIntegrationTest {
                         .content(objectMapper.writeValueAsString(updatedConfig)))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("PLATFORM_6014"));
+                .andExpect(jsonPath("$.errorCode").value("PLATFORM_6014"));
     }
 
     @Test
@@ -236,7 +236,7 @@ class PlatformConfigControllerIntegrationTest {
         mockMvc.perform(delete("/api/platform/configs/system.config.key"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("PLATFORM_6013"));
+                .andExpect(jsonPath("$.errorCode").value("PLATFORM_6013"));
     }
 
     @Test

--- a/src/test/java/com/agenticcp/core/domain/platform/controller/PlatformConfigControllerIntegrationTest.java
+++ b/src/test/java/com/agenticcp/core/domain/platform/controller/PlatformConfigControllerIntegrationTest.java
@@ -1,0 +1,268 @@
+package com.agenticcp.core.domain.platform.controller;
+
+import com.agenticcp.core.domain.platform.entity.PlatformConfig;
+import com.agenticcp.core.domain.platform.repository.PlatformConfigRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * PlatformConfigController 통합 테스트
+ *
+ * @author AgenticCP Team
+ * @since 2025-09-26
+ */
+@SpringBootTest
+@AutoConfigureWebMvc
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("PlatformConfigController 통합 테스트")
+class PlatformConfigControllerIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private PlatformConfigRepository platformConfigRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+        platformConfigRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("유효한 설정 생성 성공")
+    void shouldCreateValidConfig() throws Exception {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.config.key")
+                .configValue("test value")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .description("Test configuration")
+                .isEncrypted(false)
+                .isSystem(false)
+                .build();
+
+        // When & Then
+        mockMvc.perform(post("/api/platform/configs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(config)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.configKey").value("test.config.key"))
+                .andExpect(jsonPath("$.data.configValue").value("test value"))
+                .andExpect(jsonPath("$.data.configType").value("STRING"));
+    }
+
+    @Test
+    @DisplayName("잘못된 설정 키로 인한 생성 실패")
+    void shouldFailToCreateConfigWithInvalidKey() throws Exception {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("123invalid.key") // 숫자로 시작하는 잘못된 키
+                .configValue("test value")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .build();
+
+        // When & Then
+        mockMvc.perform(post("/api/platform/configs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(config)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("PLATFORM_6002"));
+    }
+
+    @Test
+    @DisplayName("빈 문자열 값으로 인한 생성 실패")
+    void shouldFailToCreateConfigWithEmptyValue() throws Exception {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.config.key")
+                .configValue("") // 빈 문자열
+                .configType(PlatformConfig.ConfigType.STRING)
+                .build();
+
+        // When & Then
+        mockMvc.perform(post("/api/platform/configs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(config)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("PLATFORM_6006"));
+    }
+
+    @Test
+    @DisplayName("잘못된 JSON 형식으로 인한 생성 실패")
+    void shouldFailToCreateConfigWithInvalidJson() throws Exception {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.json.key")
+                .configValue("{ invalid json }") // 잘못된 JSON
+                .configType(PlatformConfig.ConfigType.JSON)
+                .build();
+
+        // When & Then
+        mockMvc.perform(post("/api/platform/configs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(config)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("PLATFORM_6009"));
+    }
+
+    @Test
+    @DisplayName("잘못된 불린 값으로 인한 생성 실패")
+    void shouldFailToCreateConfigWithInvalidBoolean() throws Exception {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.boolean.key")
+                .configValue("yes") // 잘못된 불린 값
+                .configType(PlatformConfig.ConfigType.BOOLEAN)
+                .build();
+
+        // When & Then
+        mockMvc.perform(post("/api/platform/configs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(config)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("PLATFORM_6008"));
+    }
+
+    @Test
+    @DisplayName("잘못된 숫자 형식으로 인한 생성 실패")
+    void shouldFailToCreateConfigWithInvalidNumber() throws Exception {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.number.key")
+                .configValue("not.a.number") // 잘못된 숫자
+                .configType(PlatformConfig.ConfigType.NUMBER)
+                .build();
+
+        // When & Then
+        mockMvc.perform(post("/api/platform/configs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(config)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("PLATFORM_6007"));
+    }
+
+    @Test
+    @DisplayName("중복 키로 인한 생성 실패")
+    void shouldFailToCreateConfigWithDuplicateKey() throws Exception {
+        // Given
+        PlatformConfig existingConfig = PlatformConfig.builder()
+                .configKey("duplicate.key")
+                .configValue("existing value")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .build();
+        platformConfigRepository.save(existingConfig);
+
+        PlatformConfig newConfig = PlatformConfig.builder()
+                .configKey("duplicate.key") // 중복 키
+                .configValue("new value")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .build();
+
+        // When & Then
+        mockMvc.perform(post("/api/platform/configs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newConfig)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("PLATFORM_6012"));
+    }
+
+    @Test
+    @DisplayName("시스템 설정 수정 실패")
+    void shouldFailToUpdateSystemConfig() throws Exception {
+        // Given
+        PlatformConfig systemConfig = PlatformConfig.builder()
+                .configKey("system.config.key")
+                .configValue("system value")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .isSystem(true)
+                .build();
+        platformConfigRepository.save(systemConfig);
+
+        PlatformConfig updatedConfig = PlatformConfig.builder()
+                .configValue("updated value")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .build();
+
+        // When & Then
+        mockMvc.perform(put("/api/platform/configs/system.config.key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatedConfig)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("PLATFORM_6014"));
+    }
+
+    @Test
+    @DisplayName("시스템 설정 삭제 실패")
+    void shouldFailToDeleteSystemConfig() throws Exception {
+        // Given
+        PlatformConfig systemConfig = PlatformConfig.builder()
+                .configKey("system.config.key")
+                .configValue("system value")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .isSystem(true)
+                .build();
+        platformConfigRepository.save(systemConfig);
+
+        // When & Then
+        mockMvc.perform(delete("/api/platform/configs/system.config.key"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("PLATFORM_6013"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 설정 조회 실패")
+    void shouldFailToGetNonExistentConfig() throws Exception {
+        // When & Then
+        mockMvc.perform(get("/api/platform/configs/non.existent.key"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("유효한 설정 조회 성공")
+    void shouldGetValidConfig() throws Exception {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.config.key")
+                .configValue("test value")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .build();
+        platformConfigRepository.save(config);
+
+        // When & Then
+        mockMvc.perform(get("/api/platform/configs/test.config.key"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.configKey").value("test.config.key"))
+                .andExpect(jsonPath("$.data.configValue").value("test value"));
+    }
+}

--- a/src/test/java/com/agenticcp/core/domain/platform/service/PlatformConfigServiceTest.java
+++ b/src/test/java/com/agenticcp/core/domain/platform/service/PlatformConfigServiceTest.java
@@ -1,0 +1,204 @@
+package com.agenticcp.core.domain.platform.service;
+
+import com.agenticcp.core.domain.platform.entity.PlatformConfig;
+import com.agenticcp.core.domain.platform.enums.PlatformConfigErrorCode;
+import com.agenticcp.core.domain.platform.exception.ConfigValidationException;
+import com.agenticcp.core.domain.platform.repository.PlatformConfigRepository;
+import com.agenticcp.core.domain.platform.validation.ConfigValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * PlatformConfigService 단위 테스트
+ *
+ * @author AgenticCP Team
+ * @since 2025-09-26
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PlatformConfigService 테스트")
+class PlatformConfigServiceTest {
+
+    @Mock
+    private PlatformConfigRepository platformConfigRepository;
+
+    @Mock
+    private ConfigValidator configValidator;
+
+    @InjectMocks
+    private PlatformConfigService platformConfigService;
+
+    private PlatformConfig validConfig;
+    private PlatformConfig systemConfig;
+
+    @BeforeEach
+    void setUp() {
+        // Mock validator가 아무것도 하지 않도록 설정
+        doNothing().when(configValidator).validate(any(PlatformConfig.class));
+        doNothing().when(configValidator).validateKey(anyString());
+        doNothing().when(configValidator).validateValue(anyString(), any(PlatformConfig.ConfigType.class));
+
+        validConfig = PlatformConfig.builder()
+                .configKey("test.config.key")
+                .configValue("test value")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .description("Test configuration")
+                .isEncrypted(false)
+                .isSystem(false)
+                .build();
+
+        systemConfig = PlatformConfig.builder()
+                .configKey("system.config.key")
+                .configValue("system value")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .description("System configuration")
+                .isEncrypted(false)
+                .isSystem(true)
+                .build();
+    }
+
+    @Test
+    @DisplayName("유효한 설정 생성 성공")
+    void shouldCreateValidConfig() {
+        // Given
+        when(platformConfigRepository.findByConfigKey(anyString())).thenReturn(Optional.empty());
+        when(platformConfigRepository.save(any(PlatformConfig.class))).thenReturn(validConfig);
+
+        // When
+        PlatformConfig result = platformConfigService.createConfig(validConfig);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(validConfig.getConfigKey(), result.getConfigKey());
+        verify(platformConfigRepository).findByConfigKey(validConfig.getConfigKey());
+        verify(platformConfigRepository).save(validConfig);
+        verify(configValidator).validate(validConfig);
+    }
+
+    @Test
+    @DisplayName("중복 키로 인한 설정 생성 실패")
+    void shouldFailToCreateConfigWithDuplicateKey() {
+        // Given
+        when(platformConfigRepository.findByConfigKey(anyString())).thenReturn(Optional.of(validConfig));
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> platformConfigService.createConfig(validConfig));
+        assertEquals(PlatformConfigErrorCode.CONFIG_ALREADY_EXISTS, exception.getErrorCode());
+        verify(platformConfigRepository).findByConfigKey(validConfig.getConfigKey());
+        verify(platformConfigRepository, never()).save(any(PlatformConfig.class));
+    }
+
+    @Test
+    @DisplayName("유효한 설정 수정 성공")
+    void shouldUpdateValidConfig() {
+        // Given
+        PlatformConfig updatedConfig = PlatformConfig.builder()
+                .configValue("updated value")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .description("Updated description")
+                .isEncrypted(false)
+                .build();
+
+        when(platformConfigRepository.findByConfigKey(anyString())).thenReturn(Optional.of(validConfig));
+        when(platformConfigRepository.save(any(PlatformConfig.class))).thenReturn(validConfig);
+
+        // When
+        PlatformConfig result = platformConfigService.updateConfig(validConfig.getConfigKey(), updatedConfig);
+
+        // Then
+        assertNotNull(result);
+        verify(platformConfigRepository).findByConfigKey(validConfig.getConfigKey());
+        verify(platformConfigRepository).save(any(PlatformConfig.class));
+        verify(configValidator).validate(any(PlatformConfig.class));
+    }
+
+    @Test
+    @DisplayName("시스템 설정 수정 실패")
+    void shouldFailToUpdateSystemConfig() {
+        // Given
+        PlatformConfig updatedConfig = PlatformConfig.builder()
+                .configValue("updated value")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .build();
+
+        when(platformConfigRepository.findByConfigKey(anyString())).thenReturn(Optional.of(systemConfig));
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> platformConfigService.updateConfig(systemConfig.getConfigKey(), updatedConfig));
+        assertEquals(PlatformConfigErrorCode.SYSTEM_CONFIG_CANNOT_MODIFY, exception.getErrorCode());
+        verify(platformConfigRepository).findByConfigKey(systemConfig.getConfigKey());
+        verify(platformConfigRepository, never()).save(any(PlatformConfig.class));
+    }
+
+    @Test
+    @DisplayName("유효한 설정 삭제 성공")
+    void shouldDeleteValidConfig() {
+        // Given
+        when(platformConfigRepository.findByConfigKey(anyString())).thenReturn(Optional.of(validConfig));
+        when(platformConfigRepository.save(any(PlatformConfig.class))).thenReturn(validConfig);
+
+        // When
+        platformConfigService.deleteConfig(validConfig.getConfigKey());
+
+        // Then
+        verify(platformConfigRepository).findByConfigKey(validConfig.getConfigKey());
+        verify(platformConfigRepository).save(any(PlatformConfig.class));
+        assertTrue(validConfig.getIsDeleted());
+    }
+
+    @Test
+    @DisplayName("시스템 설정 삭제 실패")
+    void shouldFailToDeleteSystemConfig() {
+        // Given
+        when(platformConfigRepository.findByConfigKey(anyString())).thenReturn(Optional.of(systemConfig));
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> platformConfigService.deleteConfig(systemConfig.getConfigKey()));
+        assertEquals(PlatformConfigErrorCode.SYSTEM_CONFIG_CANNOT_DELETE, exception.getErrorCode());
+        verify(platformConfigRepository).findByConfigKey(systemConfig.getConfigKey());
+        verify(platformConfigRepository, never()).save(any(PlatformConfig.class));
+    }
+
+    @Test
+    @DisplayName("시스템 설정 하드 삭제 실패")
+    void shouldFailToHardDeleteSystemConfig() {
+        // Given
+        when(platformConfigRepository.findByConfigKey(anyString())).thenReturn(Optional.of(systemConfig));
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> platformConfigService.hardDeleteConfig(systemConfig.getConfigKey()));
+        assertEquals(PlatformConfigErrorCode.SYSTEM_CONFIG_CANNOT_DELETE, exception.getErrorCode());
+        verify(platformConfigRepository).findByConfigKey(systemConfig.getConfigKey());
+        verify(platformConfigRepository, never()).delete(any(PlatformConfig.class));
+    }
+
+    @Test
+    @DisplayName("설정 검증 실패 시 예외 발생")
+    void shouldThrowExceptionWhenValidationFails() {
+        // Given
+        doThrow(new ConfigValidationException(PlatformConfigErrorCode.CONFIG_KEY_REQUIRED))
+                .when(configValidator).validate(any(PlatformConfig.class));
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> platformConfigService.createConfig(validConfig));
+        assertEquals(PlatformConfigErrorCode.CONFIG_KEY_REQUIRED, exception.getErrorCode());
+        verify(configValidator).validate(validConfig);
+        verify(platformConfigRepository, never()).save(any(PlatformConfig.class));
+    }
+}

--- a/src/test/java/com/agenticcp/core/domain/platform/service/PlatformConfigServiceTest.java
+++ b/src/test/java/com/agenticcp/core/domain/platform/service/PlatformConfigServiceTest.java
@@ -13,7 +13,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,10 +47,14 @@ class PlatformConfigServiceTest {
 
     @BeforeEach
     void setUp() {
-        // Mock validator가 아무것도 하지 않도록 설정
-        doNothing().when(configValidator).validate(any(PlatformConfig.class));
-        doNothing().when(configValidator).validateKey(anyString());
-        doNothing().when(configValidator).validateValue(anyString(), any(PlatformConfig.ConfigType.class));
+        // Mock validator 리스트 설정
+        List<ConfigValidator> mockValidators = Arrays.asList(configValidator);
+        ReflectionTestUtils.setField(platformConfigService, "configValidators", mockValidators);
+        
+        // Mock validator가 아무것도 하지 않도록 설정 (lenient 모드 사용)
+        lenient().doNothing().when(configValidator).validate(any(PlatformConfig.class));
+        lenient().doNothing().when(configValidator).validateKey(anyString());
+        lenient().doNothing().when(configValidator).validateValue(anyString(), any(PlatformConfig.ConfigType.class));
 
         validConfig = PlatformConfig.builder()
                 .configKey("test.config.key")

--- a/src/test/java/com/agenticcp/core/domain/platform/validation/impl/BooleanConfigValidatorTest.java
+++ b/src/test/java/com/agenticcp/core/domain/platform/validation/impl/BooleanConfigValidatorTest.java
@@ -1,0 +1,175 @@
+package com.agenticcp.core.domain.platform.validation.impl;
+
+import com.agenticcp.core.domain.platform.entity.PlatformConfig;
+import com.agenticcp.core.domain.platform.enums.PlatformConfigErrorCode;
+import com.agenticcp.core.domain.platform.exception.ConfigValidationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * BooleanConfigValidator 단위 테스트
+ *
+ * @author AgenticCP Team
+ * @since 2025-09-26
+ */
+@DisplayName("BooleanConfigValidator 테스트")
+class BooleanConfigValidatorTest {
+
+    private BooleanConfigValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new BooleanConfigValidator();
+    }
+
+    @Test
+    @DisplayName("유효한 'true' 값 검증 성공")
+    void shouldValidateTrueValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.boolean.key")
+                .configType(PlatformConfig.ConfigType.BOOLEAN)
+                .configValue("true")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("유효한 'false' 값 검증 성공")
+    void shouldValidateFalseValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.boolean.key")
+                .configType(PlatformConfig.ConfigType.BOOLEAN)
+                .configValue("false")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("대문자 'TRUE' 값 검증 성공")
+    void shouldValidateUpperCaseTrueValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.boolean.key")
+                .configType(PlatformConfig.ConfigType.BOOLEAN)
+                .configValue("TRUE")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("대문자 'FALSE' 값 검증 성공")
+    void shouldValidateUpperCaseFalseValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.boolean.key")
+                .configType(PlatformConfig.ConfigType.BOOLEAN)
+                .configValue("FALSE")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("혼합 대소문자 'True' 값 검증 성공")
+    void shouldValidateMixedCaseTrueValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.boolean.key")
+                .configType(PlatformConfig.ConfigType.BOOLEAN)
+                .configValue("True")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("잘못된 불린 값 검증 실패")
+    void shouldRejectInvalidBooleanValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.boolean.key")
+                .configType(PlatformConfig.ConfigType.BOOLEAN)
+                .configValue("yes")
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.BOOLEAN_VALUE_INVALID, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("숫자 값 검증 실패")
+    void shouldRejectNumericValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.boolean.key")
+                .configType(PlatformConfig.ConfigType.BOOLEAN)
+                .configValue("1")
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.BOOLEAN_VALUE_INVALID, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("빈 문자열 값 검증 실패")
+    void shouldRejectEmptyStringValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.boolean.key")
+                .configType(PlatformConfig.ConfigType.BOOLEAN)
+                .configValue("")
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.CONFIG_VALUE_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("null 값 검증 실패")
+    void shouldRejectNullValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.boolean.key")
+                .configType(PlatformConfig.ConfigType.BOOLEAN)
+                .configValue(null)
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.CONFIG_VALUE_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("BOOLEAN 타입이 아닌 경우 검증 통과")
+    void shouldPassValidationForNonBooleanType() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.string.key")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .configValue("not a boolean")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+}

--- a/src/test/java/com/agenticcp/core/domain/platform/validation/impl/EncryptedConfigValidatorTest.java
+++ b/src/test/java/com/agenticcp/core/domain/platform/validation/impl/EncryptedConfigValidatorTest.java
@@ -1,0 +1,139 @@
+package com.agenticcp.core.domain.platform.validation.impl;
+
+import com.agenticcp.core.domain.platform.entity.PlatformConfig;
+import com.agenticcp.core.domain.platform.enums.PlatformConfigErrorCode;
+import com.agenticcp.core.domain.platform.exception.ConfigValidationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * EncryptedConfigValidator 단위 테스트
+ *
+ * @author AgenticCP Team
+ * @since 2025-09-26
+ */
+@DisplayName("EncryptedConfigValidator 테스트")
+class EncryptedConfigValidatorTest {
+
+    private EncryptedConfigValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new EncryptedConfigValidator();
+    }
+
+    @Test
+    @DisplayName("유효한 암호화된 값 검증 성공")
+    void shouldValidateValidEncryptedValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.encrypted.key")
+                .configType(PlatformConfig.ConfigType.ENCRYPTED)
+                .configValue("encrypted_value_123")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("긴 암호화된 값 검증 성공")
+    void shouldValidateLongEncryptedValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.encrypted.key")
+                .configType(PlatformConfig.ConfigType.ENCRYPTED)
+                .configValue("very_long_encrypted_value_with_special_characters_!@#$%^&*()")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("빈 문자열 값 검증 실패")
+    void shouldRejectEmptyStringValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.encrypted.key")
+                .configType(PlatformConfig.ConfigType.ENCRYPTED)
+                .configValue("")
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.ENCRYPTED_VALUE_EMPTY, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("공백만 있는 값 검증 실패")
+    void shouldRejectWhitespaceOnlyValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.encrypted.key")
+                .configType(PlatformConfig.ConfigType.ENCRYPTED)
+                .configValue("   ")
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.ENCRYPTED_VALUE_EMPTY, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("null 값 검증 실패")
+    void shouldRejectNullValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.encrypted.key")
+                .configType(PlatformConfig.ConfigType.ENCRYPTED)
+                .configValue(null)
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.CONFIG_VALUE_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("ENCRYPTED 타입이 아닌 경우 검증 통과")
+    void shouldPassValidationForNonEncryptedType() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.string.key")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .configValue("not encrypted")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("유효한 키 형식 검증 성공")
+    void shouldValidateValidKey() {
+        // Given
+        String validKey = "test.encrypted.key";
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validateKey(validKey));
+    }
+
+    @Test
+    @DisplayName("잘못된 키 형식 검증 실패")
+    void shouldRejectInvalidKey() {
+        // Given
+        String invalidKey = "123invalid.key"; // 숫자로 시작
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validateKey(invalidKey));
+        assertEquals(PlatformConfigErrorCode.CONFIG_KEY_INVALID_FORMAT, exception.getErrorCode());
+    }
+}

--- a/src/test/java/com/agenticcp/core/domain/platform/validation/impl/JsonConfigValidatorTest.java
+++ b/src/test/java/com/agenticcp/core/domain/platform/validation/impl/JsonConfigValidatorTest.java
@@ -1,0 +1,189 @@
+package com.agenticcp.core.domain.platform.validation.impl;
+
+import com.agenticcp.core.domain.platform.entity.PlatformConfig;
+import com.agenticcp.core.domain.platform.enums.PlatformConfigErrorCode;
+import com.agenticcp.core.domain.platform.exception.ConfigValidationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * JsonConfigValidator 단위 테스트
+ *
+ * @author AgenticCP Team
+ * @since 2025-09-26
+ */
+@DisplayName("JsonConfigValidator 테스트")
+class JsonConfigValidatorTest {
+
+    private JsonConfigValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new JsonConfigValidator();
+    }
+
+    @Test
+    @DisplayName("유효한 JSON 객체 검증 성공")
+    void shouldValidateValidJsonObject() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.json.key")
+                .configType(PlatformConfig.ConfigType.JSON)
+                .configValue("{\"name\": \"test\", \"value\": 123}")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("유효한 JSON 배열 검증 성공")
+    void shouldValidateValidJsonArray() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.json.key")
+                .configType(PlatformConfig.ConfigType.JSON)
+                .configValue("[1, 2, 3, \"test\"]")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("유효한 JSON 문자열 검증 성공")
+    void shouldValidateValidJsonString() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.json.key")
+                .configType(PlatformConfig.ConfigType.JSON)
+                .configValue("\"simple string\"")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("유효한 JSON 숫자 검증 성공")
+    void shouldValidateValidJsonNumber() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.json.key")
+                .configType(PlatformConfig.ConfigType.JSON)
+                .configValue("123.45")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("유효한 JSON 불린 검증 성공")
+    void shouldValidateValidJsonBoolean() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.json.key")
+                .configType(PlatformConfig.ConfigType.JSON)
+                .configValue("true")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("유효한 JSON null 검증 성공")
+    void shouldValidateValidJsonNull() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.json.key")
+                .configType(PlatformConfig.ConfigType.JSON)
+                .configValue("null")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("잘못된 JSON 형식 검증 실패")
+    void shouldRejectInvalidJsonFormat() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.json.key")
+                .configType(PlatformConfig.ConfigType.JSON)
+                .configValue("{ invalid json }")
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.JSON_VALUE_INVALID_FORMAT, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("불완전한 JSON 객체 검증 실패")
+    void shouldRejectIncompleteJsonObject() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.json.key")
+                .configType(PlatformConfig.ConfigType.JSON)
+                .configValue("{\"name\": \"test\"")
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.JSON_VALUE_INVALID_FORMAT, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("빈 문자열 값 검증 실패")
+    void shouldRejectEmptyStringValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.json.key")
+                .configType(PlatformConfig.ConfigType.JSON)
+                .configValue("")
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.CONFIG_VALUE_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("null 값 검증 실패")
+    void shouldRejectNullValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.json.key")
+                .configType(PlatformConfig.ConfigType.JSON)
+                .configValue(null)
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.CONFIG_VALUE_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("JSON 타입이 아닌 경우 검증 통과")
+    void shouldPassValidationForNonJsonType() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.string.key")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .configValue("not a json")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+}

--- a/src/test/java/com/agenticcp/core/domain/platform/validation/impl/NumberConfigValidatorTest.java
+++ b/src/test/java/com/agenticcp/core/domain/platform/validation/impl/NumberConfigValidatorTest.java
@@ -1,0 +1,145 @@
+package com.agenticcp.core.domain.platform.validation.impl;
+
+import com.agenticcp.core.domain.platform.entity.PlatformConfig;
+import com.agenticcp.core.domain.platform.enums.PlatformConfigErrorCode;
+import com.agenticcp.core.domain.platform.exception.ConfigValidationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * NumberConfigValidator 단위 테스트
+ *
+ * @author AgenticCP Team
+ * @since 2025-09-26
+ */
+@DisplayName("NumberConfigValidator 테스트")
+class NumberConfigValidatorTest {
+
+    private NumberConfigValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new NumberConfigValidator();
+    }
+
+    @Test
+    @DisplayName("유효한 정수 값 검증 성공")
+    void shouldValidateValidIntegerValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.number.key")
+                .configType(PlatformConfig.ConfigType.NUMBER)
+                .configValue("123")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("유효한 실수 값 검증 성공")
+    void shouldValidateValidDecimalValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.number.key")
+                .configType(PlatformConfig.ConfigType.NUMBER)
+                .configValue("123.45")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("음수 값 검증 성공")
+    void shouldValidateNegativeNumberValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.number.key")
+                .configType(PlatformConfig.ConfigType.NUMBER)
+                .configValue("-123.45")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("0 값 검증 성공")
+    void shouldValidateZeroValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.number.key")
+                .configType(PlatformConfig.ConfigType.NUMBER)
+                .configValue("0")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("잘못된 숫자 형식 검증 실패")
+    void shouldRejectInvalidNumberFormat() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.number.key")
+                .configType(PlatformConfig.ConfigType.NUMBER)
+                .configValue("not.a.number")
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.NUMBER_VALUE_INVALID_FORMAT, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("빈 문자열 값 검증 실패")
+    void shouldRejectEmptyStringValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.number.key")
+                .configType(PlatformConfig.ConfigType.NUMBER)
+                .configValue("")
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.CONFIG_VALUE_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("null 값 검증 실패")
+    void shouldRejectNullValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.number.key")
+                .configType(PlatformConfig.ConfigType.NUMBER)
+                .configValue(null)
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.CONFIG_VALUE_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("NUMBER 타입이 아닌 경우 검증 통과")
+    void shouldPassValidationForNonNumberType() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.string.key")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .configValue("not a number")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+}

--- a/src/test/java/com/agenticcp/core/domain/platform/validation/impl/StringConfigValidatorTest.java
+++ b/src/test/java/com/agenticcp/core/domain/platform/validation/impl/StringConfigValidatorTest.java
@@ -1,0 +1,125 @@
+package com.agenticcp.core.domain.platform.validation.impl;
+
+import com.agenticcp.core.domain.platform.entity.PlatformConfig;
+import com.agenticcp.core.domain.platform.enums.PlatformConfigErrorCode;
+import com.agenticcp.core.domain.platform.exception.ConfigValidationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * StringConfigValidator 단위 테스트
+ *
+ * @author AgenticCP Team
+ * @since 2025-09-26
+ */
+@DisplayName("StringConfigValidator 테스트")
+class StringConfigValidatorTest {
+
+    private StringConfigValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new StringConfigValidator();
+    }
+
+    @Test
+    @DisplayName("유효한 STRING 타입 설정 검증 성공")
+    void shouldValidateValidStringConfig() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.string.key")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .configValue("valid string value")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("빈 문자열 값 검증 실패")
+    void shouldRejectEmptyStringValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.string.key")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .configValue("")
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.STRING_VALUE_EMPTY, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("공백만 있는 문자열 값 검증 실패")
+    void shouldRejectWhitespaceOnlyStringValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.string.key")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .configValue("   ")
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.STRING_VALUE_EMPTY, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("null 값 검증 실패")
+    void shouldRejectNullStringValue() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.string.key")
+                .configType(PlatformConfig.ConfigType.STRING)
+                .configValue(null)
+                .build();
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validate(config));
+        assertEquals(PlatformConfigErrorCode.CONFIG_VALUE_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("STRING 타입이 아닌 경우 검증 통과")
+    void shouldPassValidationForNonStringType() {
+        // Given
+        PlatformConfig config = PlatformConfig.builder()
+                .configKey("test.number.key")
+                .configType(PlatformConfig.ConfigType.NUMBER)
+                .configValue("123")
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(config));
+    }
+
+    @Test
+    @DisplayName("유효한 키 형식 검증 성공")
+    void shouldValidateValidKey() {
+        // Given
+        String validKey = "test.string.key";
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validateKey(validKey));
+    }
+
+    @Test
+    @DisplayName("잘못된 키 형식 검증 실패")
+    void shouldRejectInvalidKey() {
+        // Given
+        String invalidKey = "123invalid.key"; // 숫자로 시작
+
+        // When & Then
+        ConfigValidationException exception = assertThrows(ConfigValidationException.class,
+                () -> validator.validateKey(invalidKey));
+        assertEquals(PlatformConfigErrorCode.CONFIG_KEY_INVALID_FORMAT, exception.getErrorCode());
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number

#18

## **🔗 관련 이슈**

#9

## **✨ 작업 내용**

- **설정 타입별 검증 시스템 구축**
  - `ConfigValidator` 인터페이스 및 `BaseConfigValidator` 추상 클래스 구현
  - 타입별 검증기 구현: `StringConfigValidator`, `NumberConfigValidator`, `BooleanConfigValidator`, `JsonConfigValidator`, `EncryptedConfigValidator`
  - 각 타입별 엄격한 유효성 검사 로직 적용

- **에러 처리 시스템 구축**
  - `PlatformConfigErrorCode` (6000-6999 범위) 정의
  - `ConfigValidationException` 비즈니스 예외 클래스 구현
  - 현재 코드베이스의 예외 처리 표준 준수

- **PlatformConfigService 검증 로직 통합**
  - `createConfig`, `updateConfig`, `deleteConfig` 메서드에 검증 로직 추가
  - 중복 키 검증 및 시스템 설정 보호 기능 구현
  - 값이 유효하지 않으면 `ConfigValidationException` 발생시키고 적절한 HTTP 상태 코드 반환

- **키 정책 검증**
  - 길이 3~255자, 영문자로 시작, 허용문자 `[a-zA-Z0-9._-]` 검증
  - 정규식을 활용한 엄격한 키 형식 검증

- **테스트 코드 작성**
  - 각 검증기별 단위 테스트 (정상/경계/실패 케이스)
  - `PlatformConfigService` 통합 테스트
  - API 엔드포인트 통합 테스트

---

## **✅ 체크리스트**

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] API 문서(Swagger)에서 테스트를 완료했나요?
- [x] 시스템 설정 보호 기능이 정상 작동하는지 확인했나요?
- [x] 각 설정 타입별 검증 로직이 올바르게 작동하는지 확인했나요?

## **🎃 새롭게 알게된 사항**

- **전략 패턴을 활용한 검증 로직 분리**: `ConfigValidator` 인터페이스를 통해 각 타입별 검증 로직을 독립적으로 구현하고 관리하는 방법
- **Spring의 의존성 주입을 활용한 검증기 관리**: `List<ConfigValidator>`를 통해 모든 검증기를 자동으로 주입받아 순차적으로 검증 수행
- **현재 코드베이스의 예외 처리 표준**: `BusinessException` 기반의 일관된 에러 처리 방식과 `ErrorCategory`를 통한 에러 코드 관리
- **Jackson ObjectMapper를 활용한 JSON 검증**: 단순 문자열 검증이 아닌 실제 파싱을 통한 엄격한 JSON 유효성 검사

## **📋 참고 사항**

### **주요 구현 특징**
- **기존 코드와의 호환성**: `PlatformConfigService`의 기존 로직을 유지하면서 검증 로직만 추가
- **확장성**: 새로운 설정 타입 추가 시 `ConfigValidator` 구현체만 추가하면 됨
- **성능**: 검증 로직이 서비스 레이어에서 수행되어 데이터베이스 접근 전에 실패 케이스 필터링

### **테스트 결과**
- **Swagger UI 테스트 완료**: 모든 설정 타입별 생성/수정/삭제 시나리오 검증
<img width="1443" height="454" alt="image" src="https://github.com/user-attachments/assets/d82eb366-9515-4fb4-a6b2-ed4323f3399c" />

- **시스템 설정 보호 확인**: `isSystem: true` 설정의 수정/삭제 시 `403 Forbidden` 응답 확인
- **검증 실패 케이스 확인**: 잘못된 형식 입력 시 적절한 에러 코드와 메시지 반환 확인

### **향후 개선 사항**
- 암호화된 설정의 실제 암호화/복호화 로직 추가 시 `EncryptedConfigValidator` 확장 필요
- 설정 변경 이력 추적 기능 추가 시 검증 로직과의 연동 고려