### PR TITLE
feat: 비동기 처리에서 tenant context 전파를 위한 TaskExecutor 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
         </dependency>
         
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+        
+        <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
             <version>0.11.5</version>

--- a/src/main/java/com/agenticcp/core/AgenticCpCoreApplication.java
+++ b/src/main/java/com/agenticcp/core/AgenticCpCoreApplication.java
@@ -3,9 +3,11 @@ package com.agenticcp.core;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaRepositories
+@EnableAsync
 public class AgenticCpCoreApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/agenticcp/core/common/config/AsyncConfig.java
+++ b/src/main/java/com/agenticcp/core/common/config/AsyncConfig.java
@@ -1,0 +1,26 @@
+package com.agenticcp.core.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "tenantTaskExecutor")
+    public TaskExecutor tenantTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("tenant-async-");
+        executor.setTaskDecorator(new TenantContextTaskDecorator()); // tenant context 전파
+        executor.initialize();
+
+        return executor;
+    }
+}

--- a/src/main/java/com/agenticcp/core/common/config/TenantContextTaskDecorator.java
+++ b/src/main/java/com/agenticcp/core/common/config/TenantContextTaskDecorator.java
@@ -1,0 +1,33 @@
+package com.agenticcp.core.common.config;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import org.springframework.core.task.TaskDecorator;
+
+public class TenantContextTaskDecorator implements TaskDecorator {
+
+    @Override
+    public Runnable decorate(Runnable runnable) {
+        // 1. 현재 스레드의 tenant context 캡처
+        Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+        String currentTenantKey = TenantContextHolder.getCurrentTenantKey();
+
+        return () -> {
+            try {
+                // 2. 새로운 스레드에서 tenant context 복원
+                if (currentTenant != null) {
+                    TenantContextHolder.setTenant(currentTenant);
+                }
+                else if (currentTenantKey != null) {
+                    TenantContextHolder.setTenantKey(currentTenantKey);
+                }
+                // 3. 실제 작업 실행
+                runnable.run();
+            } finally {
+                // 4. 작업 완료 후 컨텍스트 정리
+                TenantContextHolder.clear();
+            }
+        };
+
+    }
+}

