### PR TITLE
feat: 비동기 로직에서 tenant context 전파를 위해 executor 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,13 @@
             <scope>test</scope>
         </dependency>
         
+        <!-- H2 Database for Testing -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,17 +58,17 @@
         
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-redis</artifactId>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
         
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
         
         <dependency>
@@ -125,10 +125,18 @@
             <version>7.4</version>
         </dependency>
 
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>7.4</version>
+        </dependency>
+
         <!-- Database -->
         <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
             <version>${mysql.version}</version>
         </dependency>
 
@@ -160,13 +168,6 @@
             <version>1.17.6</version>
             <scope>test</scope>
         </dependency>
-        
-        <!-- H2 Database for testing -->
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -174,6 +175,38 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            
+            <!-- Lombok Annotation Processor -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <release>17</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.5.5.Final</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
             
             
@@ -184,61 +217,6 @@
                 <configuration>
                     <repository>${docker.image.prefix}/${project.artifactId}</repository>
                     <tag>${project.version}</tag>
-                </configuration>
-            </plugin>
-            
-            <!-- JaCoCo for test coverage -->
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.10</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <rule>
-                                    <element>PACKAGE</element>
-                                    <limits>
-                                        <limit>
-                                            <counter>LINE</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.50</minimum>
-                                        </limit>
-                                    </limits>
-                                </rule>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            
-            <!-- Maven Surefire Plugin for better test reporting -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
-                <configuration>
-                    <includes>
-                        <include>**/*Test.java</include>
-                        <include>**/*Tests.java</include>
-                    </includes>
-                    <reportFormat>xml</reportFormat>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -58,17 +58,17 @@
         
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-redis</artifactId>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
         
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
         
         <dependency>
@@ -120,8 +120,8 @@
 
         <!-- Database -->
         <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
             <version>${mysql.version}</version>
         </dependency>
 
@@ -153,13 +153,6 @@
             <version>1.17.6</version>
             <scope>test</scope>
         </dependency>
-        
-        <!-- H2 Database for testing -->
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -167,6 +160,38 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            
+            <!-- Lombok Annotation Processor -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <release>17</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.5.5.Final</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
             
             
@@ -177,61 +202,6 @@
                 <configuration>
                     <repository>${docker.image.prefix}/${project.artifactId}</repository>
                     <tag>${project.version}</tag>
-                </configuration>
-            </plugin>
-            
-            <!-- JaCoCo for test coverage -->
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.10</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <rule>
-                                    <element>PACKAGE</element>
-                                    <limits>
-                                        <limit>
-                                            <counter>LINE</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.50</minimum>
-                                        </limit>
-                                    </limits>
-                                </rule>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            
-            <!-- Maven Surefire Plugin for better test reporting -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
-                <configuration>
-                    <includes>
-                        <include>**/*Test.java</include>
-                        <include>**/*Tests.java</include>
-                    </includes>
-                    <reportFormat>xml</reportFormat>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,13 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.2.0</version>
         </dependency>
+        
+        <!-- Logging -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>7.4</version>
+        </dependency>
 
         <!-- Database -->
         <dependency>

--- a/src/main/java/com/agenticcp/core/AgenticCpCoreApplication.java
+++ b/src/main/java/com/agenticcp/core/AgenticCpCoreApplication.java
@@ -3,9 +3,11 @@ package com.agenticcp.core;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaRepositories
+@EnableAsync
 public class AgenticCpCoreApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/agenticcp/core/common/config/AsyncConfig.java
+++ b/src/main/java/com/agenticcp/core/common/config/AsyncConfig.java
@@ -1,0 +1,26 @@
+package com.agenticcp.core.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "tenantTaskExecutor")
+    public TaskExecutor tenantTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("tenant-async-");
+        executor.setTaskDecorator(new TenantContextTaskDecorator()); // tenant context 전파
+        executor.initialize();
+
+        return executor;
+    }
+}

--- a/src/main/java/com/agenticcp/core/common/config/TenantContextTaskDecorator.java
+++ b/src/main/java/com/agenticcp/core/common/config/TenantContextTaskDecorator.java
@@ -1,0 +1,33 @@
+package com.agenticcp.core.common.config;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import org.springframework.core.task.TaskDecorator;
+
+public class TenantContextTaskDecorator implements TaskDecorator {
+
+    @Override
+    public Runnable decorate(Runnable runnable) {
+        // 1. 현재 스레드의 tenant context 캡처
+        Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+        String currentTenantKey = TenantContextHolder.getCurrentTenantKey();
+
+        return () -> {
+            try {
+                // 2. 새로운 스레드에서 tenant context 복원
+                if (currentTenant != null) {
+                    TenantContextHolder.setTenant(currentTenant);
+                }
+                else if (currentTenantKey != null) {
+                    TenantContextHolder.setTenantKey(currentTenantKey);
+                }
+                // 3. 실제 작업 실행
+                runnable.run();
+            } finally {
+                // 4. 작업 완료 후 컨텍스트 정리
+                TenantContextHolder.clear();
+            }
+        };
+
+    }
+}

