### PR TITLE
Fix/39

### DIFF
--- a/src/main/java/com/agenticcp/core/domain/monitoring/entity/Metric.java
+++ b/src/main/java/com/agenticcp/core/domain/monitoring/entity/Metric.java
@@ -31,8 +31,8 @@ import java.util.List;
     @Index(name = "idx_metrics_source", columnList = "source"),
     @Index(name = "idx_metrics_status", columnList = "status"),
     @Index(name = "idx_metrics_tenant_id", columnList = "tenant_id"),
-    @Index(name = "idx_metrics_tenant_name", columnList = "tenant_id, metric_name"),
-    @Index(name = "idx_metrics_tenant_time", columnList = "tenant_id, collected_at")
+    @Index(name = "idx_metrics_tenant_name", columnList = "tenant_id,metric_name"),
+    @Index(name = "idx_metrics_tenant_time", columnList = "tenant_id,collected_at")
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/agenticcp/core/domain/monitoring/entity/MetricMetadata.java
+++ b/src/main/java/com/agenticcp/core/domain/monitoring/entity/MetricMetadata.java
@@ -20,8 +20,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "metric_metadata", indexes = {
     @Index(name = "idx_metric_metadata_metric_id", columnList = "metric_id"),
-    @Index(name = "idx_metric_metadata_key", columnList = "key"),
-    @Index(name = "idx_metric_metadata_key_value", columnList = "key, value")
+    @Index(name = "idx_metric_metadata_key", columnList = "`key`")
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -37,13 +36,13 @@ public class MetricMetadata extends BaseEntity {
     /**
      * 메타데이터 키 (예: hostname, region, instance_type)
      */
-    @Column(name = "key", nullable = false, length = 100)
+    @Column(name = "`key`", nullable = false, length = 100)
     private String key;
 
     /**
      * 메타데이터 값
      */
-    @Column(name = "value", columnDefinition = "TEXT")
+    @Column(name = "`value`", columnDefinition = "TEXT")
     private String value;
 
     /**

--- a/src/main/java/com/agenticcp/core/domain/monitoring/entity/MetricTag.java
+++ b/src/main/java/com/agenticcp/core/domain/monitoring/entity/MetricTag.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "metric_tags", indexes = {
     @Index(name = "idx_metric_tags_metric_id", columnList = "metric_id"),
     @Index(name = "idx_metric_tags_name", columnList = "name"),
-    @Index(name = "idx_metric_tags_name_value", columnList = "name, value"),
+    @Index(name = "idx_metric_tags_name_value", columnList = "name,value"),
     @Index(name = "idx_metric_tags_category", columnList = "category")
 })
 @Getter


### PR DESCRIPTION
fix: 모니터링 도메인 Hibernate DDL 구문 오류 수정 (#39)

## 문제
- feature/39 브랜치를 develop에 머지 후 Hibernate DDL 실행 시 구문 오류 발생
- 테이블 생성 및 인덱스 생성 실패

## 해결
1. 복합 인덱스 columnList 공백 제거
   - `tenant_id, metric_name` → `tenant_id,metric_name`
2. SQL 예약어 처리
   - `key`, `value` 컬럼명에 백틱 추가
3. TEXT 컬럼 복합 인덱스 제거

## 변경 파일
- Metric.java
- MetricMetadata.java  
- MetricTag.java