--- a/src/main/java/com/agenticcp/core/common/service/PerformanceMonitoringService.java
+++ b/src/main/java/com/agenticcp/core/common/service/PerformanceMonitoringService.java
@@ -2,6 +2,9 @@ package com.agenticcp.core.common.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +24,11 @@ import java.util.function.Supplier;
 public class PerformanceMonitoringService {
 
     private final RedisTemplate<String, String> redisTemplate;
+
+    // 빈 주입
+    @Autowired
+    @Qualifier("tenantTaskExecutor")
+    private TaskExecutor tenantTaskExecutor;
     
     private static final String LOGIN_PERFORMANCE_PREFIX = "perf:login:";
     private static final String TOKEN_REFRESH_PERFORMANCE_PREFIX = "perf:refresh:";
@@ -158,7 +166,7 @@ public class PerformanceMonitoringService {
                 logPerformanceMetrics(metrics);
                 return metrics;
             }
-        });
+        }, tenantTaskExecutor);
     }
 
     /**

--- a/src/main/java/com/agenticcp/core/domain/platform/enums/PlatformConfigErrorCode.java
+++ b/src/main/java/com/agenticcp/core/domain/platform/enums/PlatformConfigErrorCode.java
@@ -1,7 +1,7 @@
 package com.agenticcp.core.domain.platform.enums;
 
 import com.agenticcp.core.common.dto.BaseErrorCode;
-import com.agenticcp.core.common.enums.ErrorCategory;
+import com.agenticcp.core.common.exception.ErrorCategory;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/test/java/com/agenticcp/core/common/config/AsyncConfigTest.java
+++ b/src/test/java/com/agenticcp/core/common/config/AsyncConfigTest.java
@@ -1,0 +1,215 @@
+package com.agenticcp.core.common.config;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * AsyncConfig 단위 테스트
+ * TaskExecutor 설정과 TenantContextTaskDecorator 사용을 테스트
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-01-27
+ */
+class AsyncConfigTest {
+
+    private AsyncConfig asyncConfig;
+    private TaskExecutor tenantTaskExecutor;
+
+    @BeforeEach
+    void setUp() {
+        asyncConfig = new AsyncConfig();
+        tenantTaskExecutor = asyncConfig.tenantTaskExecutor();
+        TenantContextHolder.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContextHolder.clear();
+    }
+
+    @Test
+    @DisplayName("tenantTaskExecutor 빈이 올바르게 생성되는지 테스트")
+    void tenantTaskExecutor_ShouldBeCreatedCorrectly() {
+        // Then
+        assertThat(tenantTaskExecutor).isNotNull();
+        assertThat(tenantTaskExecutor).isInstanceOf(ThreadPoolTaskExecutor.class);
+        
+        ThreadPoolTaskExecutor executor = (ThreadPoolTaskExecutor) tenantTaskExecutor;
+        assertThat(executor.getCorePoolSize()).isEqualTo(5);
+        assertThat(executor.getMaxPoolSize()).isEqualTo(10);
+        assertThat(executor.getQueueCapacity()).isEqualTo(100);
+        assertThat(executor.getThreadNamePrefix()).isEqualTo("tenant-async-");
+    }
+
+    @Test
+    @DisplayName("tenantTaskExecutor에서 Tenant Context가 전파되는지 테스트")
+    void tenantTaskExecutor_ShouldPropagateTenantContext() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+            if (currentTenant != null) {
+                capturedTenantKey.set(currentTenant.getTenantKey());
+            }
+        };
+
+        // When
+        CompletableFuture<Void> future = CompletableFuture.runAsync(testRunnable, tenantTaskExecutor);
+        future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+    }
+
+    @Test
+    @DisplayName("tenantTaskExecutor에서 Tenant Key만 있을 때 컨텍스트가 전파되는지 테스트")
+    void tenantTaskExecutor_WithTenantKeyOnly_ShouldPropagateContext() throws Exception {
+        // Given
+        String testTenantKey = "test-tenant-key-only";
+        TenantContextHolder.setTenantKey(testTenantKey);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+        };
+
+        // When
+        CompletableFuture<Void> future = CompletableFuture.runAsync(testRunnable, tenantTaskExecutor);
+        future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(capturedTenantKey.get()).isEqualTo(testTenantKey);
+    }
+
+    @Test
+    @DisplayName("tenantTaskExecutor에서 컨텍스트가 없을 때 null이 전파되는지 테스트")
+    void tenantTaskExecutor_WithoutTenantContext_ShouldPropagateNull() throws Exception {
+        // Given
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        AtomicReference<Tenant> capturedTenant = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            capturedTenant.set(TenantContextHolder.getCurrentTenant());
+        };
+
+        // When
+        CompletableFuture<Void> future = CompletableFuture.runAsync(testRunnable, tenantTaskExecutor);
+        future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(capturedTenantKey.get()).isNull();
+        assertThat(capturedTenant.get()).isNull();
+    }
+
+    @Test
+    @DisplayName("여러 작업이 동시에 실행될 때 각각의 컨텍스트가 독립적으로 전파되는지 테스트")
+    void tenantTaskExecutor_MultipleConcurrentTasks_ShouldPropagateIndependentContexts() throws Exception {
+        // Given
+        Tenant tenant1 = createTestTenant("tenant-1", "Tenant 1");
+        Tenant tenant2 = createTestTenant("tenant-2", "Tenant 2");
+        
+        AtomicReference<String> capturedTenant1Key = new AtomicReference<>();
+        AtomicReference<String> capturedTenant2Key = new AtomicReference<>();
+        
+        Runnable runnable1 = () -> {
+            Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+            if (currentTenant != null) {
+                capturedTenant1Key.set(currentTenant.getTenantKey());
+            }
+        };
+        
+        Runnable runnable2 = () -> {
+            Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+            if (currentTenant != null) {
+                capturedTenant2Key.set(currentTenant.getTenantKey());
+            }
+        };
+
+        // When
+        TenantContextHolder.setTenant(tenant1);
+        CompletableFuture<Void> future1 = CompletableFuture.runAsync(runnable1, tenantTaskExecutor);
+        
+        TenantContextHolder.setTenant(tenant2);
+        CompletableFuture<Void> future2 = CompletableFuture.runAsync(runnable2, tenantTaskExecutor);
+        
+        CompletableFuture.allOf(future1, future2).get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(capturedTenant1Key.get()).isEqualTo("tenant-1");
+        assertThat(capturedTenant2Key.get()).isEqualTo("tenant-2");
+    }
+
+    @Test
+    @DisplayName("작업 중 예외 발생 시에도 컨텍스트가 정리되는지 테스트")
+    void tenantTaskExecutor_WithException_ShouldClearContext() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant-key", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            // 예외 발생 전에 컨텍스트 캡처
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            throw new RuntimeException("Test exception");
+        };
+
+        // When & Then
+        CompletableFuture<Void> future = CompletableFuture.runAsync(testRunnable, tenantTaskExecutor);
+        
+        // 예외가 발생해도 작업 중에는 컨텍스트가 전파되었는지 확인
+        assertThatThrownBy(() -> future.get(5, TimeUnit.SECONDS))
+                .isInstanceOf(Exception.class);
+        
+        // 작업 중에는 컨텍스트가 전파되었는지 확인
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant-key");
+        
+        // 메인 스레드의 컨텍스트는 그대로 유지되어야 함 (ThreadLocal 특성상)
+        assertThat(TenantContextHolder.getCurrentTenantKey()).isEqualTo("test-tenant-key");
+        assertThat(TenantContextHolder.getCurrentTenant()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("TaskExecutor 스레드 풀 설정이 올바른지 테스트")
+    void tenantTaskExecutor_ShouldHaveCorrectThreadPoolSettings() {
+        // Given
+        ThreadPoolTaskExecutor executor = (ThreadPoolTaskExecutor) tenantTaskExecutor;
+
+        // When & Then
+        assertThat(executor.getCorePoolSize()).isEqualTo(5);
+        assertThat(executor.getMaxPoolSize()).isEqualTo(10);
+        assertThat(executor.getQueueCapacity()).isEqualTo(100);
+        assertThat(executor.getThreadNamePrefix()).isEqualTo("tenant-async-");
+    }
+
+    /**
+     * 테스트용 Tenant 객체 생성
+     */
+    private Tenant createTestTenant(String tenantKey, String tenantName) {
+        return Tenant.builder()
+                .tenantKey(tenantKey)
+                .tenantName(tenantName)
+                .description("Test tenant for AsyncConfig testing")
+                .build();
+    }
+}