--- a/src/main/java/com/agenticcp/core/common/service/PerformanceMonitoringService.java
+++ b/src/main/java/com/agenticcp/core/common/service/PerformanceMonitoringService.java
@@ -1,0 +1,257 @@
+package com.agenticcp.core.common.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+/**
+ * 성능 모니터링 서비스
+ * JWT 인증 관련 성능 요구사항 측정 및 모니터링
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PerformanceMonitoringService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    // 빈 주입
+    @Autowired
+    @Qualifier("tenantTaskExecutor")
+    private TaskExecutor tenantTaskExecutor;
+    
+    private static final String LOGIN_PERFORMANCE_PREFIX = "perf:login:";
+    private static final String TOKEN_REFRESH_PERFORMANCE_PREFIX = "perf:refresh:";
+    private static final String REDIS_PERFORMANCE_PREFIX = "perf:redis:";
+    private static final long LOGIN_THRESHOLD_MS = 200L; // 200ms
+    private static final long REDIS_THRESHOLD_MS = 50L; // 50ms
+
+    /**
+     * 로그인 성능 측정
+     */
+    public <T> PerformanceMetrics measureLoginPerformance(String username, Supplier<T> loginOperation) {
+        Instant start = Instant.now();
+        
+        try {
+            T result = loginOperation.get();
+            Instant end = Instant.now();
+            long duration = Duration.between(start, end).toMillis();
+            
+            PerformanceMetrics metrics = new PerformanceMetrics(
+                    "LOGIN", username, duration, duration <= LOGIN_THRESHOLD_MS
+            );
+            
+            logPerformanceMetrics(metrics);
+            storePerformanceMetrics(LOGIN_PERFORMANCE_PREFIX + username, metrics);
+            
+            return metrics;
+        } catch (Exception e) {
+            Instant end = Instant.now();
+            long duration = Duration.between(start, end).toMillis();
+            
+            PerformanceMetrics metrics = new PerformanceMetrics(
+                    "LOGIN", username, duration, false, e.getMessage()
+            );
+            
+            logPerformanceMetrics(metrics);
+            return metrics;
+        }
+    }
+
+    /**
+     * 토큰 갱신 성능 측정
+     */
+    public <T> PerformanceMetrics measureTokenRefreshPerformance(String username, Supplier<T> refreshOperation) {
+        Instant start = Instant.now();
+        
+        try {
+            T result = refreshOperation.get();
+            Instant end = Instant.now();
+            long duration = Duration.between(start, end).toMillis();
+            
+            PerformanceMetrics metrics = new PerformanceMetrics(
+                    "TOKEN_REFRESH", username, duration, duration <= LOGIN_THRESHOLD_MS
+            );
+            
+            logPerformanceMetrics(metrics);
+            storePerformanceMetrics(TOKEN_REFRESH_PERFORMANCE_PREFIX + username, metrics);
+            
+            return metrics;
+        } catch (Exception e) {
+            Instant end = Instant.now();
+            long duration = Duration.between(start, end).toMillis();
+            
+            PerformanceMetrics metrics = new PerformanceMetrics(
+                    "TOKEN_REFRESH", username, duration, false, e.getMessage()
+            );
+            
+            logPerformanceMetrics(metrics);
+            return metrics;
+        }
+    }
+
+    /**
+     * Redis 작업 성능 측정
+     */
+    public <T> PerformanceMetrics measureRedisPerformance(String operation, Supplier<T> redisOperation) {
+        Instant start = Instant.now();
+        
+        try {
+            T result = redisOperation.get();
+            Instant end = Instant.now();
+            long duration = Duration.between(start, end).toMillis();
+            
+            PerformanceMetrics metrics = new PerformanceMetrics(
+                    "REDIS_" + operation, "system", duration, duration <= REDIS_THRESHOLD_MS
+            );
+            
+            if (duration > REDIS_THRESHOLD_MS) {
+                log.warn("Redis 성능 저하 감지: operation={}, duration={}ms", operation, duration);
+            }
+            
+            return metrics;
+        } catch (Exception e) {
+            Instant end = Instant.now();
+            long duration = Duration.between(start, end).toMillis();
+            
+            PerformanceMetrics metrics = new PerformanceMetrics(
+                    "REDIS_" + operation, "system", duration, false, e.getMessage()
+            );
+            
+            log.error("Redis 작업 실패: operation={}, duration={}ms, error={}", 
+                    operation, duration, e.getMessage());
+            
+            return metrics;
+        }
+    }
+
+    /**
+     * 비동기 성능 측정
+     */
+    public <T> CompletableFuture<PerformanceMetrics> measureAsyncPerformance(
+            String operation, String identifier, Supplier<T> operationToMeasure) {
+        
+        return CompletableFuture.supplyAsync(() -> {
+            Instant start = Instant.now();
+            
+            try {
+                T result = operationToMeasure.get();
+                Instant end = Instant.now();
+                long duration = Duration.between(start, end).toMillis();
+                
+                PerformanceMetrics metrics = new PerformanceMetrics(
+                        operation, identifier, duration, true
+                );
+                
+                logPerformanceMetrics(metrics);
+                return metrics;
+            } catch (Exception e) {
+                Instant end = Instant.now();
+                long duration = Duration.between(start, end).toMillis();
+                
+                PerformanceMetrics metrics = new PerformanceMetrics(
+                        operation, identifier, duration, false, e.getMessage()
+                );
+                
+                logPerformanceMetrics(metrics);
+                return metrics;
+            }
+        }, tenantTaskExecutor);
+    }
+
+    /**
+     * 성능 메트릭 저장
+     */
+    private void storePerformanceMetrics(String key, PerformanceMetrics metrics) {
+        try {
+            redisTemplate.opsForValue().set(
+                    key,
+                    metrics.toJson(),
+                    Duration.ofHours(24) // 24시간 보관
+            );
+        } catch (Exception e) {
+            log.warn("성능 메트릭 저장 실패: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 성능 메트릭 로깅
+     */
+    private void logPerformanceMetrics(PerformanceMetrics metrics) {
+        if (metrics.isSuccess() && metrics.getDuration() <= getThresholdForOperation(metrics.getOperation())) {
+            log.debug("성능 메트릭: operation={}, identifier={}, duration={}ms", 
+                    metrics.getOperation(), metrics.getIdentifier(), metrics.getDuration());
+        } else if (!metrics.isSuccess()) {
+            log.error("성능 메트릭 (실패): operation={}, identifier={}, duration={}ms, error={}", 
+                    metrics.getOperation(), metrics.getIdentifier(), metrics.getDuration(), metrics.getError());
+        } else {
+            log.warn("성능 임계값 초과: operation={}, identifier={}, duration={}ms (임계값: {}ms)", 
+                    metrics.getOperation(), metrics.getIdentifier(), metrics.getDuration(), 
+                    getThresholdForOperation(metrics.getOperation()));
+        }
+    }
+
+    /**
+     * 작업별 임계값 조회
+     */
+    private long getThresholdForOperation(String operation) {
+        if (operation.startsWith("REDIS_")) {
+            return REDIS_THRESHOLD_MS;
+        }
+        return LOGIN_THRESHOLD_MS;
+    }
+
+    /**
+     * 성능 메트릭 클래스
+     */
+    public static class PerformanceMetrics {
+        private final String operation;
+        private final String identifier;
+        private final long duration;
+        private final boolean success;
+        private final String error;
+        private final Instant timestamp;
+        private Object result;
+
+        public PerformanceMetrics(String operation, String identifier, long duration, boolean success) {
+            this(operation, identifier, duration, success, null);
+        }
+
+        public PerformanceMetrics(String operation, String identifier, long duration, boolean success, String error) {
+            this.operation = operation;
+            this.identifier = identifier;
+            this.duration = duration;
+            this.success = success;
+            this.error = error;
+            this.timestamp = Instant.now();
+        }
+
+        public String getOperation() { return operation; }
+        public String getIdentifier() { return identifier; }
+        public long getDuration() { return duration; }
+        public boolean isSuccess() { return success; }
+        public String getError() { return error; }
+        public Instant getTimestamp() { return timestamp; }
+        
+        @SuppressWarnings("unchecked")
+        public <T> T getResult() { return (T) result; }
+        public void setResult(Object result) { this.result = result; }
+
+        public String toJson() {
+            return String.format(
+                    "{\"operation\":\"%s\",\"identifier\":\"%s\",\"duration\":%d,\"success\":%b,\"error\":\"%s\",\"timestamp\":\"%s\"}",
+                    operation, identifier, duration, success, error != null ? error : "", timestamp.toString()
+            );
+        }
+    }
+}

--- a/src/main/java/com/agenticcp/core/common/service/RetryService.java
+++ b/src/main/java/com/agenticcp/core/common/service/RetryService.java
@@ -1,0 +1,223 @@
+package com.agenticcp.core.common.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+/**
+ * 재시도 서비스
+ * 토큰 갱신 실패 시 재시도 로직 제공
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RetryService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    
+    private static final String RETRY_COUNT_PREFIX = "retry:count:";
+    private static final String RETRY_BACKOFF_PREFIX = "retry:backoff:";
+    private static final int MAX_RETRY_ATTEMPTS = 3;
+    private static final long BASE_DELAY_MS = 1000L; // 1초
+    private static final long MAX_DELAY_MS = 10000L; // 10초
+
+    // 빈 주입
+    @Autowired
+    @Qualifier("tenantTaskExecutor")
+    private TaskExecutor tenantTaskExecutor;
+
+    /**
+     * 토큰 갱신 재시도 로직
+     */
+    public <T> T retryTokenRefresh(String username, Supplier<T> operation) {
+        return retryWithBackoff(
+                "TOKEN_REFRESH",
+                username,
+                operation,
+                MAX_RETRY_ATTEMPTS,
+                BASE_DELAY_MS,
+                MAX_DELAY_MS
+        );
+    }
+
+    /**
+     * 일반적인 재시도 로직
+     */
+    public <T> T retryWithBackoff(String operation, String identifier, Supplier<T> operationToRetry, 
+                                 int maxAttempts, long baseDelayMs, long maxDelayMs) {
+        
+        int attempt = 1;
+        Exception lastException = null;
+        
+        while (attempt <= maxAttempts) {
+            try {
+                log.debug("재시도 시도: operation={}, identifier={}, attempt={}/{}", 
+                        operation, identifier, attempt, maxAttempts);
+                
+                T result = operationToRetry.get();
+                
+                // 성공 시 재시도 카운트 초기화
+                resetRetryCount(operation, identifier);
+                
+                if (attempt > 1) {
+                    log.info("재시도 성공: operation={}, identifier={}, attempt={}", 
+                            operation, identifier, attempt);
+                }
+                
+                return result;
+                
+            } catch (Exception e) {
+                lastException = e;
+                log.warn("재시도 실패: operation={}, identifier={}, attempt={}/{}, error={}", 
+                        operation, identifier, attempt, maxAttempts, e.getMessage());
+                
+                if (attempt == maxAttempts) {
+                    break;
+                }
+                
+                // 백오프 지연
+                long delay = calculateBackoffDelay(attempt, baseDelayMs, maxDelayMs);
+                incrementRetryCount(operation, identifier);
+                
+                try {
+                    Thread.sleep(delay);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("재시도 중 인터럽트 발생", ie);
+                }
+                
+                attempt++;
+            }
+        }
+        
+        // 최대 재시도 횟수 초과
+        log.error("최대 재시도 횟수 초과: operation={}, identifier={}, attempts={}", 
+                operation, identifier, maxAttempts);
+        
+        throw new RuntimeException(
+                String.format("재시도 실패: operation=%s, identifier=%s, attempts=%d", 
+                        operation, identifier, maxAttempts), 
+                lastException
+        );
+    }
+
+    /**
+     * 비동기 재시도 로직
+     */
+    public <T> CompletableFuture<T> retryAsync(String operation, String identifier, 
+                                             Supplier<T> operationToRetry, int maxAttempts) {
+        
+        return CompletableFuture.supplyAsync(() -> 
+                retryWithBackoff(operation,
+                        identifier,
+                        operationToRetry,
+                        maxAttempts,
+                        BASE_DELAY_MS,
+                        MAX_DELAY_MS),
+                tenantTaskExecutor // 커스텀 executor
+        );
+    }
+
+
+    /**
+     * 지수 백오프 지연 계산
+     */
+    private long calculateBackoffDelay(int attempt, long baseDelayMs, long maxDelayMs) {
+        // 지수 백오프: baseDelay * 2^(attempt-1)
+        long delay = baseDelayMs * (1L << (attempt - 1));
+        
+        // 최대 지연 시간 제한
+        delay = Math.min(delay, maxDelayMs);
+        
+        // 지터 추가 (±25% 랜덤 변동)
+        double jitter = 0.75 + (Math.random() * 0.5); // 0.75 ~ 1.25
+        delay = (long) (delay * jitter);
+        
+        return delay;
+    }
+
+    /**
+     * 재시도 횟수 증가
+     */
+    private void incrementRetryCount(String operation, String identifier) {
+        String key = RETRY_COUNT_PREFIX + operation + ":" + identifier;
+        try {
+            String count = redisTemplate.opsForValue().get(key);
+            int currentCount = count != null ? Integer.parseInt(count) : 0;
+            redisTemplate.opsForValue().set(key, String.valueOf(currentCount + 1), Duration.ofHours(1));
+        } catch (Exception e) {
+            log.warn("재시도 횟수 증가 실패: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 재시도 횟수 조회
+     */
+    public int getRetryCount(String operation, String identifier) {
+        String key = RETRY_COUNT_PREFIX + operation + ":" + identifier;
+        try {
+            String count = redisTemplate.opsForValue().get(key);
+            return count != null ? Integer.parseInt(count) : 0;
+        } catch (Exception e) {
+            log.warn("재시도 횟수 조회 실패: {}", e.getMessage());
+            return 0;
+        }
+    }
+
+    /**
+     * 재시도 횟수 초기화
+     */
+    private void resetRetryCount(String operation, String identifier) {
+        String key = RETRY_COUNT_PREFIX + operation + ":" + identifier;
+        try {
+            redisTemplate.delete(key);
+        } catch (Exception e) {
+            log.warn("재시도 횟수 초기화 실패: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 백오프 상태 설정
+     */
+    public void setBackoffState(String operation, String identifier, long backoffMs) {
+        String key = RETRY_BACKOFF_PREFIX + operation + ":" + identifier;
+        try {
+            redisTemplate.opsForValue().set(key, "true", Duration.ofMillis(backoffMs));
+        } catch (Exception e) {
+            log.warn("백오프 상태 설정 실패: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 백오프 상태 확인
+     */
+    public boolean isInBackoffState(String operation, String identifier) {
+        String key = RETRY_BACKOFF_PREFIX + operation + ":" + identifier;
+        try {
+            return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+        } catch (Exception e) {
+            log.warn("백오프 상태 확인 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 백오프 상태 해제
+     */
+    public void clearBackoffState(String operation, String identifier) {
+        String key = RETRY_BACKOFF_PREFIX + operation + ":" + identifier;
+        try {
+            redisTemplate.delete(key);
+        } catch (Exception e) {
+            log.warn("백오프 상태 해제 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/agenticcp/core/common/config/AsyncConfigTest.java
+++ b/src/test/java/com/agenticcp/core/common/config/AsyncConfigTest.java
@@ -1,0 +1,215 @@
+package com.agenticcp.core.common.config;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * AsyncConfig 단위 테스트
+ * TaskExecutor 설정과 TenantContextTaskDecorator 사용을 테스트
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-01-27
+ */
+class AsyncConfigTest {
+
+    private AsyncConfig asyncConfig;
+    private TaskExecutor tenantTaskExecutor;
+
+    @BeforeEach
+    void setUp() {
+        asyncConfig = new AsyncConfig();
+        tenantTaskExecutor = asyncConfig.tenantTaskExecutor();
+        TenantContextHolder.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContextHolder.clear();
+    }
+
+    @Test
+    @DisplayName("tenantTaskExecutor 빈이 올바르게 생성되는지 테스트")
+    void tenantTaskExecutor_ShouldBeCreatedCorrectly() {
+        // Then
+        assertThat(tenantTaskExecutor).isNotNull();
+        assertThat(tenantTaskExecutor).isInstanceOf(ThreadPoolTaskExecutor.class);
+        
+        ThreadPoolTaskExecutor executor = (ThreadPoolTaskExecutor) tenantTaskExecutor;
+        assertThat(executor.getCorePoolSize()).isEqualTo(5);
+        assertThat(executor.getMaxPoolSize()).isEqualTo(10);
+        assertThat(executor.getQueueCapacity()).isEqualTo(100);
+        assertThat(executor.getThreadNamePrefix()).isEqualTo("tenant-async-");
+    }
+
+    @Test
+    @DisplayName("tenantTaskExecutor에서 Tenant Context가 전파되는지 테스트")
+    void tenantTaskExecutor_ShouldPropagateTenantContext() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+            if (currentTenant != null) {
+                capturedTenantKey.set(currentTenant.getTenantKey());
+            }
+        };
+
+        // When
+        CompletableFuture<Void> future = CompletableFuture.runAsync(testRunnable, tenantTaskExecutor);
+        future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+    }
+
+    @Test
+    @DisplayName("tenantTaskExecutor에서 Tenant Key만 있을 때 컨텍스트가 전파되는지 테스트")
+    void tenantTaskExecutor_WithTenantKeyOnly_ShouldPropagateContext() throws Exception {
+        // Given
+        String testTenantKey = "test-tenant-key-only";
+        TenantContextHolder.setTenantKey(testTenantKey);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+        };
+
+        // When
+        CompletableFuture<Void> future = CompletableFuture.runAsync(testRunnable, tenantTaskExecutor);
+        future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(capturedTenantKey.get()).isEqualTo(testTenantKey);
+    }
+
+    @Test
+    @DisplayName("tenantTaskExecutor에서 컨텍스트가 없을 때 null이 전파되는지 테스트")
+    void tenantTaskExecutor_WithoutTenantContext_ShouldPropagateNull() throws Exception {
+        // Given
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        AtomicReference<Tenant> capturedTenant = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            capturedTenant.set(TenantContextHolder.getCurrentTenant());
+        };
+
+        // When
+        CompletableFuture<Void> future = CompletableFuture.runAsync(testRunnable, tenantTaskExecutor);
+        future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(capturedTenantKey.get()).isNull();
+        assertThat(capturedTenant.get()).isNull();
+    }
+
+    @Test
+    @DisplayName("여러 작업이 동시에 실행될 때 각각의 컨텍스트가 독립적으로 전파되는지 테스트")
+    void tenantTaskExecutor_MultipleConcurrentTasks_ShouldPropagateIndependentContexts() throws Exception {
+        // Given
+        Tenant tenant1 = createTestTenant("tenant-1", "Tenant 1");
+        Tenant tenant2 = createTestTenant("tenant-2", "Tenant 2");
+        
+        AtomicReference<String> capturedTenant1Key = new AtomicReference<>();
+        AtomicReference<String> capturedTenant2Key = new AtomicReference<>();
+        
+        Runnable runnable1 = () -> {
+            Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+            if (currentTenant != null) {
+                capturedTenant1Key.set(currentTenant.getTenantKey());
+            }
+        };
+        
+        Runnable runnable2 = () -> {
+            Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+            if (currentTenant != null) {
+                capturedTenant2Key.set(currentTenant.getTenantKey());
+            }
+        };
+
+        // When
+        TenantContextHolder.setTenant(tenant1);
+        CompletableFuture<Void> future1 = CompletableFuture.runAsync(runnable1, tenantTaskExecutor);
+        
+        TenantContextHolder.setTenant(tenant2);
+        CompletableFuture<Void> future2 = CompletableFuture.runAsync(runnable2, tenantTaskExecutor);
+        
+        CompletableFuture.allOf(future1, future2).get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(capturedTenant1Key.get()).isEqualTo("tenant-1");
+        assertThat(capturedTenant2Key.get()).isEqualTo("tenant-2");
+    }
+
+    @Test
+    @DisplayName("작업 중 예외 발생 시에도 컨텍스트가 정리되는지 테스트")
+    void tenantTaskExecutor_WithException_ShouldClearContext() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant-key", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            // 예외 발생 전에 컨텍스트 캡처
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            throw new RuntimeException("Test exception");
+        };
+
+        // When & Then
+        CompletableFuture<Void> future = CompletableFuture.runAsync(testRunnable, tenantTaskExecutor);
+        
+        // 예외가 발생해도 작업 중에는 컨텍스트가 전파되었는지 확인
+        assertThatThrownBy(() -> future.get(5, TimeUnit.SECONDS))
+                .isInstanceOf(Exception.class);
+        
+        // 작업 중에는 컨텍스트가 전파되었는지 확인
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant-key");
+        
+        // 메인 스레드의 컨텍스트는 그대로 유지되어야 함 (ThreadLocal 특성상)
+        assertThat(TenantContextHolder.getCurrentTenantKey()).isEqualTo("test-tenant-key");
+        assertThat(TenantContextHolder.getCurrentTenant()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("TaskExecutor 스레드 풀 설정이 올바른지 테스트")
+    void tenantTaskExecutor_ShouldHaveCorrectThreadPoolSettings() {
+        // Given
+        ThreadPoolTaskExecutor executor = (ThreadPoolTaskExecutor) tenantTaskExecutor;
+
+        // When & Then
+        assertThat(executor.getCorePoolSize()).isEqualTo(5);
+        assertThat(executor.getMaxPoolSize()).isEqualTo(10);
+        assertThat(executor.getQueueCapacity()).isEqualTo(100);
+        assertThat(executor.getThreadNamePrefix()).isEqualTo("tenant-async-");
+    }
+
+    /**
+     * 테스트용 Tenant 객체 생성
+     */
+    private Tenant createTestTenant(String tenantKey, String tenantName) {
+        return Tenant.builder()
+                .tenantKey(tenantKey)
+                .tenantName(tenantName)
+                .description("Test tenant for AsyncConfig testing")
+                .build();
+    }
+}

--- a/src/test/java/com/agenticcp/core/common/config/TenantContextTaskDecoratorSimpleTest.java
+++ b/src/test/java/com/agenticcp/core/common/config/TenantContextTaskDecoratorSimpleTest.java
@@ -1,0 +1,167 @@
+package com.agenticcp.core.common.config;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * TenantContextTaskDecorator 간단한 단위 테스트
+ * 다른 코드의 영향을 받지 않는 순수 테스트
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-01-27
+ */
+class TenantContextTaskDecoratorSimpleTest {
+
+    private TenantContextTaskDecorator taskDecorator;
+
+    @BeforeEach
+    void setUp() {
+        taskDecorator = new TenantContextTaskDecorator();
+        TenantContextHolder.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContextHolder.clear();
+    }
+
+    @Test
+    @DisplayName("Tenant Context가 정상적으로 전파되는지 테스트")
+    void testTenantContextPropagation() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        Runnable testRunnable = () -> {
+            Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+            if (currentTenant != null) {
+                capturedTenantKey.set(currentTenant.getTenantKey());
+            }
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+    }
+
+    @Test
+    @DisplayName("Tenant Key만 있을 때 컨텍스트가 전파되는지 테스트")
+    void testTenantKeyPropagation() {
+        // Given
+        String testTenantKey = "test-tenant-key";
+        TenantContextHolder.setTenantKey(testTenantKey);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        Runnable testRunnable = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then
+        assertThat(capturedTenantKey.get()).isEqualTo(testTenantKey);
+    }
+
+    @Test
+    @DisplayName("작업 완료 후 컨텍스트가 정리되는지 테스트")
+    void testContextCleanup() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            // 작업 수행 중 컨텍스트 캡처
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then - 작업 중에는 컨텍스트가 전파되었는지 확인
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+        
+        // 메인 스레드의 컨텍스트는 그대로 유지되어야 함 (ThreadLocal 특성상)
+        assertThat(TenantContextHolder.getCurrentTenantKey()).isEqualTo("test-tenant");
+        assertThat(TenantContextHolder.getCurrentTenant()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("예외 발생 시에도 컨텍스트가 정리되는지 테스트")
+    void testContextCleanupOnException() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            // 예외 발생 전에 컨텍스트 캡처
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            throw new RuntimeException("Test exception");
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        
+        // 예외가 발생해도 작업 중에는 컨텍스트가 전파되었는지 확인
+        try {
+            CompletableFuture.runAsync(decoratedRunnable).join();
+        } catch (Exception e) {
+            // 예외는 무시하고 컨텍스트 전파만 확인
+        }
+
+        // Then - 작업 중에는 컨텍스트가 전파되었는지 확인
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+        
+        // 메인 스레드의 컨텍스트는 그대로 유지되어야 함 (ThreadLocal 특성상)
+        assertThat(TenantContextHolder.getCurrentTenantKey()).isEqualTo("test-tenant");
+        assertThat(TenantContextHolder.getCurrentTenant()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("컨텍스트가 없을 때 null이 전파되는지 테스트")
+    void testNullContextPropagation() {
+        // Given
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        Runnable testRunnable = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then
+        assertThat(capturedTenantKey.get()).isNull();
+    }
+
+    /**
+     * 테스트용 Tenant 객체 생성
+     */
+    private Tenant createTestTenant(String tenantKey, String tenantName) {
+        return Tenant.builder()
+                .tenantKey(tenantKey)
+                .tenantName(tenantName)
+                .description("Test tenant")
+                .build();
+    }
+}

--- a/src/test/java/com/agenticcp/core/common/config/TenantContextTaskDecoratorTest.java
+++ b/src/test/java/com/agenticcp/core/common/config/TenantContextTaskDecoratorTest.java
@@ -1,0 +1,254 @@
+package com.agenticcp.core.common.config;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * TenantContextTaskDecorator 단위 테스트
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-01-27
+ */
+@ExtendWith(MockitoExtension.class)
+class TenantContextTaskDecoratorTest {
+
+    private TenantContextTaskDecorator taskDecorator;
+
+    @BeforeEach
+    void setUp() {
+        taskDecorator = new TenantContextTaskDecorator();
+        // 테스트 전에 컨텍스트 정리
+        TenantContextHolder.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 테스트 후에 컨텍스트 정리
+        TenantContextHolder.clear();
+    }
+
+    @Test
+    @DisplayName("Tenant 객체가 있을 때 컨텍스트가 정상적으로 전파되는지 테스트")
+    void decorate_WithTenantObject_ShouldPropagateContext() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant-key", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        AtomicReference<String> capturedTenantName = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+            if (currentTenant != null) {
+                capturedTenantKey.set(currentTenant.getTenantKey());
+                capturedTenantName.set(currentTenant.getTenantName());
+            }
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant-key");
+        assertThat(capturedTenantName.get()).isEqualTo("Test Tenant");
+    }
+
+    @Test
+    @DisplayName("Tenant 키만 있을 때 컨텍스트가 정상적으로 전파되는지 테스트")
+    void decorate_WithTenantKeyOnly_ShouldPropagateContext() {
+        // Given
+        String testTenantKey = "test-tenant-key-only";
+        TenantContextHolder.setTenantKey(testTenantKey);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then
+        assertThat(capturedTenantKey.get()).isEqualTo(testTenantKey);
+    }
+
+    @Test
+    @DisplayName("Tenant 컨텍스트가 없을 때 null이 전파되는지 테스트")
+    void decorate_WithoutTenantContext_ShouldPropagateNull() {
+        // Given
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        AtomicReference<Tenant> capturedTenant = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            capturedTenant.set(TenantContextHolder.getCurrentTenant());
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then
+        assertThat(capturedTenantKey.get()).isNull();
+        assertThat(capturedTenant.get()).isNull();
+    }
+
+    @Test
+    @DisplayName("작업 완료 후 컨텍스트가 정리되는지 테스트")
+    void decorate_AfterTaskCompletion_ShouldClearContext() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant-key", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        AtomicReference<Tenant> capturedTenant = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            // 작업 수행 중 컨텍스트 캡처
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            capturedTenant.set(TenantContextHolder.getCurrentTenant());
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then - 작업 중에는 컨텍스트가 전파되었고, 작업 완료 후에는 정리되었는지 확인
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant-key");
+        assertThat(capturedTenant.get()).isNotNull();
+        
+        // 메인 스레드의 컨텍스트는 그대로 유지되어야 함 (ThreadLocal 특성상)
+        assertThat(TenantContextHolder.getCurrentTenantKey()).isEqualTo("test-tenant-key");
+        assertThat(TenantContextHolder.getCurrentTenant()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("작업 중 예외 발생 시에도 컨텍스트가 정리되는지 테스트")
+    void decorate_WithException_ShouldClearContext() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant-key", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            // 예외 발생 전에 컨텍스트 캡처
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            throw new RuntimeException("Test exception");
+        };
+
+        // When & Then
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        
+        // 예외가 발생해도 작업 중에는 컨텍스트가 전파되었는지 확인
+        assertThatThrownBy(() -> CompletableFuture.runAsync(decoratedRunnable).join())
+                .isInstanceOf(Exception.class);
+        
+        // 작업 중에는 컨텍스트가 전파되었는지 확인
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant-key");
+        
+        // 메인 스레드의 컨텍스트는 그대로 유지되어야 함 (ThreadLocal 특성상)
+        assertThat(TenantContextHolder.getCurrentTenantKey()).isEqualTo("test-tenant-key");
+        assertThat(TenantContextHolder.getCurrentTenant()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("여러 작업이 동시에 실행될 때 각각의 컨텍스트가 독립적으로 전파되는지 테스트")
+    void decorate_MultipleConcurrentTasks_ShouldPropagateIndependentContexts() {
+        // Given
+        Tenant tenant1 = createTestTenant("tenant-1", "Tenant 1");
+        Tenant tenant2 = createTestTenant("tenant-2", "Tenant 2");
+        
+        AtomicReference<String> capturedTenant1Key = new AtomicReference<>();
+        AtomicReference<String> capturedTenant2Key = new AtomicReference<>();
+        
+        Runnable runnable1 = () -> {
+            Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+            if (currentTenant != null) {
+                capturedTenant1Key.set(currentTenant.getTenantKey());
+            }
+        };
+        
+        Runnable runnable2 = () -> {
+            Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+            if (currentTenant != null) {
+                capturedTenant2Key.set(currentTenant.getTenantKey());
+            }
+        };
+
+        // When
+        TenantContextHolder.setTenant(tenant1);
+        Runnable decoratedRunnable1 = taskDecorator.decorate(runnable1);
+        
+        TenantContextHolder.setTenant(tenant2);
+        Runnable decoratedRunnable2 = taskDecorator.decorate(runnable2);
+        
+        CompletableFuture<Void> future1 = CompletableFuture.runAsync(decoratedRunnable1);
+        CompletableFuture<Void> future2 = CompletableFuture.runAsync(decoratedRunnable2);
+        
+        CompletableFuture.allOf(future1, future2).join();
+
+        // Then
+        assertThat(capturedTenant1Key.get()).isEqualTo("tenant-1");
+        assertThat(capturedTenant2Key.get()).isEqualTo("tenant-2");
+    }
+
+    @Test
+    @DisplayName("Tenant 객체와 Tenant 키가 모두 있을 때 Tenant 객체가 우선되는지 테스트")
+    void decorate_WithBothTenantAndKey_ShouldPrioritizeTenantObject() {
+        // Given
+        Tenant testTenant = createTestTenant("tenant-object-key", "Tenant Object");
+        String differentTenantKey = "different-tenant-key";
+        
+        TenantContextHolder.setTenant(testTenant);
+        TenantContextHolder.setTenantKey(differentTenantKey);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        AtomicReference<String> capturedTenantName = new AtomicReference<>();
+        
+        Runnable testRunnable = () -> {
+            Tenant currentTenant = TenantContextHolder.getCurrentTenant();
+            if (currentTenant != null) {
+                capturedTenantKey.set(currentTenant.getTenantKey());
+                capturedTenantName.set(currentTenant.getTenantName());
+            }
+        };
+
+        // When
+        Runnable decoratedRunnable = taskDecorator.decorate(testRunnable);
+        CompletableFuture.runAsync(decoratedRunnable).join();
+
+        // Then
+        assertThat(capturedTenantKey.get()).isEqualTo("tenant-object-key");
+        assertThat(capturedTenantName.get()).isEqualTo("Tenant Object");
+        // Tenant 객체가 우선되므로 다른 키는 무시됨
+        assertThat(capturedTenantKey.get()).isNotEqualTo(differentTenantKey);
+    }
+
+    /**
+     * 테스트용 Tenant 객체 생성
+     */
+    private Tenant createTestTenant(String tenantKey, String tenantName) {
+        return Tenant.builder()
+                .tenantKey(tenantKey)
+                .tenantName(tenantName)
+                .description("Test tenant for unit testing")
+                .build();
+    }
+}

--- a/src/test/java/com/agenticcp/core/common/service/AsyncLogicTest.java
+++ b/src/test/java/com/agenticcp/core/common/service/AsyncLogicTest.java
@@ -1,0 +1,203 @@
+package com.agenticcp.core.common.service;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 비동기 로직만 테스트하는 간단한 테스트
+ * Spring Context나 다른 의존성 없이 순수 비동기 로직만 검증
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-01-27
+ */
+class AsyncLogicTest {
+
+    @BeforeEach
+    void setUp() {
+        TenantContextHolder.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContextHolder.clear();
+    }
+
+    @Test
+    @DisplayName("CompletableFuture에서 Tenant Context가 전파되지 않는 문제 확인")
+    void testCompletableFutureWithoutTenantContext() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        // When - 기본 CompletableFuture 사용 (Tenant Context 전파 안됨)
+        CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            return "result";
+        });
+        
+        String result = future.get(5, TimeUnit.SECONDS);
+
+        // Then - Tenant Context가 전파되지 않음을 확인
+        assertThat(result).isEqualTo("result");
+        assertThat(capturedTenantKey.get()).isNull(); // 전파되지 않음
+    }
+
+    @Test
+    @DisplayName("수동으로 Tenant Context를 전파하는 방법 테스트")
+    void testManualTenantContextPropagation() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        // When - 수동으로 Tenant Context 전파
+        CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> {
+            try {
+                // 수동으로 Tenant Context 복원
+                TenantContextHolder.setTenant(testTenant);
+                capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+                return "result";
+            } finally {
+                // 수동으로 컨텍스트 정리
+                TenantContextHolder.clear();
+            }
+        });
+        
+        String result = future.get(5, TimeUnit.SECONDS);
+
+        // Then - Tenant Context가 전파됨을 확인
+        assertThat(result).isEqualTo("result");
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+    }
+
+    @Test
+    @DisplayName("Supplier를 사용한 비동기 작업에서 Tenant Context 전파 테스트")
+    void testSupplierWithTenantContext() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Supplier<String> operation = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            return "operation result";
+        };
+
+        // When - Supplier를 CompletableFuture로 실행
+        CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> {
+            try {
+                // 수동으로 Tenant Context 복원
+                TenantContextHolder.setTenant(testTenant);
+                return operation.get();
+            } finally {
+                TenantContextHolder.clear();
+            }
+        });
+        
+        String result = future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(result).isEqualTo("operation result");
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+    }
+
+    @Test
+    @DisplayName("여러 비동기 작업이 동시에 실행될 때 Tenant Context 독립성 테스트")
+    void testConcurrentAsyncTasksWithTenantContext() throws Exception {
+        // Given
+        Tenant tenant1 = createTestTenant("tenant-1", "Tenant 1");
+        Tenant tenant2 = createTestTenant("tenant-2", "Tenant 2");
+        
+        AtomicReference<String> capturedTenant1Key = new AtomicReference<>();
+        AtomicReference<String> capturedTenant2Key = new AtomicReference<>();
+        
+        Supplier<String> operation1 = () -> {
+            try {
+                TenantContextHolder.setTenant(tenant1);
+                capturedTenant1Key.set(TenantContextHolder.getCurrentTenantKey());
+                return "result1";
+            } finally {
+                TenantContextHolder.clear();
+            }
+        };
+        
+        Supplier<String> operation2 = () -> {
+            try {
+                TenantContextHolder.setTenant(tenant2);
+                capturedTenant2Key.set(TenantContextHolder.getCurrentTenantKey());
+                return "result2";
+            } finally {
+                TenantContextHolder.clear();
+            }
+        };
+
+        // When
+        CompletableFuture<String> future1 = CompletableFuture.supplyAsync(operation1);
+        CompletableFuture<String> future2 = CompletableFuture.supplyAsync(operation2);
+        
+        CompletableFuture.allOf(future1, future2).get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(future1.get()).isEqualTo("result1");
+        assertThat(future2.get()).isEqualTo("result2");
+        assertThat(capturedTenant1Key.get()).isEqualTo("tenant-1");
+        assertThat(capturedTenant2Key.get()).isEqualTo("tenant-2");
+    }
+
+    @Test
+    @DisplayName("비동기 작업에서 예외 발생 시 Tenant Context 정리 테스트")
+    void testAsyncTaskExceptionWithTenantContext() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Supplier<String> failingOperation = () -> {
+            try {
+                TenantContextHolder.setTenant(testTenant);
+                capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+                throw new RuntimeException("Test exception");
+            } finally {
+                TenantContextHolder.clear();
+            }
+        };
+
+        // When & Then
+        CompletableFuture<String> future = CompletableFuture.supplyAsync(failingOperation);
+        
+        // 예외가 발생했는지 확인
+        assertThatThrownBy(() -> future.get(5, TimeUnit.SECONDS))
+                .isInstanceOf(Exception.class);
+        
+        assertThat(future.isCompletedExceptionally()).isTrue();
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+    }
+
+    /**
+     * 테스트용 Tenant 객체 생성
+     */
+    private Tenant createTestTenant(String tenantKey, String tenantName) {
+        return Tenant.builder()
+                .tenantKey(tenantKey)
+                .tenantName(tenantName)
+                .description("Test tenant")
+                .build();
+    }
+}

--- a/src/test/java/com/agenticcp/core/common/service/PerformanceMonitoringServiceTest.java
+++ b/src/test/java/com/agenticcp/core/common/service/PerformanceMonitoringServiceTest.java
@@ -1,0 +1,292 @@
+package com.agenticcp.core.common.service;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * PerformanceMonitoringService 단위 테스트
+ * TaskExecutor 사용 부분을 중점적으로 테스트
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-01-27
+ */
+@ExtendWith(MockitoExtension.class)
+class PerformanceMonitoringServiceTest {
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+    
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+    
+    @Mock
+    private TaskExecutor tenantTaskExecutor;
+    
+    private PerformanceMonitoringService performanceMonitoringService;
+
+    @BeforeEach
+    void setUp() {
+        performanceMonitoringService = new PerformanceMonitoringService(redisTemplate);
+        
+        // TaskExecutor 주입 (리플렉션 사용)
+        try {
+            var field = PerformanceMonitoringService.class.getDeclaredField("tenantTaskExecutor");
+            field.setAccessible(true);
+            field.set(performanceMonitoringService, tenantTaskExecutor);
+        } catch (Exception e) {
+            throw new RuntimeException("TaskExecutor 주입 실패", e);
+        }
+        
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        TenantContextHolder.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContextHolder.clear();
+    }
+
+    @Test
+    @DisplayName("비동기 성능 측정에서 TaskExecutor가 사용되는지 테스트")
+    void measureAsyncPerformance_ShouldUseTaskExecutor() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String operation = "TEST_OPERATION";
+        String identifier = "test-user";
+        Supplier<String> operationToMeasure = () -> "success";
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When
+        CompletableFuture<PerformanceMonitoringService.PerformanceMetrics> future = 
+                performanceMonitoringService.measureAsyncPerformance(operation, identifier, operationToMeasure);
+        PerformanceMonitoringService.PerformanceMetrics metrics = future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(metrics).isNotNull();
+        assertThat(metrics.getOperation()).isEqualTo(operation);
+        assertThat(metrics.getIdentifier()).isEqualTo(identifier);
+        assertThat(metrics.isSuccess()).isTrue();
+        verify(tenantTaskExecutor, times(1)).execute(any(Runnable.class));
+    }
+
+    @Test
+    @DisplayName("비동기 성능 측정에서 Tenant Context가 전파되는지 테스트")
+    void measureAsyncPerformance_ShouldPropagateTenantContext() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String operation = "TEST_OPERATION";
+        String identifier = "test-user";
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Supplier<String> operationToMeasure = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            return "success";
+        };
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When
+        CompletableFuture<PerformanceMonitoringService.PerformanceMetrics> future = 
+                performanceMonitoringService.measureAsyncPerformance(operation, identifier, operationToMeasure);
+        PerformanceMonitoringService.PerformanceMetrics metrics = future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(metrics).isNotNull();
+        assertThat(metrics.isSuccess()).isTrue();
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+    }
+
+    @Test
+    @DisplayName("비동기 성능 측정에서 예외 발생 시 TaskExecutor가 사용되는지 테스트")
+    void measureAsyncPerformance_WithException_ShouldUseTaskExecutor() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String operation = "TEST_OPERATION";
+        String identifier = "test-user";
+        
+        Supplier<String> failingOperation = () -> {
+            throw new RuntimeException("Test exception");
+        };
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When
+        CompletableFuture<PerformanceMonitoringService.PerformanceMetrics> future = 
+                performanceMonitoringService.measureAsyncPerformance(operation, identifier, failingOperation);
+        PerformanceMonitoringService.PerformanceMetrics metrics = future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(metrics).isNotNull();
+        assertThat(metrics.isSuccess()).isFalse();
+        assertThat(metrics.getError()).isEqualTo("Test exception");
+        verify(tenantTaskExecutor, times(1)).execute(any(Runnable.class));
+    }
+
+    @Test
+    @DisplayName("여러 비동기 성능 측정 작업이 동시에 실행될 때 각각의 TaskExecutor 사용 테스트")
+    void measureAsyncPerformance_MultipleConcurrentTasks_ShouldUseTaskExecutor() throws Exception {
+        // Given
+        Tenant tenant1 = createTestTenant("tenant-1", "Tenant 1");
+        Tenant tenant2 = createTestTenant("tenant-2", "Tenant 2");
+        
+        AtomicReference<String> capturedTenant1Key = new AtomicReference<>();
+        AtomicReference<String> capturedTenant2Key = new AtomicReference<>();
+        
+        Supplier<String> operation1 = () -> {
+            capturedTenant1Key.set(TenantContextHolder.getCurrentTenantKey());
+            return "result1";
+        };
+        
+        Supplier<String> operation2 = () -> {
+            capturedTenant2Key.set(TenantContextHolder.getCurrentTenantKey());
+            return "result2";
+        };
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When
+        TenantContextHolder.setTenant(tenant1);
+        CompletableFuture<PerformanceMonitoringService.PerformanceMetrics> future1 = 
+                performanceMonitoringService.measureAsyncPerformance("OP1", "user1", operation1);
+        
+        TenantContextHolder.setTenant(tenant2);
+        CompletableFuture<PerformanceMonitoringService.PerformanceMetrics> future2 = 
+                performanceMonitoringService.measureAsyncPerformance("OP2", "user2", operation2);
+        
+        CompletableFuture.allOf(future1, future2).get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(future1.get().isSuccess()).isTrue();
+        assertThat(future2.get().isSuccess()).isTrue();
+        assertThat(capturedTenant1Key.get()).isEqualTo("tenant-1");
+        assertThat(capturedTenant2Key.get()).isEqualTo("tenant-2");
+        verify(tenantTaskExecutor, times(2)).execute(any(Runnable.class));
+    }
+
+    @Test
+    @DisplayName("로그인 성능 측정 테스트")
+    void measureLoginPerformance_ShouldWorkCorrectly() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String username = "test-user";
+        Supplier<String> loginOperation = () -> "login-success";
+        
+        // When
+        PerformanceMonitoringService.PerformanceMetrics metrics = 
+                performanceMonitoringService.measureLoginPerformance(username, loginOperation);
+
+        // Then
+        assertThat(metrics).isNotNull();
+        assertThat(metrics.getOperation()).isEqualTo("LOGIN");
+        assertThat(metrics.getIdentifier()).isEqualTo(username);
+        assertThat(metrics.isSuccess()).isTrue();
+        assertThat(metrics.getDuration()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 성능 측정 테스트")
+    void measureTokenRefreshPerformance_ShouldWorkCorrectly() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String username = "test-user";
+        Supplier<String> refreshOperation = () -> "refresh-success";
+        
+        // When
+        PerformanceMonitoringService.PerformanceMetrics metrics = 
+                performanceMonitoringService.measureTokenRefreshPerformance(username, refreshOperation);
+
+        // Then
+        assertThat(metrics).isNotNull();
+        assertThat(metrics.getOperation()).isEqualTo("TOKEN_REFRESH");
+        assertThat(metrics.getIdentifier()).isEqualTo(username);
+        assertThat(metrics.isSuccess()).isTrue();
+        assertThat(metrics.getDuration()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("Redis 작업 성능 측정 테스트")
+    void measureRedisPerformance_ShouldWorkCorrectly() {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String operation = "GET";
+        Supplier<String> redisOperation = () -> "redis-result";
+        
+        // When
+        PerformanceMonitoringService.PerformanceMetrics metrics = 
+                performanceMonitoringService.measureRedisPerformance(operation, redisOperation);
+
+        // Then
+        assertThat(metrics).isNotNull();
+        assertThat(metrics.getOperation()).isEqualTo("REDIS_GET");
+        assertThat(metrics.getIdentifier()).isEqualTo("system");
+        assertThat(metrics.isSuccess()).isTrue();
+        assertThat(metrics.getDuration()).isGreaterThanOrEqualTo(0);
+    }
+
+    /**
+     * 테스트용 Tenant 객체 생성
+     */
+    private Tenant createTestTenant(String tenantKey, String tenantName) {
+        return Tenant.builder()
+                .tenantKey(tenantKey)
+                .tenantName(tenantName)
+                .description("Test tenant for PerformanceMonitoringService testing")
+                .build();
+    }
+}

--- a/src/test/java/com/agenticcp/core/common/service/RetryServiceTest.java
+++ b/src/test/java/com/agenticcp/core/common/service/RetryServiceTest.java
@@ -1,0 +1,245 @@
+package com.agenticcp.core.common.service;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * RetryService 단위 테스트
+ * TaskExecutor 사용 부분을 중점적으로 테스트
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-01-27
+ */
+@ExtendWith(MockitoExtension.class)
+class RetryServiceTest {
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+    
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+    
+    @Mock
+    private TaskExecutor tenantTaskExecutor;
+    
+    private RetryService retryService;
+
+    @BeforeEach
+    void setUp() {
+        retryService = new RetryService(redisTemplate);
+        
+        // TaskExecutor 주입 (리플렉션 사용)
+        try {
+            var field = RetryService.class.getDeclaredField("tenantTaskExecutor");
+            field.setAccessible(true);
+            field.set(retryService, tenantTaskExecutor);
+        } catch (Exception e) {
+            throw new RuntimeException("TaskExecutor 주입 실패", e);
+        }
+        
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        TenantContextHolder.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContextHolder.clear();
+    }
+
+    @Test
+    @DisplayName("비동기 재시도 로직에서 TaskExecutor가 사용되는지 테스트")
+    void retryAsync_ShouldUseTaskExecutor() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String operation = "TEST_OPERATION";
+        String identifier = "test-user";
+        Supplier<String> operationToRetry = () -> "success";
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            // 작업을 실행하면서 Tenant Context 캡처
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When
+        CompletableFuture<String> future = retryService.retryAsync(operation, identifier, operationToRetry, 3);
+        String result = future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(result).isEqualTo("success");
+        verify(tenantTaskExecutor, times(1)).execute(any(Runnable.class));
+    }
+
+    @Test
+    @DisplayName("비동기 재시도 로직에서 Tenant Context가 전파되는지 테스트")
+    void retryAsync_ShouldPropagateTenantContext() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String operation = "TEST_OPERATION";
+        String identifier = "test-user";
+        
+        AtomicReference<String> capturedTenantKey = new AtomicReference<>();
+        
+        Supplier<String> operationToRetry = () -> {
+            capturedTenantKey.set(TenantContextHolder.getCurrentTenantKey());
+            return "success";
+        };
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When
+        CompletableFuture<String> future = retryService.retryAsync(operation, identifier, operationToRetry, 3);
+        String result = future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(result).isEqualTo("success");
+        assertThat(capturedTenantKey.get()).isEqualTo("test-tenant");
+    }
+
+    @Test
+    @DisplayName("비동기 재시도 로직에서 예외 발생 시 TaskExecutor가 사용되는지 테스트")
+    void retryAsync_WithException_ShouldUseTaskExecutor() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String operation = "TEST_OPERATION";
+        String identifier = "test-user";
+        
+        Supplier<String> failingOperation = () -> {
+            throw new RuntimeException("Test exception");
+        };
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When & Then
+        CompletableFuture<String> future = retryService.retryAsync(operation, identifier, failingOperation, 3);
+        
+        assertThatThrownBy(() -> future.get(5, TimeUnit.SECONDS))
+                .isInstanceOf(Exception.class);
+        
+        verify(tenantTaskExecutor, times(1)).execute(any(Runnable.class));
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 재시도 로직에서 TaskExecutor가 사용되는지 테스트")
+    void retryTokenRefresh_ShouldUseTaskExecutor() throws Exception {
+        // Given
+        Tenant testTenant = createTestTenant("test-tenant", "Test Tenant");
+        TenantContextHolder.setTenant(testTenant);
+        
+        String username = "test-user";
+        Supplier<String> tokenRefreshOperation = () -> "new-token";
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When
+        CompletableFuture<String> future = retryService.retryAsync("TOKEN_REFRESH", username, tokenRefreshOperation, 3);
+        String result = future.get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(result).isEqualTo("new-token");
+        verify(tenantTaskExecutor, times(1)).execute(any(Runnable.class));
+    }
+
+    @Test
+    @DisplayName("여러 비동기 재시도 작업이 동시에 실행될 때 각각의 TaskExecutor 사용 테스트")
+    void retryAsync_MultipleConcurrentTasks_ShouldUseTaskExecutor() throws Exception {
+        // Given
+        Tenant tenant1 = createTestTenant("tenant-1", "Tenant 1");
+        Tenant tenant2 = createTestTenant("tenant-2", "Tenant 2");
+        
+        AtomicReference<String> capturedTenant1Key = new AtomicReference<>();
+        AtomicReference<String> capturedTenant2Key = new AtomicReference<>();
+        
+        Supplier<String> operation1 = () -> {
+            capturedTenant1Key.set(TenantContextHolder.getCurrentTenantKey());
+            return "result1";
+        };
+        
+        Supplier<String> operation2 = () -> {
+            capturedTenant2Key.set(TenantContextHolder.getCurrentTenantKey());
+            return "result2";
+        };
+        
+        // TaskExecutor가 호출될 때 실제로 실행될 작업을 캡처
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(tenantTaskExecutor).execute(any(Runnable.class));
+
+        // When
+        TenantContextHolder.setTenant(tenant1);
+        CompletableFuture<String> future1 = retryService.retryAsync("OP1", "user1", operation1, 3);
+        
+        TenantContextHolder.setTenant(tenant2);
+        CompletableFuture<String> future2 = retryService.retryAsync("OP2", "user2", operation2, 3);
+        
+        CompletableFuture.allOf(future1, future2).get(5, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(future1.get()).isEqualTo("result1");
+        assertThat(future2.get()).isEqualTo("result2");
+        assertThat(capturedTenant1Key.get()).isEqualTo("tenant-1");
+        assertThat(capturedTenant2Key.get()).isEqualTo("tenant-2");
+        verify(tenantTaskExecutor, times(2)).execute(any(Runnable.class));
+    }
+
+    /**
+     * 테스트용 Tenant 객체 생성
+     */
+    private Tenant createTestTenant(String tenantKey, String tenantName) {
+        return Tenant.builder()
+                .tenantKey(tenantKey)
+                .tenantName(tenantName)
+                .description("Test tenant for RetryService testing")
+                .build();
+    }
+}


### PR DESCRIPTION
## 관련 이슈 
closed #34 

## 주요 기능 
- 커스텀 TaskExecutor를 구현하여 Spring의 비동기 처리(@Async) 시 자동으로 해당 빈이 주입되도록 하였습니다.

- TenantContextTaskDecorator를 커스텀하여 비동기 작업 실행 시 현재 테넌트 컨텍스트를 캡처 및 전파하도록 설계했습니다. 이 TaskDecorator 객체는 커스텀 TaskExecutor가 생성 및 관리합니다.

- 서비스 로직에서는 CompletableFuture를 반환하는 비동기 메서드에서 이 커스텀 TaskExecutor를 사용해 테넌트 컨텍스트가 올바르게 전달되도록 했습니다.


## 테스트 

 1. 비동기 작업에서 Tenant Context 전파 테스트: CompletableFuture와 TaskExecutor를 사용한 비동기 작업에서 TenantContextTaskDecorator가 현재 스레드의 Tenant 정보를 새로운 스레드로 올바르게 전파하는지 검증했습니다.

  2. ThreadLocal 특성 반영한 테스트 로직: 다른 스레드에서 실행된 작업의 컨텍스트 정리가 메인 스레드에 영향을 주지 않는다는 ThreadLocal의 특성을 반영하여, 작업 중에는 컨텍스트가 전파되지만 메인 스레드 컨텍스트는 유지되는 것을 확인하는 테스트로 수정했습니다.
  3. TaskExecutor 사용 검증: RetryService와 PerformanceMonitoringService에서 비동기 작업 시 커스텀 TaskExecutor가 실제로 사용되고, 예외 발생 시에도 컨텍스트가 적절히 정리되며, 여러 작업이 동시 실행될 때 각각 독립적인 Tenant Context를 가지는 것을 Mockito를 통해 검증했습니다.

## 추가 구현해야할 사항 
- 리액티브(Webflux) 환경에서 context 전파 로직 