--- a/src/test/java/com/agenticcp/core/common/config/TenantContextTaskDecoratorSimpleTest.java
+++ b/src/test/java/com/agenticcp/core/common/config/TenantContextTaskDecoratorSimpleTest.java
@@ -1,0 +1,167 @@
+package com.agenticcp.core.common.config;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * TenantContextTaskDecorator 간단한 단위 테스트
+ * 다른 코드의 영향을 받지 않는 순수 테스트
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-01-27
+ */
+class TenantContextTaskDecoratorSimpleTest {
+
+    private TenantContextTaskDecorator taskDecorator;
+
+    @BeforeEach
+    void setUp() {
+        taskDecorator = new TenantContextTaskDecorator();
+        TenantContextHolder.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContextHolder.clear();
+    }
+
+    @Test
+    @DisplayName("Tenant Context가 정상적으로 전파되는지 테스트")
+    void testTenantContextPropagation() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        Runnable testRunnable = () -> {
+            Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+            if (currentTenant != null) {
+                capturedTenantKey.set(currentTenant.getTenantKey());
+            }
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+    }
+
+    @Test
+    @DisplayName("Tenant Key만 있을 때 컨텍스트가 전파되는지 테스트")
+    void testTenantKeyPropagation() {
+        // Given
+        String testTenantKey = "test-tenant-key";
+        TenantContextHolder.setTenantKey(testTenantKey);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        Runnable testRunnable = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then
+        assertThat(capturedTenantKey.get()).isEqualTo(testTenantKey);
+    }
+
+    @Test
+    @DisplayName("작업 완료 후 컨텍스트가 정리되는지 테스트")
+    void testContextCleanup() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            // 작업 수행 중 컨텍스트 캡처
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then - 작업 중에는 컨텍스트가 전파되었는지 확인
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+        
+        // 메인 스레드의 컨텍스트는 그대로 유지되어야 함 (ThreadLocal 특성상)
+        assertThat(TenantContextHolder.getCurrentTenantKey()).isEqualTo("test-tenant");
+        assertThat(TenantContextHolder.getCurrentTenant()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("예외 발생 시에도 컨텍스트가 정리되는지 테스트")
+    void testContextCleanupOnException() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            // 예외 발생 전에 컨텍스트 캡처
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            throw new RuntimeException("Test exception");
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        
+        // 예외가 발생해도 작업 중에는 컨텍스트가 전파되었는지 확인
+        try {
+            CompletableFuture.runAsync(decoratedRunnable).join();
+        } catch (Exception e) {
+            // 예외는 무시하고 컨텍스트 전파만 확인
+        }
+
+        // Then - 작업 중에는 컨텍스트가 전파되었는지 확인
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+        
+        // 메인 스레드의 컨텍스트는 그대로 유지되어야 함 (ThreadLocal 특성상)
+        assertThat(TenantContextHolder.getCurrentTenantKey()).isEqualTo("test-tenant");
+        assertThat(TenantContextHolder.getCurrentTenant()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("컨텍스트가 없을 때 null이 전파되는지 테스트")
+    void testNullContextPropagation() {
+        // Given
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        Runnable testRunnable = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then
+        assertThat(capturedTenantKey.get()).isNull();
+    }
+
+    /**
+     * 테스트용 Tenant 객체 생성
+     */
+    private Tenant createTestTenant(String tenantKey, String tenantName) {
+        return Tenant.builder()
+                .tenantKey(tenantKey)
+                .tenantName(tenantName)
+                .description("Test tenant")
+                .build();
+    }
+}

--- a/src/test/java/com/agenticcp/core/common/config/TenantContextTaskDecoratorTest.java
+++ b/src/test/java/com/agenticcp/core/common/config/TenantContextTaskDecoratorTest.java
@@ -1,0 +1,254 @@
+package com.agenticcp.core.common.config;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * TenantContextTaskDecorator 단위 테스트
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-01-27
+ */
+@ExtendWith(MockitoExtension.class)
+class TenantContextTaskDecoratorTest {
+
+    private TenantContextTaskDecorator taskDecorator;
+
+    @BeforeEach
+    void setUp() {
+        taskDecorator = new TenantContextTaskDecorator();
+        // 테스트 전에 컨텍스트 정리
+        TenantContextHolder.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 테스트 후에 컨텍스트 정리
+        TenantContextHolder.clear();
+    }
+
+    @Test
+    @DisplayName("Tenant 객체가 있을 때 컨텍스트가 정상적으로 전파되는지 테스트")
+    void decorate_WithTenantObject_ShouldPropagateContext() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant-key", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        AtomicReference<String> capturedTenantName = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+            if (currentTenant != null) {
+                capturedTenantKey.set(currentTenant.getTenantKey());
+                capturedTenantName.set(currentTenant.getTenantName());
+            }
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant-key");
+        assertThat(capturedTenantName.get()).isEqualTo("Test Tenant");
+    }
+
+    @Test
+    @DisplayName("Tenant 키만 있을 때 컨텍스트가 정상적으로 전파되는지 테스트")
+    void decorate_WithTenantKeyOnly_ShouldPropagateContext() {
+        // Given
+        String testTenantKey = "test-tenant-key-only";
+        TenantContextHolder.setTenantKey(testTenantKey);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then
+        assertThat(capturedTenantKey.get()).isEqualTo(testTenantKey);
+    }
+
+    @Test
+    @DisplayName("Tenant 컨텍스트가 없을 때 null이 전파되는지 테스트")
+    void decorate_WithoutTenantContext_ShouldPropagateNull() {
+        // Given
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        AtomicReference<Tenant> capturedTenant = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            capturedTenant.set(TenantContextHolder.getCurrentTenant());
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then
+        assertThat(capturedTenantKey.get()).isNull();
+        assertThat(capturedTenant.get()).isNull();
+    }
+
+    @Test
+    @DisplayName("작업 완료 후 컨텍스트가 정리되는지 테스트")
+    void decorate_AfterTaskCompletion_ShouldClearContext() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant-key", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        AtomicReference<Tenant> capturedTenant = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            // 작업 수행 중 컨텍스트 캡처
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            capturedTenant.set(TenantContextHolder.getCurrentTenant());
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then - 작업 중에는 컨텍스트가 전파되었고, 작업 완료 후에는 정리되었는지 확인
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant-key");
+        assertThat(capturedTenant.get()).isNotNull();
+        
+        // 메인 스레드의 컨텍스트는 그대로 유지되어야 함 (ThreadLocal 특성상)
+        assertThat(TenantContextHolder.getCurrentTenantKey()).isEqualTo("test-tenant-key");
+        assertThat(TenantContextHolder.getCurrentTenant()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("작업 중 예외 발생 시에도 컨텍스트가 정리되는지 테스트")
+    void decorate_WithException_ShouldClearContext() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant-key", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            // 예외 발생 전에 컨텍스트 캡처
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            throw new RuntimeException("Test exception");
+        };
+
+        // When & Then
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        
+        // 예외가 발생해도 작업 중에는 컨텍스트가 전파되었는지 확인
+        assertThatThrownBy(() -> CompletableFuture.runAsync(decoratedRunnable).join())
+                .isInstanceOf(Exception.class);
+        
+        // 작업 중에는 컨텍스트가 전파되었는지 확인
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant-key");
+        
+        // 메인 스레드의 컨텍스트는 그대로 유지되어야 함 (ThreadLocal 특성상)
+        assertThat(TenantContextHolder.getCurrentTenantKey()).isEqualTo("test-tenant-key");
+        assertThat(TenantContextHolder.getCurrentTenant()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("여러 작업이 동시에 실행될 때 각각의 컨텍스트가 독립적으로 전파되는지 테스트")
+    void decorate_MultipleConcurrentTasks_ShouldPropagateIndependentContexts() {
+        // Given
+        Tenant tenant1 = createTestTenant("tenant-1", "Tenant 1");
+        Tenant tenant2 = createTestTenant("tenant-2", "Tenant 2");
+        
+        AtomicReference<String> capturedTenant1Key = new AtomicReference<>();
+        AtomicReference<String> capturedTenant2Key = new AtomicReference<>();
+        
+        Runnable runnable1 = () -> {
+            Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+            if (currentTenant != null) {
+                capturedTenant1Key.set(currentTenant.getTenantKey());
+            }
+        };
+        
+        Runnable runnable2 = () -> {
+            Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+            if (currentTenant != null) {
+                capturedTenant2Key.set(currentTenant.getTenantKey());
+            }
+        };
+
+        // When
+        TenantContextHolder.setTenant(tenant1);
+        Runnable decoratedRunnable1 = taskDecorator.decorate(runnable1);
+        
+        TenantContextHolder.setTenant(tenant2);
+        Runnable decoratedRunnable2 = taskDecorator.decorate(runnable2);
+        
+        CompletableFuture<Void> future1 = CompletableFuture.runAsync(decoratedRunnable1);
+        CompletableFuture<Void> future2 = CompletableFuture.runAsync(decoratedRunnable2);
+        
+        CompletableFuture.allOf(future1, future2).join();
+
+        // Then
+        assertThat(capturedTenant1Key.get()).isEqualTo("tenant-1");
+        assertThat(capturedTenant2Key.get()).isEqualTo("tenant-2");
+    }
+
+    @Test
+    @DisplayName("Tenant 객체와 Tenant 키가 모두 있을 때 Tenant 객체가 우선되는지 테스트")
+    void decorate_WithBothTenantAndKey_ShouldPrioritizeTenantObject() {
+        // Given
+        Tenant testTenant = createTestTenant("tenant-object-key", "Tenant Object");
+        String differentTenantKey = "different-tenant-key";
+        
+        TenantContextHolder.setTenant(testTenant);
+        TenantContextHolder.setTenantKey(differentTenantKey);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        AtomicReference<String> capturedTenantName = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+            if (currentTenant != null) {
+                capturedTenantKey.set(currentTenant.getTenantKey());
+                capturedTenantName.set(currentTenant.getTenantName());
+            }
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then
+        assertThat(capturedTenantKey.get()).isEqualTo("tenant-object-key");
+        assertThat(capturedTenantName.get()).isEqualTo("Tenant Object");
+        // Tenant 객체가 우선되므로 다른 키는 무시됨
+        assertThat(capturedTenantKey.get()).isNotEqualTo(differentTenantKey);
+    }
+
+    /**
+     * 테스트용 Tenant 객체 생성
+     */
+    private Tenant createTestTenant(String tenantKey, String tenantName) {
+        return Tenant.builder()
+                .tenantKey(tenantKey)
+                .tenantName(tenantName)
+                .description("Test tenant for unit testing")
+                .build();
+    }
+}

--- a/src/test/java/com/agenticcp/core/common/service/AsyncLogicTest.java
+++ b/src/test/java/com/agenticcp/core/common/service/AsyncLogicTest.java
@@ -1,0 +1,203 @@
+package com.agenticcp.core.common.service;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 비동기 로직만 테스트하는 간단한 테스트
+ * Spring Context나 다른 의존성 없이 순수 비동기 로직만 검증
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-01-27
+ */
+class AsyncLogicTest {
+
+    @BeforeEach
+    void setUp() {
+        TenantContextHolder.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContextHolder.clear();
+    }
+
+    @Test
+    @DisplayName("CompletableFuture에서 Tenant Context가 전파되지 않는 문제 확인")
+    void testCompletableFutureWithoutTenantContext() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        // When - 기본 CompletableFuture 사용 (Tenant Context 전파 안됨)
+        CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            return "result";
+        });
+        
+        String result = future.get(5, TimeUnit.SECONDS);
+
+        // Then - Tenant Context가 전파되지 않음을 확인
+        assertThat(result).isEqualTo("result");
+        assertThat(capturedTenantKey.get()).isNull(); // 전파되지 않음
+    }
+
+    @Test
+    @DisplayName("수동으로 Tenant Context를 전파하는 방법 테스트")
+    void testManualTenantContextPropagation() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        // When - 수동으로 Tenant Context 전파
+        CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> {
+            try {
+                // 수동으로 Tenant Context 복원
+                TenantContextHolder.setTenant(testTenant);
+                capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+                return "result";
+            } finally {
+                // 수동으로 컨텍스트 정리
+                TenantContextHolder.clear();
+            }
+        });
+        
+        String result = future.get(5, TimeUnit.SECONDS);
+
+        // Then - Tenant Context가 전파됨을 확인
+        assertThat(result).isEqualTo("result");
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+    }
+
+    @Test
+    @DisplayName("Supplier를 사용한 비동기 작업에서 Tenant Context 전파 테스트")
+    void testSupplierWithTenantContext() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Supplier<String> operation = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            return "operation result";
+        };
+
+        // When - Supplier를 CompletableFuture로 실행
+        CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> {
+            try {
+                // 수동으로 Tenant Context 복원
+                TenantContextHolder.setTenant(testTenant);
+                return operation.get();
+            } finally {
+                TenantContextHolder.clear();
+            }
+        });
+        
+        String result = future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(result).isEqualTo("operation result");
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+    }
+
+    @Test
+    @DisplayName("여러 비동기 작업이 동시에 실행될 때 Tenant Context 독립성 테스트")
+    void testConcurrentAsyncTasksWithTenantContext() throws Exception {
+        // Given
+        Tenant tenant1 = createTestTenant("tenant-1", "Tenant 1");
+        Tenant tenant2 = createTestTenant("tenant-2", "Tenant 2");
+        
+        AtomicReference<String> capturedTenant1Key = new AtomicReference<>();
+        AtomicReference<String> capturedTenant2Key = new AtomicReference<>();
+        
+        Supplier<String> operation1 = () -> {
+            try {
+                TenantContextHolder.setTenant(tenant1);
+                capturedTenant1Key.set(TenantContextHolder.getCurrentTenantKey());
+                return "result1";
+            } finally {
+                TenantContextHolder.clear();
+            }
+        };
+        
+        Supplier<String> operation2 = () -> {
+            try {
+                TenantContextHolder.setTenant(tenant2);
+                capturedTenant2Key.set(TenantContextHolder.getCurrentTenantKey());
+                return "result2";
+            } finally {
+                TenantContextHolder.clear();
+            }
+        };
+
+        // When
+        CompletableFuture<String> future1 = CompletableFuture.supplyAsync(operation1);
+        CompletableFuture<String> future2 = CompletableFuture.supplyAsync(operation2);
+        
+        CompletableFuture.allOf(future1, future2).get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(future1.get()).isEqualTo("result1");
+        assertThat(future2.get()).isEqualTo("result2");
+        assertThat(capturedTenant1Key.get()).isEqualTo("tenant-1");
+        assertThat(capturedTenant2Key.get()).isEqualTo("tenant-2");
+    }
+
+    @Test
+    @DisplayName("비동기 작업에서 예외 발생 시 Tenant Context 정리 테스트")
+    void testAsyncTaskExceptionWithTenantContext() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Supplier<String> failingOperation = () -> {
+            try {
+                TenantContextHolder.setTenant(testTenant);
+                capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+                throw new RuntimeException("Test exception");
+            } finally {
+                TenantContextHolder.clear();
+            }
+        };
+
+        // When & Then
+        CompletableFuture<String> future = CompletableFuture.supplyAsync(failingOperation);
+        
+        // 예외가 발생했는지 확인
+        assertThatThrownBy(() -> future.get(5, TimeUnit.SECONDS))
+                .isInstanceOf(Exception.class);
+        
+        assertThat(future.isCompletedExceptionally()).isTrue();
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+    }
+
+    /**
+     * 테스트용 Tenant 객체 생성
+     */
+    private Tenant createTestTenant(String tenantKey, String tenantName) {
+        return Tenant.builder()
+                .tenantKey(tenantKey)
+                .tenantName(tenantName)
+                .description("Test tenant")
+                .build();
+    }
+}

--- a/src/test/java/com/agenticcp/core/common/service/PerformanceMonitoringServiceTest.java
+++ b/src/test/java/com/agenticcp/core/common/service/PerformanceMonitoringServiceTest.java
@@ -1,0 +1,292 @@
+package com.agenticcp.core.common.service;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * PerformanceMonitoringService 단위 테스트
+ * TaskExecutor 사용 부분을 중점적으로 테스트
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-01-27
+ */
+@ExtendWith(MockitoExtension.class)
+class PerformanceMonitoringServiceTest {
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+    
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+    
+    @Mock
+    private TaskExecutor tenantTaskExecutor;
+    
+    private PerformanceMonitoringService performanceMonitoringService;
+
+    @BeforeEach
+    void setUp() {
+        performanceMonitoringService = new PerformanceMonitoringService(redisTemplate);
+        
+        // TaskExecutor 주입 (리플렉션 사용)
+        try {
+            var field = PerformanceMonitoringService.class.getDeclaredField("tenantTaskExecutor");
+            field.setAccessible(true);
+            field.set(performanceMonitoringService, tenantTaskExecutor);
+        } catch (Exception e) {
+            throw new RuntimeException("TaskExecutor 주입 실패", e);
+        }
+        
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        TenantContextHolder.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContextHolder.clear();
+    }
+
+    @Test
+    @DisplayName("비동기 성능 측정에서 TaskExecutor가 사용되는지 테스트")
+    void measureAsyncPerformance_ShouldUseTaskExecutor() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String operation = "TEST_OPERATION";
+        String identifier = "test-user";
+        Supplier<String> operationToMeasure = () -> "success";
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When
+        CompletableFuture<PerformanceMonitoringService.PerformanceMetrics> future = 
+                performanceMonitoringService.measureAsyncPerformance(operation, identifier, operationToMeasure);
+        PerformanceMonitoringService.PerformanceMetrics metrics = future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(metrics).isNotNull();
+        assertThat(metrics.getOperation()).isEqualTo(operation);
+        assertThat(metrics.getIdentifier()).isEqualTo(identifier);
+        assertThat(metrics.isSuccess()).isTrue();
+        verify(tenantTaskExecutor, times(1)).execute(any(Runnable.class));
+    }
+
+    @Test
+    @DisplayName("비동기 성능 측정에서 Tenant Context가 전파되는지 테스트")
+    void measureAsyncPerformance_ShouldPropagateTenantContext() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String operation = "TEST_OPERATION";
+        String identifier = "test-user";
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Supplier<String> operationToMeasure = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            return "success";
+        };
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When
+        CompletableFuture<PerformanceMonitoringService.PerformanceMetrics> future = 
+                performanceMonitoringService.measureAsyncPerformance(operation, identifier, operationToMeasure);
+        PerformanceMonitoringService.PerformanceMetrics metrics = future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(metrics).isNotNull();
+        assertThat(metrics.isSuccess()).isTrue();
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+    }
+
+    @Test
+    @DisplayName("비동기 성능 측정에서 예외 발생 시 TaskExecutor가 사용되는지 테스트")
+    void measureAsyncPerformance_WithException_ShouldUseTaskExecutor() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String operation = "TEST_OPERATION";
+        String identifier = "test-user";
+        
+        Supplier<String> failingOperation = () -> {
+            throw new RuntimeException("Test exception");
+        };
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When
+        CompletableFuture<PerformanceMonitoringService.PerformanceMetrics> future = 
+                performanceMonitoringService.measureAsyncPerformance(operation, identifier, failingOperation);
+        PerformanceMonitoringService.PerformanceMetrics metrics = future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(metrics).isNotNull();
+        assertThat(metrics.isSuccess()).isFalse();
+        assertThat(metrics.getError()).isEqualTo("Test exception");
+        verify(tenantTaskExecutor, times(1)).execute(any(Runnable.class));
+    }
+
+    @Test
+    @DisplayName("여러 비동기 성능 측정 작업이 동시에 실행될 때 각각의 TaskExecutor 사용 테스트")
+    void measureAsyncPerformance_MultipleConcurrentTasks_ShouldUseTaskExecutor() throws Exception {
+        // Given
+        Tenant tenant1 = createTestTenant("tenant-1", "Tenant 1");
+        Tenant tenant2 = createTestTenant("tenant-2", "Tenant 2");
+        
+        AtomicReference<String> capturedTenant1Key = new AtomicReference<>();
+        AtomicReference<String> capturedTenant2Key = new AtomicReference<>();
+        
+        Supplier<String> operation1 = () -> {
+            capturedTenant1Key.set(TenantContextHolder.getCurrentTenantKey());
+            return "result1";
+        };
+        
+        Supplier<String> operation2 = () -> {
+            capturedTenant2Key.set(TenantContextHolder.getCurrentTenantKey());
+            return "result2";
+        };
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When
+        TenantContextHolder.setTenant(tenant1);
+        CompletableFuture<PerformanceMonitoringService.PerformanceMetrics> future1 = 
+                performanceMonitoringService.measureAsyncPerformance("OP1", "user1", operation1);
+        
+        TenantContextHolder.setTenant(tenant2);
+        CompletableFuture<PerformanceMonitoringService.PerformanceMetrics> future2 = 
+                performanceMonitoringService.measureAsyncPerformance("OP2", "user2", operation2);
+        
+        CompletableFuture.allOf(future1, future2).get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(future1.get().isSuccess()).isTrue();
+        assertThat(future2.get().isSuccess()).isTrue();
+        assertThat(capturedTenant1Key.get()).isEqualTo("tenant-1");
+        assertThat(capturedTenant2Key.get()).isEqualTo("tenant-2");
+        verify(tenantTaskExecutor, times(2)).execute(any(Runnable.class));
+    }
+
+    @Test
+    @DisplayName("로그인 성능 측정 테스트")
+    void measureLoginPerformance_ShouldWorkCorrectly() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String username = "test-user";
+        Supplier<String> loginOperation = () -> "login-success";
+        
+        // When
+        PerformanceMonitoringService.PerformanceMetrics metrics = 
+                performanceMonitoringService.measureLoginPerformance(username, loginOperation);
+
+        // Then
+        assertThat(metrics).isNotNull();
+        assertThat(metrics.getOperation()).isEqualTo("LOGIN");
+        assertThat(metrics.getIdentifier()).isEqualTo(username);
+        assertThat(metrics.isSuccess()).isTrue();
+        assertThat(metrics.getDuration()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 성능 측정 테스트")
+    void measureTokenRefreshPerformance_ShouldWorkCorrectly() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String username = "test-user";
+        Supplier<String> refreshOperation = () -> "refresh-success";
+        
+        // When
+        PerformanceMonitoringService.PerformanceMetrics metrics = 
+                performanceMonitoringService.measureTokenRefreshPerformance(username, refreshOperation);
+
+        // Then
+        assertThat(metrics).isNotNull();
+        assertThat(metrics.getOperation()).isEqualTo("TOKEN_REFRESH");
+        assertThat(metrics.getIdentifier()).isEqualTo(username);
+        assertThat(metrics.isSuccess()).isTrue();
+        assertThat(metrics.getDuration()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("Redis 작업 성능 측정 테스트")
+    void measureRedisPerformance_ShouldWorkCorrectly() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String operation = "GET";
+        Supplier<String> redisOperation = () -> "redis-result";
+        
+        // When
+        PerformanceMonitoringService.PerformanceMetrics metrics = 
+                performanceMonitoringService.measureRedisPerformance(operation, redisOperation);
+
+        // Then
+        assertThat(metrics).isNotNull();
+        assertThat(metrics.getOperation()).isEqualTo("REDIS_GET");
+        assertThat(metrics.getIdentifier()).isEqualTo("system");
+        assertThat(metrics.isSuccess()).isTrue();
+        assertThat(metrics.getDuration()).isGreaterThanOrEqualTo(0);
+    }
+
+    /**
+     * 테스트용 Tenant 객체 생성
+     */
+    private Tenant createTestTenant(String tenantKey, String tenantName) {
+        return Tenant.builder()
+                .tenantKey(tenantKey)
+                .tenantName(tenantName)
+                .description("Test tenant for PerformanceMonitoringService testing")
+                .build();
+    }
+}

--- a/src/test/java/com/agenticcp/core/common/service/RetryServiceTest.java
+++ b/src/test/java/com/agenticcp/core/common/service/RetryServiceTest.java
@@ -1,0 +1,245 @@
+package com.agenticcp.core.common.service;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * RetryService 단위 테스트
+ * TaskExecutor 사용 부분을 중점적으로 테스트
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-01-27
+ */
+@ExtendWith(MockitoExtension.class)
+class RetryServiceTest {
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+    
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+    
+    @Mock
+    private TaskExecutor tenantTaskExecutor;
+    
+    private RetryService retryService;
+
+    @BeforeEach
+    void setUp() {
+        retryService = new RetryService(redisTemplate);
+        
+        // TaskExecutor 주입 (리플렉션 사용)
+        try {
+            var field = RetryService.class.getDeclaredField("tenantTaskExecutor");
+            field.setAccessible(true);
+            field.set(retryService, tenantTaskExecutor);
+        } catch (Exception e) {
+            throw new RuntimeException("TaskExecutor 주입 실패", e);
+        }
+        
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        TenantContextHolder.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContextHolder.clear();
+    }
+
+    @Test
+    @DisplayName("비동기 재시도 로직에서 TaskExecutor가 사용되는지 테스트")
+    void retryAsync_ShouldUseTaskExecutor() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String operation = "TEST_OPERATION";
+        String identifier = "test-user";
+        Supplier<String> operationToRetry = () -> "success";
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            // 작업을 실행하면서 Tenant Context 캡처
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When
+        CompletableFuture<String> future = retryService.retryAsync(operation, identifier, operationToRetry, 3);
+        String result = future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(result).isEqualTo("success");
+        verify(tenantTaskExecutor, times(1)).execute(any(Runnable.class));
+    }
+
+    @Test
+    @DisplayName("비동기 재시도 로직에서 Tenant Context가 전파되는지 테스트")
+    void retryAsync_ShouldPropagateTenantContext() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String operation = "TEST_OPERATION";
+        String identifier = "test-user";
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Supplier<String> operationToRetry = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            return "success";
+        };
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When
+        CompletableFuture<String> future = retryService.retryAsync(operation, identifier, operationToRetry, 3);
+        String result = future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(result).isEqualTo("success");
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+    }
+
+    @Test
+    @DisplayName("비동기 재시도 로직에서 예외 발생 시 TaskExecutor가 사용되는지 테스트")
+    void retryAsync_WithException_ShouldUseTaskExecutor() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String operation = "TEST_OPERATION";
+        String identifier = "test-user";
+        
+        Supplier<String> failingOperation = () -> {
+            throw new RuntimeException("Test exception");
+        };
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When & Then
+        CompletableFuture<String> future = retryService.retryAsync(operation, identifier, failingOperation, 3);
+        
+        assertThatThrownBy(() -> future.get(5, TimeUnit.SECONDS))
+                .isInstanceOf(Exception.class);
+        
+        verify(tenantTaskExecutor, times(1)).execute(any(Runnable.class));
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 재시도 로직에서 TaskExecutor가 사용되는지 테스트")
+    void retryTokenRefresh_ShouldUseTaskExecutor() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String username = "test-user";
+        Supplier<String> tokenRefreshOperation = () -> "new-token";
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When
+        CompletableFuture<String> future = retryService.retryAsync("TOKEN_REFRESH", username, tokenRefreshOperation, 3);
+        String result = future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(result).isEqualTo("new-token");
+        verify(tenantTaskExecutor, times(1)).execute(any(Runnable.class));
+    }
+
+    @Test
+    @DisplayName("여러 비동기 재시도 작업이 동시에 실행될 때 각각의 TaskExecutor 사용 테스트")
+    void retryAsync_MultipleConcurrentTasks_ShouldUseTaskExecutor() throws Exception {
+        // Given
+        Tenant tenant1 = createTestTenant("tenant-1", "Tenant 1");
+        Tenant tenant2 = createTestTenant("tenant-2", "Tenant 2");
+        
+        AtomicReference<String> capturedTenant1Key = new AtomicReference<>();
+        AtomicReference<String> capturedTenant2Key = new AtomicReference<>();
+        
+        Supplier<String> operation1 = () -> {
+            capturedTenant1Key.set(TenantContextHolder.getCurrentTenantKey());
+            return "result1";
+        };
+        
+        Supplier<String> operation2 = () -> {
+            capturedTenant2Key.set(TenantContextHolder.getCurrentTenantKey());
+            return "result2";
+        };
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When
+        TenantContextHolder.setTenant(tenant1);
+        CompletableFuture<String> future1 = retryService.retryAsync("OP1", "user1", operation1, 3);
+        
+        TenantContextHolder.setTenant(tenant2);
+        CompletableFuture<String> future2 = retryService.retryAsync("OP2", "user2", operation2, 3);
+        
+        CompletableFuture.allOf(future1, future2).get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(future1.get()).isEqualTo("result1");
+        assertThat(future2.get()).isEqualTo("result2");
+        assertThat(capturedTenant1Key.get()).isEqualTo("tenant-1");
+        assertThat(capturedTenant2Key.get()).isEqualTo("tenant-2");
+        verify(tenantTaskExecutor, times(2)).execute(any(Runnable.class));
+    }
+
+    /**
+     * 테스트용 Tenant 객체 생성
+     */
+    private Tenant createTestTenant(String tenantKey, String tenantName) {
+        return Tenant.builder()
+                .tenantKey(tenantKey)
+                .tenantName(tenantName)
+                .description("Test tenant for RetryService testing")
+                .build();
+    }
+}


### PR DESCRIPTION
## 관련 이슈 
#34 

## 주요 기능 
- 커스텀 TaskExecutor를 구현하여 Spring의 비동기 처리(@Async) 시 자동으로 해당 빈이 주입되도록 하였습니다.

- TenantContextTaskDecorator를 커스텀하여 비동기 작업 실행 시 현재 테넌트 컨텍스트를 캡처 및 전파하도록 설계했습니다. 이 TaskDecorator 객체는 커스텀 TaskExecutor가 생성 및 관리합니다.

- 서비스 로직에서는 CompletableFuture를 반환하는 비동기 메서드에서 이 커스텀 TaskExecutor를 사용해 테넌트 컨텍스트가 올바르게 전달되도록 했습니다.


## 테스트 

 1. 비동기 작업에서 Tenant Context 전파 테스트: CompletableFuture와 TaskExecutor를 사용한 비동기 작업에서 TenantContextTaskDecorator가 현재 스레드의 Tenant 정보를 새로운 스레드로 올바르게 전파하는지 검증했습니다.

  2. ThreadLocal 특성 반영한 테스트 로직: 다른 스레드에서 실행된 작업의 컨텍스트 정리가 메인 스레드에 영향을 주지 않는다는 ThreadLocal의 특성을 반영하여, 작업 중에는 컨텍스트가 전파되지만 메인 스레드 컨텍스트는 유지되는 것을 확인하는 테스트로 수정했습니다.
  3. TaskExecutor 사용 검증: RetryService와 PerformanceMonitoringService에서 비동기 작업 시 커스텀 TaskExecutor가 실제로 사용되고, 예외 발생 시에도 컨텍스트가 적절히 정리되며, 여러 작업이 동시 실행될 때 각각 독립적인 Tenant Context를 가지는 것을 Mockito를 통해 검증했습니다.

## 추가 구현해야할 사항 
- 리액티브(Webflux) 환경에서 context 전파 로직 
