### PR TITLE
feat: Add comprehensive Cursor rules for AgenticCP code standards

### DIFF
--- a/.cursor/rules/audit-logging-pattern.mdc
+++ b/.cursor/rules/audit-logging-pattern.mdc
@@ -1,0 +1,474 @@
+# Audit Logging Pattern (감사 로깅 패턴)
+
+## 개요
+
+감사 로깅은 **보안, 컴플라이언스, 디버깅**을 위해 시스템의 중요한 작업과 이벤트를 기록하는 필수 시스템입니다.
+
+### 주요 목적
+- **보안 감사**: 사용자 행위 추적 및 보안 사고 대응
+- **컴플라이언스**: 규정 준수를 위한 감사 증적 생성
+- **운영 모니터링**: 시스템 사용 현황 및 성능 분석
+- **문제 해결**: 장애 발생 시 원인 분석 및 복구
+
+---
+
+## 필수 규칙
+
+### 1. 클래스 레벨 감사 로깅 (@AuditController)
+
+**언제 사용하는가?**
+- ✅ CRUD 컨트롤러에서 대부분의 메서드가 동일한 리소스 타입을 다룰 때
+- ✅ 관리자 기능에서 모든 작업이 중요하고 감사가 필요할 때
+- ✅ 보안 민감한 컨트롤러에서 모든 접근을 기록해야 할 때
+- ✅ 클래스 내 모든 메서드에 동일한 감사 정책을 적용할 때
+
+**기본 구조:**
+```java
+@RestController
+@RequestMapping("/api/v1/users")
+@AuditController(
+    resourceType = AuditResourceType.USER,
+    defaultSeverity = AuditSeverity.HIGH,
+    defaultIncludeRequestData = true,
+    targetHttpMethods = {"POST", "PUT", "PATCH", "DELETE"},
+    excludeMethods = {"healthCheck", "ping"}
+)
+public class UserController {
+    
+    @PostMapping
+    public ResponseEntity<ApiResponse<UserResponse>> createUser(@Valid @RequestBody UserCreateRequest request) {
+        // 자동으로 감사 로깅 적용됨
+        // - action: "createUser"
+        // - resourceType: USER
+        // - severity: HIGH
+        // - requestData 포함
+    }
+    
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteUser(@PathVariable Long id) {
+        // 자동으로 감사 로깅 적용됨
+        // - action: "deleteUser"
+        // - severity: HIGH (클래스 레벨에서 상속)
+    }
+    
+    @GetMapping("/health")
+    public ResponseEntity<String> healthCheck() {
+        // excludeMethods에 포함되어 감사 로깅 제외됨
+    }
+}
+```
+
+**주요 속성:**
+```java
+@AuditController(
+    resourceType = AuditResourceType.USER,              // 필수: 리소스 타입
+    defaultSeverity = AuditSeverity.HIGH,               // 기본 심각도
+    defaultIncludeRequestData = true,                   // 요청 데이터 포함 여부
+    defaultIncludeResponseData = false,                 // 응답 데이터 포함 여부
+    targetHttpMethods = {"POST", "PUT", "PATCH", "DELETE"},  // 대상 HTTP 메서드
+    excludeMethods = {"healthCheck"}                    // 제외할 메서드명
+)
+```
+
+### 2. 메서드 레벨 감사 로깅 (@AuditRequired)
+
+**언제 사용하는가?**
+- ✅ 특정 메서드만 감사가 필요할 때
+- ✅ 메서드별로 다른 감사 정책이 필요할 때
+- ✅ 클래스가 여러 리소스 타입을 다룰 때 (혼재된 리소스)
+- ✅ 특정 메서드에서만 요청/응답 데이터가 필요할 때
+
+**기본 구조:**
+```java
+@RestController
+@RequestMapping("/api/v1/admin")
+public class AdminController {
+    
+    @PostMapping("/users")
+    @AuditRequired(
+        action = "createUser",
+        resourceType = AuditResourceType.USER,
+        severity = AuditSeverity.HIGH,
+        includeRequestData = true,
+        description = "관리자가 새 사용자를 생성합니다"
+    )
+    public ResponseEntity<ApiResponse<UserResponse>> createUser(@Valid @RequestBody UserCreateRequest request) {
+        // 사용자 생성만 감사 로깅됨
+    }
+    
+    @PostMapping("/tenants")
+    @AuditRequired(
+        action = "createTenant",
+        resourceType = AuditResourceType.TENANT,
+        severity = AuditSeverity.CRITICAL,
+        includeRequestData = true,
+        description = "관리자가 새 테넌트를 생성합니다"
+    )
+    public ResponseEntity<ApiResponse<TenantResponse>> createTenant(@Valid @RequestBody TenantCreateRequest request) {
+        // 테넌트 생성만 감사 로깅됨
+    }
+    
+    @GetMapping("/dashboard")
+    public ResponseEntity<ApiResponse<DashboardResponse>> getDashboard() {
+        // 감사 로깅 없음 (중요도가 낮은 조회)
+    }
+}
+```
+
+**주요 속성:**
+```java
+@AuditRequired(
+    action = "deleteUser",                    // 필수: 액션명 (명확하고 구체적)
+    resourceType = AuditResourceType.USER,    // 필수: 리소스 타입
+    description = "사용자 삭제",              // 선택: 액션 설명
+    includeRequestData = true,                // 선택: 요청 데이터 포함 여부
+    includeResponseData = false,              // 선택: 응답 데이터 포함 여부
+    severity = AuditSeverity.CRITICAL         // 선택: 심각도
+)
+```
+
+### 3. AuditResourceType (리소스 타입)
+
+```java
+public enum AuditResourceType {
+    USER,                // 사용자 관리
+    TENANT,              // 테넌트 관리
+    ROLE,                // 역할 관리
+    PERMISSION,          // 권한 관리
+    SECURITY,            // 보안 설정
+    PLATFORM,            // 플랫폼 설정
+    CLOUD,               // 클라우드 리소스
+    MONITORING,          // 모니터링
+    COST,                // 비용 관리
+    NOTIFICATION,        // 알림
+    INTEGRATION,         // 통합
+    CONFIGURATION        // 설정
+}
+```
+
+### 4. AuditSeverity (심각도)
+
+```java
+public enum AuditSeverity {
+    INFO,         // 일반 정보성 작업 (조회 등)
+    LOW,          // 낮은 중요도 (일반 설정 변경)
+    MEDIUM,       // 중간 중요도 (리소스 생성/수정)
+    HIGH,         // 높은 중요도 (사용자/권한 변경)
+    CRITICAL      // 매우 중요 (보안 설정, 삭제, 관리자 작업)
+}
+```
+
+### 5. 클래스 vs 메서드 레벨 선택 가이드
+
+```java
+// ✅ 클래스 레벨 사용 (좋은 예)
+@AuditController(
+    resourceType = AuditResourceType.USER,
+    defaultSeverity = AuditSeverity.HIGH
+)
+public class UserController {
+    // 모든 메서드가 USER 리소스 타입
+    // 모든 쓰기 작업이 중요
+}
+
+// ✅ 메서드 레벨 사용 (좋은 예)
+public class AdminController {
+    
+    @AuditRequired(resourceType = AuditResourceType.USER, ...)
+    public void createUser() { }
+    
+    @AuditRequired(resourceType = AuditResourceType.TENANT, ...)
+    public void createTenant() { }
+    
+    @AuditRequired(resourceType = AuditResourceType.SECURITY, ...)
+    public void updateSecurityPolicy() { }
+    // 여러 리소스 타입이 혼재
+}
+
+// ✅ 클래스 + 메서드 조합 (메서드가 오버라이드)
+@AuditController(
+    resourceType = AuditResourceType.USER,
+    defaultSeverity = AuditSeverity.MEDIUM
+)
+public class UserController {
+    
+    @PostMapping
+    public void createUser() {
+        // 클래스 레벨 설정 사용: MEDIUM
+    }
+    
+    @DeleteMapping("/{id}")
+    @AuditRequired(
+        action = "deleteUser",
+        resourceType = AuditResourceType.USER,
+        severity = AuditSeverity.CRITICAL  // 메서드 레벨에서 오버라이드
+    )
+    public void deleteUser(@PathVariable Long id) {
+        // 메서드 레벨 설정 사용: CRITICAL
+    }
+}
+```
+
+---
+
+## 실제 사용 예시
+
+### 예시 1: 사용자 관리 (클래스 레벨)
+
+```java
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "User Management", description = "사용자 관리 API")
+@AuditController(
+    resourceType = AuditResourceType.USER,
+    defaultSeverity = AuditSeverity.HIGH,
+    defaultIncludeRequestData = true,
+    targetHttpMethods = {"POST", "PUT", "PATCH", "DELETE"},
+    excludeMethods = {"healthCheck"}
+)
+public class UserController {
+    
+    private final UserService userService;
+    
+    @PostMapping
+    @Operation(summary = "사용자 생성")
+    public ResponseEntity<ApiResponse<UserResponse>> createUser(
+            @Valid @RequestBody UserCreateRequest request) {
+        log.info("[UserController] createUser - username={}", 
+                LogMaskingUtils.mask(request.getUsername(), 2, 2));
+        UserResponse user = userService.createUser(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(user, "사용자 생성에 성공했습니다."));
+        // 감사 로그: action=createUser, resourceType=USER, severity=HIGH, requestData 포함
+    }
+    
+    @PutMapping("/{id}")
+    @Operation(summary = "사용자 수정")
+    public ResponseEntity<ApiResponse<UserResponse>> updateUser(
+            @PathVariable Long id,
+            @Valid @RequestBody UserUpdateRequest request) {
+        log.info("[UserController] updateUser - id={}", id);
+        UserResponse user = userService.updateUser(id, request);
+        return ResponseEntity.ok(ApiResponse.success(user));
+        // 감사 로그: action=updateUser, resourceType=USER, severity=HIGH
+    }
+    
+    @DeleteMapping("/{id}")
+    @AuditRequired(
+        action = "deleteUser",
+        resourceType = AuditResourceType.USER,
+        severity = AuditSeverity.CRITICAL,  // 메서드 레벨에서 CRITICAL로 오버라이드
+        includeRequestData = true,
+        description = "사용자 영구 삭제"
+    )
+    @Operation(summary = "사용자 삭제")
+    public ResponseEntity<ApiResponse<Void>> deleteUser(@PathVariable Long id) {
+        log.info("[UserController] deleteUser - id={}", id);
+        userService.deleteUser(id);
+        return ResponseEntity.noContent().build();
+        // 감사 로그: severity=CRITICAL (오버라이드됨)
+    }
+    
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<UserResponse>>> getUsers() {
+        // GET 메서드는 targetHttpMethods에 없으므로 감사 로깅 안 됨
+        return ResponseEntity.ok(ApiResponse.success(userService.getUsers()));
+    }
+}
+```
+
+### 예시 2: 보안 설정 (메서드 레벨 - 높은 심각도)
+
+```java
+@RestController
+@RequestMapping("/api/v1/security")
+@RequiredArgsConstructor
+@Slf4j
+public class SecurityController {
+    
+    private final SecurityService securityService;
+    
+    @PostMapping("/policies")
+    @AuditRequired(
+        action = "createSecurityPolicy",
+        resourceType = AuditResourceType.SECURITY,
+        severity = AuditSeverity.CRITICAL,
+        includeRequestData = true,
+        includeResponseData = true,
+        description = "새로운 보안 정책 생성"
+    )
+    public ResponseEntity<ApiResponse<SecurityPolicyResponse>> createPolicy(
+            @Valid @RequestBody SecurityPolicyCreateRequest request) {
+        log.info("[SecurityController] createPolicy");
+        SecurityPolicyResponse policy = securityService.createPolicy(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(policy));
+    }
+    
+    @PutMapping("/mfa")
+    @AuditRequired(
+        action = "updateMfaSettings",
+        resourceType = AuditResourceType.SECURITY,
+        severity = AuditSeverity.CRITICAL,
+        includeRequestData = true,
+        description = "다중 인증(MFA) 설정 변경"
+    )
+    public ResponseEntity<ApiResponse<MfaSettingsResponse>> updateMfaSettings(
+            @Valid @RequestBody MfaSettingsRequest request) {
+        log.info("[SecurityController] updateMfaSettings");
+        MfaSettingsResponse settings = securityService.updateMfaSettings(request);
+        return ResponseEntity.ok(ApiResponse.success(settings));
+    }
+}
+```
+
+### 예시 3: 혼재된 리소스 타입 (메서드 레벨)
+
+```java
+@RestController
+@RequestMapping("/api/v1/admin")
+@RequiredArgsConstructor
+@Slf4j
+public class AdminController {
+    
+    private final UserService userService;
+    private final TenantService tenantService;
+    private final PlatformService platformService;
+    
+    @PostMapping("/users")
+    @AuditRequired(
+        action = "adminCreateUser",
+        resourceType = AuditResourceType.USER,
+        severity = AuditSeverity.HIGH,
+        includeRequestData = true,
+        description = "관리자가 사용자 생성"
+    )
+    public ResponseEntity<ApiResponse<UserResponse>> createUser(
+            @Valid @RequestBody UserCreateRequest request) {
+        UserResponse user = userService.createUser(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(user));
+    }
+    
+    @PostMapping("/tenants")
+    @AuditRequired(
+        action = "adminCreateTenant",
+        resourceType = AuditResourceType.TENANT,
+        severity = AuditSeverity.CRITICAL,
+        includeRequestData = true,
+        description = "관리자가 테넌트 생성"
+    )
+    public ResponseEntity<ApiResponse<TenantResponse>> createTenant(
+            @Valid @RequestBody TenantCreateRequest request) {
+        TenantResponse tenant = tenantService.createTenant(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(tenant));
+    }
+    
+    @PutMapping("/platform/config")
+    @AuditRequired(
+        action = "updatePlatformConfig",
+        resourceType = AuditResourceType.PLATFORM,
+        severity = AuditSeverity.CRITICAL,
+        includeRequestData = true,
+        includeResponseData = true,
+        description = "플랫폼 전역 설정 변경"
+    )
+    public ResponseEntity<ApiResponse<PlatformConfigResponse>> updatePlatformConfig(
+            @Valid @RequestBody PlatformConfigRequest request) {
+        PlatformConfigResponse config = platformService.updateConfig(request);
+        return ResponseEntity.ok(ApiResponse.success(config));
+    }
+}
+```
+
+---
+
+## 감사 로그 출력 형식
+
+감사 로그는 JSON 형식으로 별도의 `audit-{profile}.log` 파일에 기록됩니다.
+
+```json
+{
+  "timestamp": "2024-01-15T10:30:45.123Z",
+  "eventId": "audit-1234567890",
+  "action": "deleteUser",
+  "resourceType": "USER",
+  "resourceId": "123",
+  "severity": "CRITICAL",
+  "actor": {
+    "userId": 1,
+    "username": "admin@example.com",
+    "role": "ADMIN",
+    "tenantId": 1
+  },
+  "result": "SUCCESS",
+  "requestData": {
+    "userId": 123,
+    "reason": "Policy violation"
+  },
+  "metadata": {
+    "ipAddress": "192.168.1.100",
+    "userAgent": "Mozilla/5.0...",
+    "duration": 125,
+    "httpMethod": "DELETE",
+    "endpoint": "/api/v1/users/123"
+  }
+}
+```
+
+---
+
+## 애플리케이션 로깅 vs 감사 로깅
+
+### 애플리케이션 로깅 (Slf4j)
+```java
+// 기술적 디버깅, 성능 모니터링용
+log.info("[UserService] createUser - username={}", username);
+log.debug("[UserService] validation passed");
+log.error("[UserService] database error", exception);
+```
+
+### 감사 로깅 (@AuditRequired / @AuditController)
+```java
+// 보안, 컴플라이언스, 감사 증적용
+@AuditRequired(
+    action = "deleteUser",
+    resourceType = AuditResourceType.USER,
+    severity = AuditSeverity.CRITICAL
+)
+public void deleteUser(Long userId) {
+    // 누가, 언제, 무엇을, 어떻게 했는지 기록
+}
+```
+
+**차이점:**
+- **애플리케이션 로그**: 개발자를 위한 기술 정보, 디버깅
+- **감사 로그**: 감사자/컴플라이언스를 위한 비즈니스 이벤트, 보안 추적
+
+---
+
+## 체크리스트
+
+### 감사 로깅을 적용해야 하는 경우
+- [ ] 사용자 생성/수정/삭제
+- [ ] 권한 변경 (역할, 권한 할당)
+- [ ] 보안 설정 변경 (MFA, 정책, 암호화)
+- [ ] 테넌트 관리 작업
+- [ ] 민감한 데이터 접근 (개인정보, 암호화된 설정)
+- [ ] 플랫폼 전역 설정 변경
+- [ ] 관리자 작업
+
+### 감사 로깅을 적용하지 않아도 되는 경우
+- [ ] 단순 조회 (목록, 상세)
+- [ ] 헬스 체크, 상태 확인
+- [ ] 공개 API (인증 불필요)
+- [ ] 성능에 민감한 고빈도 API
+
+### 구현 시 확인사항
+- [ ] 적절한 `AuditResourceType` 선택
+- [ ] 적절한 `AuditSeverity` 설정
+- [ ] `action` 명칭이 명확하고 구체적
+- [ ] 민감 데이터 포함 여부 결정 (`includeRequestData`, `includeResponseData`)
+- [ ] 클래스 vs 메서드 레벨 선택이 적절한지
+- [ ] `excludeMethods` 설정 확인

--- a/.cursor/rules/businessexception-pattern.mdc
+++ b/.cursor/rules/businessexception-pattern.mdc
@@ -1,0 +1,670 @@
+---
+description: 비즈니스 예외처리 방법에 대한 룰
+alwaysApply: false
+---
+# BusinessException Pattern (비즈니스 예외 패턴)
+
+## 기본 구조
+
+### BaseErrorCode 인터페이스
+```java
+public interface BaseErrorCode {
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+}
+```
+
+### ErrorCategory (에러 코드 카테고리)
+```java
+public enum ErrorCategory {
+    COMMON("COMMON_"),          // 0-999: 공통 에러
+    AUTH("AUTH_"),              // 1000-1999: 인증/인가
+    USER("USER_"),              // 2000-2999: 사용자
+    TENANT("TENANT_"),          // 3000-3999: 테넌트
+    CLOUD("CLOUD_"),            // 4000-4999: 클라우드
+    SECURITY("SECURITY_"),      // 5000-5999: 보안
+    PLATFORM("PLATFORM_"),      // 6000-6999: 플랫폼
+    COST("COST_"),              // 7000-7999: 비용
+    MONITORING("MONITORING_");  // 8000-8999: 모니터링
+    
+    private final String prefix;
+    
+    ErrorCategory(String prefix) {
+        this.prefix = prefix;
+    }
+    
+    public String generate(int codeNumber) {
+        return prefix + codeNumber;
+    }
+}
+```
+
+### 도메인별 ErrorCode 구현
+```java
+/**
+ * 사용자 도메인 에러 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements BaseErrorCode {
+    
+    // 2000-2999: 사용자 도메인
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 2001, "사용자를 찾을 수 없습니다."),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, 2002, "이미 사용 중인 사용자명입니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, 2003, "이미 사용 중인 이메일입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, 2004, "비밀번호가 올바르지 않습니다."),
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, 2005, "이미 삭제된 사용자입니다."),
+    USER_ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, 2006, "계정이 잠겨있습니다."),
+    USER_SUSPENDED(HttpStatus.FORBIDDEN, 2007, "계정이 정지되었습니다.");
+    
+    private final HttpStatus httpStatus;
+    private final int codeNumber;
+    private final String message;
+    
+    @Override
+    public String getCode() {
+        return ErrorCategory.USER.generate(codeNumber);  // "USER_2001"
+    }
+}
+```
+
+## 필수 규칙
+
+### 1. 예외 클래스
+
+#### BusinessException (기본 비즈니스 예외)
+```java
+public class BusinessException extends RuntimeException {
+    private final BaseErrorCode errorCode;
+    
+    public BusinessException(BaseErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+    
+    public BusinessException(BaseErrorCode errorCode, String customMessage) {
+        super(customMessage);
+        this.errorCode = errorCode;
+    }
+}
+```
+
+**사용 시점**:
+- 비즈니스 규칙 위반
+- 사용자 입력 오류
+- 예측 가능한 예외 상황
+
+```java
+// 사용 예시
+if (userRepository.existsByUsername(username)) {
+    throw new BusinessException(UserErrorCode.DUPLICATE_USERNAME);
+}
+```
+
+#### ResourceNotFoundException (리소스 없음 - 404)
+```java
+public class ResourceNotFoundException extends BusinessException {
+    public ResourceNotFoundException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}
+```
+
+**사용 시점**:
+- 데이터베이스 조회 결과 없음
+- 존재하지 않는 리소스 접근
+
+```java
+// 사용 예시
+User user = userRepository.findById(id)
+        .orElseThrow(() -> new ResourceNotFoundException(UserErrorCode.USER_NOT_FOUND));
+```
+
+#### AuthorizationException (권한 없음 - 403)
+```java
+public class AuthorizationException extends BusinessException {
+    
+    // 기본 생성자
+    public AuthorizationException() {
+        super(AuthErrorCode.PERMISSION_DENIED);
+    }
+    
+    // 리소스별 권한 확인
+    public AuthorizationException(Long userId, String resource, String action) {
+        super(AuthErrorCode.PERMISSION_DENIED, 
+              String.format("User %d does not have permission to %s %s", userId, action, resource));
+    }
+    
+    // 역할 기반 권한 확인
+    public AuthorizationException(Long userId, String requiredRole) {
+        super(AuthErrorCode.INSUFFICIENT_ROLE,
+              String.format("User %d requires %s role", userId, requiredRole));
+    }
+}
+```
+
+**사용 시점**:
+- 인증은 되었지만 권한 부족
+- 리소스 소유권 확인 실패
+- 역할 기반 접근 제어 실패
+
+```java
+// 사용 예시
+if (!post.getOwnerId().equals(userId)) {
+    throw new AuthorizationException(userId, "Post", "delete");
+}
+
+if (!hasAdminRole(userId)) {
+    throw new AuthorizationException(userId, "ADMIN");
+}
+```
+
+### 2. 에러 코드 번호 규칙
+
+**도메인별 번호 범위**:
+- `COMMON`: 0-999 (HTTP 상태 코드 사용)
+- `AUTH`: 1000-1999
+- `USER`: 2000-2999
+- `TENANT`: 3000-3999
+- `CLOUD`: 4000-4999
+- `SECURITY`: 5000-5999
+- `PLATFORM`: 6000-6999
+- `COST`: 7000-7999
+- `MONITORING`: 8000-8999
+
+**새 도메인 추가 시**:
+1. `ErrorCategory`에 새 카테고리 추가
+2. 번호 범위 할당 (1000 단위)
+3. 도메인별 `XxxErrorCode` enum 생성
+4. `BaseErrorCode` 인터페이스 구현
+
+```java
+// 새 도메인 예시: INTEGRATION (9000-9999)
+public enum IntegrationErrorCode implements BaseErrorCode {
+    INTEGRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 9001, "외부 시스템 연동에 실패했습니다."),
+    API_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, 9002, "API 호출 시간이 초과되었습니다.");
+    
+    private final HttpStatus httpStatus;
+    private final int codeNumber;
+    private final String message;
+    
+    @Override
+    public String getCode() {
+        return ErrorCategory.INTEGRATION.generate(codeNumber);  // "INTEGRATION_9001"
+    }
+}
+```
+
+### 3. GlobalExceptionHandler
+
+```java
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+    
+    // BusinessException 처리
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        log.error("[GlobalExceptionHandler] BusinessException: code={}, message={}", 
+                  e.getErrorCode().getCode(), e.getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(ApiResponse.error(e.getErrorCode(), e.getMessage()));
+    }
+    
+    // Validation 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        List<FieldErrorResponse> fieldErrors = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> new FieldErrorResponse(
+                        error.getField(),
+                        error.getRejectedValue(),
+                        error.getDefaultMessage()
+                ))
+                .collect(Collectors.toList());
+        
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(CommonErrorCode.FIELD_VALIDATION_ERROR, fieldErrors));
+    }
+    
+    // 예상치 못한 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleGenericException(Exception e) {
+        log.error("[GlobalExceptionHandler] Unexpected exception", e);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(CommonErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}
+```
+
+## 전체 예시
+
+### UserErrorCode
+```java
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements BaseErrorCode {
+    
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 2001, "사용자를 찾을 수 없습니다."),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, 2002, "이미 사용 중인 사용자명입니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, 2003, "이미 사용 중인 이메일입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, 2004, "비밀번호가 올바르지 않습니다."),
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, 2005, "이미 삭제된 사용자입니다."),
+    USER_ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, 2006, "계정이 잠겨있습니다."),
+    USER_SUSPENDED(HttpStatus.FORBIDDEN, 2007, "계정이 정지되었습니다.");
+    
+    private final HttpStatus httpStatus;
+    private final int codeNumber;
+    private final String message;
+    
+    @Override
+    public String getCode() {
+        return ErrorCategory.USER.generate(codeNumber);
+    }
+}
+```
+
+### TenantErrorCode
+```java
+@Getter
+@RequiredArgsConstructor
+public enum TenantErrorCode implements BaseErrorCode {
+    
+    TENANT_NOT_FOUND(HttpStatus.NOT_FOUND, 3001, "테넌트를 찾을 수 없습니다."),
+    TENANT_QUOTA_EXCEEDED(HttpStatus.BAD_REQUEST, 3002, "테넌트 할당량을 초과했습니다."),
+    TENANT_SUSPENDED(HttpStatus.FORBIDDEN, 3003, "일시정지된 테넌트입니다."),
+    INVALID_TENANT_KEY(HttpStatus.BAD_REQUEST, 3004, "유효하지 않은 테넌트 키입니다.");
+    
+    private final HttpStatus httpStatus;
+    private final int codeNumber;
+    private final String message;
+    
+    @Override
+    public String getCode() {
+        return ErrorCategory.TENANT.generate(codeNumber);
+    }
+}
+```
+
+### Service에서 예외 사용
+```java
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+    
+    private final UserRepository userRepository;
+    
+    public User getUserByIdOrThrow(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(UserErrorCode.USER_NOT_FOUND));
+    }
+    
+    @Transactional
+    public User createUser(UserCreateRequest request) {
+        // 중복 검증
+        if (userRepository.existsByUsername(request.getUsername())) {
+            throw new BusinessException(UserErrorCode.DUPLICATE_USERNAME);
+        }
+        
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new BusinessException(UserErrorCode.DUPLICATE_EMAIL);
+        }
+        
+        // 사용자 생성 로직
+        User user = buildUser(request);
+        return userRepository.save(user);
+    }
+    
+    @Transactional
+    public void deletePost(Long userId, Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new ResourceNotFoundException(PostErrorCode.POST_NOT_FOUND));
+        
+        // 권한 검증
+        if (!post.getOwnerId().equals(userId)) {
+            throw new AuthorizationException(userId, "Post", "delete");
+        }
+        
+        postRepository.delete(post);
+    }
+}
+```
+# BusinessException Pattern (비즈니스 예외 패턴)
+
+## 기본 구조
+
+### BaseErrorCode 인터페이스
+```java
+public interface BaseErrorCode {
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+}
+```
+
+### ErrorCategory (에러 코드 카테고리)
+```java
+public enum ErrorCategory {
+    COMMON("COMMON_"),          // 0-999: 공통 에러
+    AUTH("AUTH_"),              // 1000-1999: 인증/인가
+    USER("USER_"),              // 2000-2999: 사용자
+    TENANT("TENANT_"),          // 3000-3999: 테넌트
+    CLOUD("CLOUD_"),            // 4000-4999: 클라우드
+    SECURITY("SECURITY_"),      // 5000-5999: 보안
+    PLATFORM("PLATFORM_"),      // 6000-6999: 플랫폼
+    COST("COST_"),              // 7000-7999: 비용
+    MONITORING("MONITORING_");  // 8000-8999: 모니터링
+    
+    private final String prefix;
+    
+    ErrorCategory(String prefix) {
+        this.prefix = prefix;
+    }
+    
+    public String generate(int codeNumber) {
+        return prefix + codeNumber;
+    }
+}
+```
+
+### 도메인별 ErrorCode 구현
+```java
+/**
+ * 사용자 도메인 에러 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements BaseErrorCode {
+    
+    // 2000-2999: 사용자 도메인
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 2001, "사용자를 찾을 수 없습니다."),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, 2002, "이미 사용 중인 사용자명입니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, 2003, "이미 사용 중인 이메일입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, 2004, "비밀번호가 올바르지 않습니다."),
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, 2005, "이미 삭제된 사용자입니다."),
+    USER_ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, 2006, "계정이 잠겨있습니다."),
+    USER_SUSPENDED(HttpStatus.FORBIDDEN, 2007, "계정이 정지되었습니다.");
+    
+    private final HttpStatus httpStatus;
+    private final int codeNumber;
+    private final String message;
+    
+    @Override
+    public String getCode() {
+        return ErrorCategory.USER.generate(codeNumber);  // "USER_2001"
+    }
+}
+```
+
+## 필수 규칙
+
+### 1. 예외 클래스
+
+#### BusinessException (기본 비즈니스 예외)
+```java
+public class BusinessException extends RuntimeException {
+    private final BaseErrorCode errorCode;
+    
+    public BusinessException(BaseErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+    
+    public BusinessException(BaseErrorCode errorCode, String customMessage) {
+        super(customMessage);
+        this.errorCode = errorCode;
+    }
+}
+```
+
+**사용 시점**:
+- 비즈니스 규칙 위반
+- 사용자 입력 오류
+- 예측 가능한 예외 상황
+
+```java
+// 사용 예시
+if (userRepository.existsByUsername(username)) {
+    throw new BusinessException(UserErrorCode.DUPLICATE_USERNAME);
+}
+```
+
+#### ResourceNotFoundException (리소스 없음 - 404)
+```java
+public class ResourceNotFoundException extends BusinessException {
+    public ResourceNotFoundException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}
+```
+
+**사용 시점**:
+- 데이터베이스 조회 결과 없음
+- 존재하지 않는 리소스 접근
+
+```java
+// 사용 예시
+User user = userRepository.findById(id)
+        .orElseThrow(() -> new ResourceNotFoundException(UserErrorCode.USER_NOT_FOUND));
+```
+
+#### AuthorizationException (권한 없음 - 403)
+```java
+public class AuthorizationException extends BusinessException {
+    
+    // 기본 생성자
+    public AuthorizationException() {
+        super(AuthErrorCode.PERMISSION_DENIED);
+    }
+    
+    // 리소스별 권한 확인
+    public AuthorizationException(Long userId, String resource, String action) {
+        super(AuthErrorCode.PERMISSION_DENIED, 
+              String.format("User %d does not have permission to %s %s", userId, action, resource));
+    }
+    
+    // 역할 기반 권한 확인
+    public AuthorizationException(Long userId, String requiredRole) {
+        super(AuthErrorCode.INSUFFICIENT_ROLE,
+              String.format("User %d requires %s role", userId, requiredRole));
+    }
+}
+```
+
+**사용 시점**:
+- 인증은 되었지만 권한 부족
+- 리소스 소유권 확인 실패
+- 역할 기반 접근 제어 실패
+
+```java
+// 사용 예시
+if (!post.getOwnerId().equals(userId)) {
+    throw new AuthorizationException(userId, "Post", "delete");
+}
+
+if (!hasAdminRole(userId)) {
+    throw new AuthorizationException(userId, "ADMIN");
+}
+```
+
+### 2. 에러 코드 번호 규칙
+
+**도메인별 번호 범위**:
+- `COMMON`: 0-999 (HTTP 상태 코드 사용)
+- `AUTH`: 1000-1999
+- `USER`: 2000-2999
+- `TENANT`: 3000-3999
+- `CLOUD`: 4000-4999
+- `SECURITY`: 5000-5999
+- `PLATFORM`: 6000-6999
+- `COST`: 7000-7999
+- `MONITORING`: 8000-8999
+
+**새 도메인 추가 시**:
+1. `ErrorCategory`에 새 카테고리 추가
+2. 번호 범위 할당 (1000 단위)
+3. 도메인별 `XxxErrorCode` enum 생성
+4. `BaseErrorCode` 인터페이스 구현
+
+```java
+// 새 도메인 예시: INTEGRATION (9000-9999)
+public enum IntegrationErrorCode implements BaseErrorCode {
+    INTEGRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 9001, "외부 시스템 연동에 실패했습니다."),
+    API_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, 9002, "API 호출 시간이 초과되었습니다.");
+    
+    private final HttpStatus httpStatus;
+    private final int codeNumber;
+    private final String message;
+    
+    @Override
+    public String getCode() {
+        return ErrorCategory.INTEGRATION.generate(codeNumber);  // "INTEGRATION_9001"
+    }
+}
+```
+
+### 3. GlobalExceptionHandler
+
+```java
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+    
+    // BusinessException 처리
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        log.error("[GlobalExceptionHandler] BusinessException: code={}, message={}", 
+                  e.getErrorCode().getCode(), e.getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(ApiResponse.error(e.getErrorCode(), e.getMessage()));
+    }
+    
+    // Validation 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        List<FieldErrorResponse> fieldErrors = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> new FieldErrorResponse(
+                        error.getField(),
+                        error.getRejectedValue(),
+                        error.getDefaultMessage()
+                ))
+                .collect(Collectors.toList());
+        
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(CommonErrorCode.FIELD_VALIDATION_ERROR, fieldErrors));
+    }
+    
+    // 예상치 못한 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleGenericException(Exception e) {
+        log.error("[GlobalExceptionHandler] Unexpected exception", e);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(CommonErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}
+```
+
+## 전체 예시
+
+### UserErrorCode
+```java
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements BaseErrorCode {
+    
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 2001, "사용자를 찾을 수 없습니다."),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, 2002, "이미 사용 중인 사용자명입니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, 2003, "이미 사용 중인 이메일입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, 2004, "비밀번호가 올바르지 않습니다."),
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, 2005, "이미 삭제된 사용자입니다."),
+    USER_ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, 2006, "계정이 잠겨있습니다."),
+    USER_SUSPENDED(HttpStatus.FORBIDDEN, 2007, "계정이 정지되었습니다.");
+    
+    private final HttpStatus httpStatus;
+    private final int codeNumber;
+    private final String message;
+    
+    @Override
+    public String getCode() {
+        return ErrorCategory.USER.generate(codeNumber);
+    }
+}
+```
+
+### TenantErrorCode
+```java
+@Getter
+@RequiredArgsConstructor
+public enum TenantErrorCode implements BaseErrorCode {
+    
+    TENANT_NOT_FOUND(HttpStatus.NOT_FOUND, 3001, "테넌트를 찾을 수 없습니다."),
+    TENANT_QUOTA_EXCEEDED(HttpStatus.BAD_REQUEST, 3002, "테넌트 할당량을 초과했습니다."),
+    TENANT_SUSPENDED(HttpStatus.FORBIDDEN, 3003, "일시정지된 테넌트입니다."),
+    INVALID_TENANT_KEY(HttpStatus.BAD_REQUEST, 3004, "유효하지 않은 테넌트 키입니다.");
+    
+    private final HttpStatus httpStatus;
+    private final int codeNumber;
+    private final String message;
+    
+    @Override
+    public String getCode() {
+        return ErrorCategory.TENANT.generate(codeNumber);
+    }
+}
+```
+
+### Service에서 예외 사용
+```java
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+    
+    private final UserRepository userRepository;
+    
+    public User getUserByIdOrThrow(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(UserErrorCode.USER_NOT_FOUND));
+    }
+    
+    @Transactional
+    public User createUser(UserCreateRequest request) {
+        // 중복 검증
+        if (userRepository.existsByUsername(request.getUsername())) {
+            throw new BusinessException(UserErrorCode.DUPLICATE_USERNAME);
+        }
+        
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new BusinessException(UserErrorCode.DUPLICATE_EMAIL);
+        }
+        
+        // 사용자 생성 로직
+        User user = buildUser(request);
+        return userRepository.save(user);
+    }
+    
+    @Transactional
+    public void deletePost(Long userId, Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new ResourceNotFoundException(PostErrorCode.POST_NOT_FOUND));
+        
+        // 권한 검증
+        if (!post.getOwnerId().equals(userId)) {
+            throw new AuthorizationException(userId, "Post", "delete");
+        }
+        
+        postRepository.delete(post);
+    }
+}
+```

--- a/.cursor/rules/controller-pattern.mdc
+++ b/.cursor/rules/controller-pattern.mdc
@@ -1,0 +1,231 @@
+# Controller Pattern (컨트롤러 패턴)
+
+## 기본 구조
+
+```java
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/resource-name")
+@RequiredArgsConstructor
+@Tag(name = "Resource", description = "리소스 관련 API")
+public class ResourceController {
+    
+    private final ResourceService resourceService;
+    
+    @GetMapping("/{id}")
+    @Operation(summary = "리소스 조회", description = "ID로 리소스를 조회합니다.")
+    public ResponseEntity<ApiResponse<ResourceResponse>> getResource(@PathVariable Long id) {
+        log.info("[ResourceController] getResource - id={}", id);
+        ResourceResponse response = resourceService.getResourceById(id);
+        return ResponseEntity.ok(ApiResponse.success(response, "리소스 조회에 성공했습니다."));
+    }
+}
+```
+
+## 필수 규칙
+
+### 1. 클래스 레벨 어노테이션
+- `@Slf4j`: 로깅을 위해 필수
+- `@RestController`: REST API 컨트롤러 선언
+- `@RequestMapping("/api/v1/...")`: API 버전과 리소스 경로 명시
+- `@RequiredArgsConstructor`: 생성자 주입 (필드 주입 금지)
+- `@Tag`: Swagger/OpenAPI 문서화
+
+### 2. URL 설계 원칙
+- **리소스 중심 설계**: 명사 사용, 복수형 권장
+  - ✅ `/api/v1/users`, `/api/v1/tenants`
+  - ❌ `/api/v1/getUser`, `/api/v1/createUser`
+- **계층 구조**: 하위 리소스는 상위 리소스 경로 포함
+  - ✅ `/api/v1/users/{userId}/profiles`
+  - ❌ `/api/v1/userProfiles?userId={userId}`
+- **버전 관리**: URL에 버전 명시 (`/api/v1`, `/api/v2`)
+
+### 3. HTTP 메서드 사용
+- `@GetMapping`: 조회 (목록/단건) - 200 OK
+- `@PostMapping`: 생성 - 201 CREATED
+- `@PutMapping`: 전체 수정 - 200 OK
+- `@PatchMapping`: 부분 수정 - 200 OK
+- `@DeleteMapping`: 삭제 - 204 NO CONTENT
+
+### 4. 응답 형식
+- **성공**: `ApiResponse.success(data, message)`
+- **실패**: `ApiResponse.error(errorCode, message)` (GlobalExceptionHandler에서 처리)
+- 모든 응답은 `ResponseEntity<ApiResponse<T>>` 형태 반환
+
+### 5. 요청 검증
+```java
+@PostMapping
+public ResponseEntity<ApiResponse<ResourceResponse>> createResource(
+        @Valid @RequestBody ResourceCreateRequest request) {
+    // @Valid로 자동 검증, MethodArgumentNotValidException 발생 시 GlobalExceptionHandler가 처리
+}
+```
+
+### 6. Swagger/OpenAPI 문서화
+```java
+// 클래스 레벨: @Tag
+@Tag(name = "User Management", description = "사용자 관리 API")
+public class UserController {
+    
+    // 메서드 레벨: @Operation, @Parameter, @ApiResponse
+    @GetMapping("/{id}")
+    @Operation(
+        summary = "사용자 조회",
+        description = "사용자 ID로 사용자 정보를 조회합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    public ResponseEntity<ApiResponse<UserResponse>> getUser(
+            @Parameter(description = "사용자 ID", required = true, example = "1")
+            @PathVariable @Positive Long id) {
+        // ...
+    }
+    
+    @PostMapping
+    @Operation(
+        summary = "사용자 생성",
+        description = "새로운 사용자를 등록합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "생성 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+        @ApiResponse(responseCode = "409", description = "중복된 사용자명 또는 이메일")
+    })
+    public ResponseEntity<ApiResponse<UserResponse>> createUser(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                description = "사용자 생성 요청",
+                required = true
+            )
+            @Valid @RequestBody UserCreateRequest request) {
+        // ...
+    }
+}
+```
+
+### 7. 로깅 규칙
+- **진입**: `log.info("[ControllerName] methodName - param={}", param);`
+- **민감정보**: `LogMaskingUtils` 사용하여 마스킹
+  - 이메일, 사용자명, 비밀번호, 토큰 등
+- **에러**: `log.error("[ControllerName] methodName - error", e);`
+
+### 8. 예외 처리
+- Controller에서 직접 try-catch 하지 않음 (특수한 경우 제외)
+- Service Layer에서 발생한 예외는 GlobalExceptionHandler가 처리
+- 비즈니스 예외는 `BusinessException` 계층 사용
+
+## 전체 예시
+
+```java
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+@Tag(name = "User Management", description = "사용자 관리 API")
+public class UserController {
+    
+    private final UserService userService;
+    
+    @GetMapping
+    @Operation(
+        summary = "사용자 목록 조회",
+        description = "페이징을 지원하는 사용자 목록을 조회합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    public ResponseEntity<ApiResponse<List<UserResponse>>> getUsers(
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "20")
+            @RequestParam(defaultValue = "20") int size) {
+        log.info("[UserController] getUsers - page={}, size={}", page, size);
+        List<UserResponse> users = userService.getUsers(page, size);
+        return ResponseEntity.ok(ApiResponse.success(users));
+    }
+    
+    @GetMapping("/{id}")
+    @Operation(
+        summary = "사용자 조회",
+        description = "사용자 ID로 특정 사용자 정보를 조회합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
+                     content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    public ResponseEntity<ApiResponse<UserResponse>> getUser(
+            @Parameter(description = "사용자 ID", required = true, example = "1")
+            @PathVariable @Positive Long id) {
+        log.info("[UserController] getUser - id={}", id);
+        UserResponse user = userService.getUserById(id);
+        return ResponseEntity.ok(ApiResponse.success(user));
+    }
+    
+    @PostMapping
+    @Operation(
+        summary = "사용자 생성",
+        description = "새로운 사용자를 등록하고 JWT 토큰을 발급합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "생성 성공",
+                     content = @Content(schema = @Schema(implementation = UserResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+        @ApiResponse(responseCode = "409", description = "중복된 사용자명 또는 이메일")
+    })
+    public ResponseEntity<ApiResponse<UserResponse>> createUser(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                description = "사용자 생성 요청 정보",
+                required = true,
+                content = @Content(schema = @Schema(implementation = UserCreateRequest.class))
+            )
+            @Valid @RequestBody UserCreateRequest request) {
+        log.info("[UserController] createUser - username={}", 
+                LogMaskingUtils.mask(request.getUsername(), 2, 2));
+        UserResponse user = userService.createUser(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(user, "사용자 생성에 성공했습니다."));
+    }
+    
+    @PutMapping("/{id}")
+    @Operation(
+        summary = "사용자 수정",
+        description = "기존 사용자의 정보를 수정합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "수정 성공"),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터")
+    })
+    public ResponseEntity<ApiResponse<UserResponse>> updateUser(
+            @Parameter(description = "사용자 ID", required = true, example = "1")
+            @PathVariable @Positive Long id,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                description = "사용자 수정 요청 정보",
+                required = true
+            )
+            @Valid @RequestBody UserUpdateRequest request) {
+        log.info("[UserController] updateUser - id={}", id);
+        UserResponse user = userService.updateUser(id, request);
+        return ResponseEntity.ok(ApiResponse.success(user, "사용자 수정에 성공했습니다."));
+    }
+    
+    @DeleteMapping("/{id}")
+    @Operation(
+        summary = "사용자 삭제",
+        description = "사용자를 소프트 삭제합니다 (isDeleted=true)."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "삭제 성공"),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    public ResponseEntity<ApiResponse<Void>> deleteUser(
+            @Parameter(description = "사용자 ID", required = true, example = "1")
+            @PathVariable @Positive Long id) {
+        log.info("[UserController] deleteUser - id={}", id);
+        userService.deleteUser(id);
+        return ResponseEntity.noContent().build();
+    }
+}
+```

--- a/.cursor/rules/crypto-service-pattern.mdc
+++ b/.cursor/rules/crypto-service-pattern.mdc
@@ -1,0 +1,513 @@
+# Crypto Service Pattern (암호화 서비스 패턴)
+
+## 개요
+
+민감한 정보(개인정보, 비밀번호, API 키 등)를 안전하게 암호화/복호화하기 위한 `CipherService` 사용 패턴입니다.
+
+### 주요 목적
+- **개인정보 보호**: GDPR, 개인정보보호법 준수
+- **보안 강화**: 민감 데이터의 안전한 저장 및 전송
+- **키 관리**: 암호화 키의 안전한 관리 및 회전
+- **컴플라이언스**: 보안 감사 및 규정 준수
+
+---
+
+## 필수 규칙
+
+### 1. CipherService 사용
+
+#### 의존성 주입
+```java
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PlatformConfigService {
+    
+    private final CipherService cipherService;  // 생성자 주입
+    
+    // ...
+}
+```
+
+#### 암호화
+```java
+// 평문을 암호화하여 저장
+@Transactional
+public PlatformConfig createConfig(PlatformConfigRequest request) {
+    log.info("[PlatformConfigService] createConfig - key={}", request.getKey());
+    
+    // 민감 데이터 암호화
+    String encryptedValue = cipherService.encrypt(request.getValue());
+    
+    PlatformConfig config = PlatformConfig.builder()
+            .key(request.getKey())
+            .value(encryptedValue)
+            .type(ConfigType.ENCRYPTED)
+            .build();
+    
+    return configRepository.save(config);
+}
+```
+
+#### 복호화
+```java
+// 암호화된 데이터를 복호화하여 반환
+@Transactional(readOnly = true)
+public String getDecryptedValue(String key) {
+    log.info("[PlatformConfigService] getDecryptedValue - key={}", key);
+    
+    PlatformConfig config = configRepository.findByKey(key)
+            .orElseThrow(() -> new ResourceNotFoundException(PlatformErrorCode.CONFIG_NOT_FOUND));
+    
+    if (config.getType() == ConfigType.ENCRYPTED) {
+        try {
+            return cipherService.decrypt(config.getValue());
+        } catch (DecryptionException e) {
+            log.error("[PlatformConfigService] decryption failed - key={}", key, e);
+            throw new BusinessException(PlatformErrorCode.DECRYPTION_FAILED);
+        }
+    }
+    
+    return config.getValue();
+}
+```
+
+### 2. ConfigType 구분
+
+```java
+public enum ConfigType {
+    STRING,      // 일반 문자열 (암호화 불필요)
+    NUMBER,      // 숫자
+    BOOLEAN,     // 불린
+    JSON,        // JSON 객체
+    ENCRYPTED    // 암호화된 데이터 (민감 정보)
+}
+```
+
+**사용 원칙:**
+- `ENCRYPTED`: API 키, 비밀번호, 토큰, 개인정보 등 민감 데이터
+- 일반 타입: 공개 가능한 설정 값
+
+### 3. 암호화가 필요한 데이터
+
+#### ✅ 반드시 암호화해야 하는 데이터
+- 사용자 비밀번호 (BCrypt는 별도, 기타는 CipherService)
+- API 키, Secret Key, Access Token
+- 클라우드 프로바이더 자격증명 (AWS Access Key, GCP Service Account)
+- 데이터베이스 연결 정보 (비밀번호)
+- 개인식별정보 (PII): 주민등록번호, 여권번호, 신용카드 번호
+- SMTP 비밀번호, Webhook Secret
+- OAuth Client Secret
+
+#### ❌ 암호화가 불필요한 데이터
+- 공개 설정 값 (타임존, 언어)
+- 시스템 메타데이터
+- 로그 레벨, 기능 플래그
+- 공개 URL, 도메인 이름
+
+---
+
+## 실제 사용 예시
+
+### 예시 1: 플랫폼 설정 저장 (ENCRYPTED 타입)
+
+```java
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class PlatformConfigService {
+    
+    private final PlatformConfigRepository configRepository;
+    private final CipherService cipherService;
+    
+    /**
+     * 민감 정보를 포함한 설정 생성
+     */
+    @Transactional
+    public PlatformConfig createEncryptedConfig(String key, String plainValue) {
+        log.info("[PlatformConfigService] createEncryptedConfig - key={}", key);
+        
+        // 중복 검사
+        if (configRepository.existsByKey(key)) {
+            throw new BusinessException(PlatformErrorCode.DUPLICATE_CONFIG_KEY);
+        }
+        
+        // 암호화
+        String encryptedValue = cipherService.encrypt(plainValue);
+        
+        PlatformConfig config = PlatformConfig.builder()
+                .key(key)
+                .value(encryptedValue)
+                .type(ConfigType.ENCRYPTED)
+                .category(ConfigCategory.SECURITY)
+                .build();
+        
+        PlatformConfig saved = configRepository.save(config);
+        log.info("[PlatformConfigService] createEncryptedConfig - success key={}", key);
+        return saved;
+    }
+    
+    /**
+     * 민감 정보 조회 (기본: 마스킹)
+     */
+    public PlatformConfigResponse getConfig(String key) {
+        log.info("[PlatformConfigService] getConfig - key={}", key);
+        
+        PlatformConfig config = configRepository.findByKey(key)
+                .orElseThrow(() -> new ResourceNotFoundException(PlatformErrorCode.CONFIG_NOT_FOUND));
+        
+        // ENCRYPTED 타입은 기본적으로 마스킹하여 반환
+        if (config.getType() == ConfigType.ENCRYPTED) {
+            return PlatformConfigResponse.fromMasked(config);  // value: "***"
+        }
+        
+        return PlatformConfigResponse.from(config);
+    }
+    
+    /**
+     * 민감 정보 조회 (복호화) - 권한 필요
+     */
+    @PreAuthorize("hasAnyRole('ADMIN', 'PLATFORM_ADMIN')")
+    @AuditRequired(
+        action = "getDecryptedConfig",
+        resourceType = AuditResourceType.PLATFORM,
+        severity = AuditSeverity.CRITICAL,
+        includeRequestData = true,
+        description = "암호화된 설정값 복호화 조회"
+    )
+    public PlatformConfigResponse getDecryptedConfig(String key, String reason) {
+        log.info("[PlatformConfigService] getDecryptedConfig - key={}, reason={}", key, reason);
+        
+        PlatformConfig config = configRepository.findByKey(key)
+                .orElseThrow(() -> new ResourceNotFoundException(PlatformErrorCode.CONFIG_NOT_FOUND));
+        
+        if (config.getType() == ConfigType.ENCRYPTED) {
+            try {
+                String decryptedValue = cipherService.decrypt(config.getValue());
+                log.info("[PlatformConfigService] getDecryptedConfig - success key={}", key);
+                return PlatformConfigResponse.fromDecrypted(config, decryptedValue);
+            } catch (Exception e) {
+                log.error("[PlatformConfigService] decryption failed - key={}", key, e);
+                throw new BusinessException(PlatformErrorCode.DECRYPTION_FAILED);
+            }
+        }
+        
+        return PlatformConfigResponse.from(config);
+    }
+    
+    /**
+     * 민감 정보 수정
+     */
+    @Transactional
+    public PlatformConfig updateEncryptedConfig(String key, String newPlainValue) {
+        log.info("[PlatformConfigService] updateEncryptedConfig - key={}", key);
+        
+        PlatformConfig config = configRepository.findByKey(key)
+                .orElseThrow(() -> new ResourceNotFoundException(PlatformErrorCode.CONFIG_NOT_FOUND));
+        
+        if (config.getType() != ConfigType.ENCRYPTED) {
+            throw new BusinessException(PlatformErrorCode.INVALID_CONFIG_TYPE);
+        }
+        
+        // 새 평문을 암호화
+        String encryptedValue = cipherService.encrypt(newPlainValue);
+        config.setValue(encryptedValue);
+        
+        PlatformConfig saved = configRepository.save(config);
+        log.info("[PlatformConfigService] updateEncryptedConfig - success key={}", key);
+        return saved;
+    }
+}
+```
+
+### 예시 2: 클라우드 프로바이더 자격증명 저장
+
+```java
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class CloudProviderService {
+    
+    private final CloudProviderRepository providerRepository;
+    private final CipherService cipherService;
+    
+    /**
+     * AWS 자격증명 저장 (암호화)
+     */
+    @Transactional
+    public CloudProvider createAwsProvider(AwsProviderRequest request) {
+        log.info("[CloudProviderService] createAwsProvider - name={}", request.getName());
+        
+        // Access Key ID는 일반 문자열 (식별자)
+        // Secret Access Key는 암호화 필수
+        String encryptedAccessKey = cipherService.encrypt(request.getAccessKeyId());
+        String encryptedSecretKey = cipherService.encrypt(request.getSecretAccessKey());
+        
+        CloudProvider provider = CloudProvider.builder()
+                .name(request.getName())
+                .type(CloudProviderType.AWS)
+                .accessKeyId(encryptedAccessKey)
+                .secretAccessKey(encryptedSecretKey)
+                .region(request.getRegion())
+                .status(Status.ACTIVE)
+                .build();
+        
+        CloudProvider saved = providerRepository.save(provider);
+        log.info("[CloudProviderService] createAwsProvider - success id={}", saved.getId());
+        return saved;
+    }
+    
+    /**
+     * AWS 자격증명 사용 (복호화)
+     */
+    public AwsCredentials getAwsCredentials(Long providerId) {
+        log.info("[CloudProviderService] getAwsCredentials - providerId={}", providerId);
+        
+        CloudProvider provider = providerRepository.findById(providerId)
+                .orElseThrow(() -> new ResourceNotFoundException(CloudErrorCode.PROVIDER_NOT_FOUND));
+        
+        if (provider.getType() != CloudProviderType.AWS) {
+            throw new BusinessException(CloudErrorCode.INVALID_PROVIDER_TYPE);
+        }
+        
+        try {
+            String accessKeyId = cipherService.decrypt(provider.getAccessKeyId());
+            String secretAccessKey = cipherService.decrypt(provider.getSecretAccessKey());
+            
+            return new AwsCredentials(accessKeyId, secretAccessKey);
+        } catch (Exception e) {
+            log.error("[CloudProviderService] decryption failed - providerId={}", providerId, e);
+            throw new BusinessException(CloudErrorCode.CREDENTIAL_DECRYPTION_FAILED);
+        }
+    }
+}
+```
+
+### 예시 3: 사용자 개인정보 암호화 (선택적)
+
+```java
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class UserProfileService {
+    
+    private final UserProfileRepository profileRepository;
+    private final CipherService cipherService;
+    
+    /**
+     * 민감한 개인정보 저장 (암호화)
+     */
+    @Transactional
+    public UserProfile createProfile(Long userId, UserProfileRequest request) {
+        log.info("[UserProfileService] createProfile - userId={}", userId);
+        
+        // 선택적 암호화: 주민등록번호, 여권번호 등
+        String encryptedSsn = null;
+        if (request.getSsn() != null) {
+            encryptedSsn = cipherService.encrypt(request.getSsn());
+        }
+        
+        UserProfile profile = UserProfile.builder()
+                .userId(userId)
+                .name(request.getName())  // 이름은 평문 (검색 필요)
+                .ssn(encryptedSsn)        // 주민등록번호는 암호화
+                .phoneNumber(request.getPhoneNumber())  // 전화번호 (정책에 따라 암호화 고려)
+                .address(request.getAddress())
+                .build();
+        
+        UserProfile saved = profileRepository.save(profile);
+        log.info("[UserProfileService] createProfile - success userId={}", userId);
+        return saved;
+    }
+}
+```
+
+---
+
+## 예외 처리
+
+### 암호화/복호화 예외 처리
+```java
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ConfigService {
+    
+    private final CipherService cipherService;
+    
+    public String getDecryptedValue(String encryptedValue) {
+        try {
+            return cipherService.decrypt(encryptedValue);
+        } catch (DecryptionException e) {
+            // 복호화 실패 (잘못된 키, 손상된 데이터)
+            log.error("[ConfigService] decryption failed", e);
+            throw new BusinessException(PlatformErrorCode.DECRYPTION_FAILED);
+        } catch (EncryptedPayloadInvalidException e) {
+            // 암호문 형식 오류
+            log.error("[ConfigService] invalid encrypted payload", e);
+            throw new BusinessException(PlatformErrorCode.ENCRYPTED_PAYLOAD_INVALID);
+        }
+    }
+    
+    public String encryptValue(String plainValue) {
+        try {
+            return cipherService.encrypt(plainValue);
+        } catch (EncryptionException e) {
+            // 암호화 실패 (키 누락, 잘못된 설정)
+            log.error("[ConfigService] encryption failed", e);
+            throw new BusinessException(PlatformErrorCode.ENCRYPTION_FAILED);
+        }
+    }
+}
+```
+
+### ErrorCode 예시
+```java
+public enum PlatformErrorCode implements BaseErrorCode {
+    
+    DECRYPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 6017, "복호화에 실패했습니다."),
+    ENCRYPTED_PAYLOAD_INVALID(HttpStatus.BAD_REQUEST, 6019, "암호문 형식이 올바르지 않습니다."),
+    ENCRYPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 6020, "암호화에 실패했습니다."),
+    CIPHER_KEY_MISSING(HttpStatus.INTERNAL_SERVER_ERROR, 6021, "암호화 키가 설정되지 않았습니다.");
+    
+    // ...
+}
+```
+
+---
+
+## 키 관리
+
+### 1. 키 설정 (application.yml)
+
+```yaml
+config:
+  cipher:
+    key: ${CONFIG_CIPHER_KEY}                    # 환경변수로 주입 (필수)
+    secondaryKey: ${CONFIG_CIPHER_SECONDARY_KEY} # 키 회전용 보조 키 (선택)
+    missingKeyBehavior: FAIL                     # FAIL (기본) 또는 READ_ONLY
+```
+
+### 2. 환경별 키 관리
+
+```bash
+# 개발 환경 (로컬)
+export CONFIG_CIPHER_KEY="MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA="
+
+# 운영 환경 (KMS/Secret Manager 사용)
+# AWS Secrets Manager, HashiCorp Vault 등에서 주입
+```
+
+### 3. 키 회전 절차
+
+1. **새 키 생성**: Base64 인코딩된 32바이트 키 생성
+2. **보조 키 설정**: 기존 키를 `secondaryKey`로 배포
+3. **주 키 교체**: 새 키를 `key`로 배포 (신규 암호화는 새 키 사용)
+4. **복호화 Fallback**: `secondaryKey`로 과거 데이터 복호화 지원
+5. **재암호화 (선택)**: 중요 데이터를 새 키로 재암호화
+6. **보조 키 제거**: 충분한 기간 후 `secondaryKey` 제거
+
+---
+
+## 보안 권장사항
+
+### ✅ 권장사항
+- 암호화 키는 **환경변수** 또는 **Secret Manager**에서 주입
+- 저장소(Git)에 키를 **절대 커밋하지 않음**
+- 운영 환경에서는 `missingKeyBehavior=FAIL` 사용
+- 복호화 접근은 **권한 검사** 및 **감사 로깅** 필수
+- ENCRYPTED 타입 기본 조회 시 **마스킹 처리** (`***`)
+- 복호화된 평문은 **로그에 출력하지 않음**
+
+### ❌ 금지사항
+- 평문을 로그에 출력 금지
+- 암호화 키를 코드에 하드코딩 금지
+- ENCRYPTED 타입을 권한 없이 복호화 금지
+- 복호화된 데이터를 캐싱 금지 (또는 짧은 TTL)
+
+---
+
+## API 응답 패턴
+
+### 기본 조회 (마스킹)
+```java
+@GetMapping("/configs/{key}")
+public ResponseEntity<ApiResponse<PlatformConfigResponse>> getConfig(@PathVariable String key) {
+    PlatformConfigResponse config = configService.getConfig(key);
+    return ResponseEntity.ok(ApiResponse.success(config));
+}
+
+// 응답 예시 (ENCRYPTED 타입)
+{
+  "key": "aws.secret.key",
+  "value": "***",           // 마스킹됨
+  "type": "ENCRYPTED"
+}
+```
+
+### 복호화 조회 (권한 필요)
+```java
+@GetMapping("/configs/{key}/decrypted")
+@PreAuthorize("hasRole('ADMIN')")
+@AuditRequired(
+    action = "getDecryptedConfig",
+    resourceType = AuditResourceType.PLATFORM,
+    severity = AuditSeverity.CRITICAL
+)
+public ResponseEntity<ApiResponse<PlatformConfigResponse>> getDecryptedConfig(
+        @PathVariable String key,
+        @RequestParam String reason) {
+    PlatformConfigResponse config = configService.getDecryptedConfig(key, reason);
+    
+    // Cache-Control 헤더 추가 (캐싱 금지)
+    return ResponseEntity.ok()
+            .cacheControl(CacheControl.noStore()
+                    .noCache()
+                    .mustRevalidate()
+                    .maxAge(Duration.ZERO))
+            .header("Pragma", "no-cache")
+            .body(ApiResponse.success(config));
+}
+
+// 응답 예시 (복호화됨)
+{
+  "key": "aws.secret.key",
+  "value": "actual-secret-key-value",  // 복호화된 평문
+  "type": "ENCRYPTED"
+}
+```
+
+---
+
+## 체크리스트
+
+### 암호화 구현 시
+- [ ] `CipherService` 의존성 주입 완료
+- [ ] `ConfigType.ENCRYPTED` 타입으로 저장
+- [ ] 민감 데이터는 반드시 암호화
+- [ ] 암호화 실패 시 예외 처리
+- [ ] 로그에 평문 출력 안 됨
+
+### 복호화 구현 시
+- [ ] 권한 검사 (`@PreAuthorize`)
+- [ ] 감사 로깅 (`@AuditRequired`)
+- [ ] 복호화 실패 예외 처리
+- [ ] 캐싱 금지 헤더 추가 (`Cache-Control: no-store`)
+- [ ] 로그에 복호화된 평문 출력 안 됨
+
+### 키 관리
+- [ ] 환경변수로 키 주입 설정
+- [ ] 저장소에 키 커밋 안 됨
+- [ ] 운영 환경: `missingKeyBehavior=FAIL`
+- [ ] 키 회전 계획 수립
+- [ ] 보조 키(`secondaryKey`) 설정 고려
+
+### 보안 점검
+- [ ] ENCRYPTED 타입은 기본 마스킹 처리
+- [ ] 복호화 접근은 ADMIN 권한만
+- [ ] 복호화 조회는 감사 로그 기록
+- [ ] 복호화된 응답은 캐싱 금지
+- [ ] 민감 정보는 HTTPS로만 전송

--- a/.cursor/rules/dto-pattern.mdc
+++ b/.cursor/rules/dto-pattern.mdc
@@ -1,0 +1,662 @@
+---
+globs: *Dto.java
+alwaysApply: false
+---
+# DTO Pattern (DTO 패턴)
+
+## 기본 구조
+
+### Request DTO
+```java
+/**
+ * 리소스 생성 요청 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResourceCreateRequest {
+    
+    @NotBlank(message = "리소스명은 필수입니다")
+    @Size(min = 2, max = 100, message = "리소스명은 2-100자 사이여야 합니다")
+    private String name;
+    
+    @Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
+    private String description;
+    
+    @NotNull(message = "타입은 필수입니다")
+    private ResourceType type;
+}
+```
+
+### Response DTO
+```java
+/**
+ * 리소스 응답 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResourceResponse {
+    
+    private Long id;
+    private String name;
+    private String description;
+    private ResourceType type;
+    private Status status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    
+    /**
+     * Entity를 Response DTO로 변환
+     */
+    public static ResourceResponse from(Resource resource) {
+        return ResourceResponse.builder()
+                .id(resource.getId())
+                .name(resource.getName())
+                .description(resource.getDescription())
+                .type(resource.getType())
+                .status(resource.getStatus())
+                .createdAt(resource.getCreatedAt())
+                .updatedAt(resource.getUpdatedAt())
+                .build();
+    }
+    
+    /**
+     * Entity 목록을 Response DTO 목록으로 변환
+     */
+    public static List<ResourceResponse> fromList(List<Resource> resources) {
+        return resources.stream()
+                .map(ResourceResponse::from)
+                .collect(Collectors.toList());
+    }
+}
+```
+
+## 필수 규칙
+
+### 1. DTO 구분
+- **Request DTO**: `XxxCreateRequest`, `XxxUpdateRequest`, `XxxSearchRequest`
+- **Response DTO**: `XxxResponse`, `XxxDetailResponse`, `XxxSummaryResponse`
+- **Common DTO**: `ApiResponse<T>`, `PageResponse<T>`, `ErrorResponse`
+
+### 2. Validation
+
+```java
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserCreateRequest {
+    
+    @NotBlank(message = "사용자명은 필수입니다")
+    @Size(min = 2, max = 50, message = "사용자명은 2-50자 사이여야 합니다")
+    @Pattern(regexp = "^[a-zA-Z0-9_]+$", message = "사용자명은 영문, 숫자, 언더스코어만 사용 가능합니다")
+    private String username;
+    
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    private String email;
+    
+    @NotBlank(message = "비밀번호는 필수입니다")
+    @Size(min = 8, max = 100, message = "비밀번호는 8-100자 사이여야 합니다")
+    private String password;
+    
+    @NotNull(message = "역할은 필수입니다")
+    private UserRole role;
+}
+```
+
+### 3. JsonInclude 사용
+
+```java
+// null 값 제외
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResourceResponse {
+    private String optionalField;  // null이면 JSON에서 제외
+}
+
+// 빈 컬렉션 제외
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class ResourceResponse {
+    private List<String> tags;  // 빈 리스트면 JSON에서 제외
+}
+```
+
+### 4. from() 메서드 패턴
+
+```java
+// 단일 변환
+public static ResourceResponse from(Resource resource) {
+    if (resource == null) {
+        return null;
+    }
+    return ResourceResponse.builder()
+            .id(resource.getId())
+            .name(resource.getName())
+            .build();
+}
+
+// 목록 변환
+public static List<ResourceResponse> fromList(List<Resource> resources) {
+    return resources.stream()
+            .map(ResourceResponse::from)
+            .collect(Collectors.toList());
+}
+
+// 페이지 변환
+public static Page<ResourceResponse> fromPage(Page<Resource> resourcePage) {
+    return resourcePage.map(ResourceResponse::from);
+}
+```
+
+### 5. API 응답 래퍼
+
+```java
+/**
+ * 표준 API 응답 형식
+ */
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponse<T> {
+    
+    private final boolean success;
+    private final String message;
+    private final T data;
+    private final String errorCode;
+    private final List<FieldErrorResponse> fieldErrors;
+    
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+    private final OffsetDateTime timestamp;
+    
+    public static <T> ApiResponse<T> success(T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .data(data)
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC))
+                .build();
+    }
+    
+    public static <T> ApiResponse<T> success(T data, String message) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .message(message)
+                .data(data)
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC))
+                .build();
+    }
+    
+    public static <T> ApiResponse<T> error(BaseErrorCode errorCode) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .errorCode(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC))
+                .build();
+    }
+    
+    public static <T> ApiResponse<T> error(BaseErrorCode errorCode, String message) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .errorCode(errorCode.getCode())
+                .message(message)
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC))
+                .build();
+    }
+    
+    public static <T> ApiResponse<T> error(BaseErrorCode errorCode, List<FieldErrorResponse> fieldErrors) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .errorCode(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .fieldErrors(fieldErrors)
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC))
+                .build();
+    }
+    
+    public record FieldErrorResponse(
+            String field,
+            Object value,
+            String reason
+    ) {}
+}
+```
+
+## 전체 예시
+
+### UserCreateRequest
+```java
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserCreateRequest {
+    
+    @NotBlank(message = "사용자명은 필수입니다")
+    @Size(min = 2, max = 50)
+    @Pattern(regexp = "^[a-zA-Z0-9_]+$")
+    private String username;
+    
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email
+    private String email;
+    
+    @NotBlank(message = "이름은 필수입니다")
+    @Size(max = 100)
+    private String name;
+    
+    @NotBlank(message = "비밀번호는 필수입니다")
+    @Size(min = 8, max = 100)
+    private String password;
+    
+    @NotNull(message = "역할은 필수입니다")
+    private UserRole role;
+}
+```
+
+### UserUpdateRequest
+```java
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserUpdateRequest {
+    
+    @NotBlank(message = "이름은 필수입니다")
+    @Size(max = 100)
+    private String name;
+    
+    @Email
+    private String email;
+    
+    private String phoneNumber;
+    private String department;
+    private String jobTitle;
+}
+```
+
+### UserResponse
+```java
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UserResponse {
+    
+    private Long id;
+    private String username;
+    private String email;
+    private String name;
+    private UserRole role;
+    private Status status;
+    private String phoneNumber;
+    private String department;
+    private String jobTitle;
+    private LocalDateTime lastLogin;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    
+    public static UserResponse from(User user) {
+        if (user == null) {
+            return null;
+        }
+        
+        return UserResponse.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .name(user.getName())
+                .role(user.getRole())
+                .status(user.getStatus())
+                .phoneNumber(user.getPhoneNumber())
+                .department(user.getDepartment())
+                .jobTitle(user.getJobTitle())
+                .lastLogin(user.getLastLogin())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+    
+    public static List<UserResponse> fromList(List<User> users) {
+        return users.stream()
+                .map(UserResponse::from)
+                .collect(Collectors.toList());
+    }
+    
+    public static Page<UserResponse> fromPage(Page<User> userPage) {
+        return userPage.map(UserResponse::from);
+    }
+}
+```
+# DTO Pattern (DTO 패턴)
+
+## 기본 구조
+
+### Request DTO
+```java
+/**
+ * 리소스 생성 요청 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResourceCreateRequest {
+    
+    @NotBlank(message = "리소스명은 필수입니다")
+    @Size(min = 2, max = 100, message = "리소스명은 2-100자 사이여야 합니다")
+    private String name;
+    
+    @Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
+    private String description;
+    
+    @NotNull(message = "타입은 필수입니다")
+    private ResourceType type;
+}
+```
+
+### Response DTO
+```java
+/**
+ * 리소스 응답 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResourceResponse {
+    
+    private Long id;
+    private String name;
+    private String description;
+    private ResourceType type;
+    private Status status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    
+    /**
+     * Entity를 Response DTO로 변환
+     */
+    public static ResourceResponse from(Resource resource) {
+        return ResourceResponse.builder()
+                .id(resource.getId())
+                .name(resource.getName())
+                .description(resource.getDescription())
+                .type(resource.getType())
+                .status(resource.getStatus())
+                .createdAt(resource.getCreatedAt())
+                .updatedAt(resource.getUpdatedAt())
+                .build();
+    }
+    
+    /**
+     * Entity 목록을 Response DTO 목록으로 변환
+     */
+    public static List<ResourceResponse> fromList(List<Resource> resources) {
+        return resources.stream()
+                .map(ResourceResponse::from)
+                .collect(Collectors.toList());
+    }
+}
+```
+
+## 필수 규칙
+
+### 1. DTO 구분
+- **Request DTO**: `XxxCreateRequest`, `XxxUpdateRequest`, `XxxSearchRequest`
+- **Response DTO**: `XxxResponse`, `XxxDetailResponse`, `XxxSummaryResponse`
+- **Common DTO**: `ApiResponse<T>`, `PageResponse<T>`, `ErrorResponse`
+
+### 2. Validation
+
+```java
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserCreateRequest {
+    
+    @NotBlank(message = "사용자명은 필수입니다")
+    @Size(min = 2, max = 50, message = "사용자명은 2-50자 사이여야 합니다")
+    @Pattern(regexp = "^[a-zA-Z0-9_]+$", message = "사용자명은 영문, 숫자, 언더스코어만 사용 가능합니다")
+    private String username;
+    
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    private String email;
+    
+    @NotBlank(message = "비밀번호는 필수입니다")
+    @Size(min = 8, max = 100, message = "비밀번호는 8-100자 사이여야 합니다")
+    private String password;
+    
+    @NotNull(message = "역할은 필수입니다")
+    private UserRole role;
+}
+```
+
+### 3. JsonInclude 사용
+
+```java
+// null 값 제외
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResourceResponse {
+    private String optionalField;  // null이면 JSON에서 제외
+}
+
+// 빈 컬렉션 제외
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class ResourceResponse {
+    private List<String> tags;  // 빈 리스트면 JSON에서 제외
+}
+```
+
+### 4. from() 메서드 패턴
+
+```java
+// 단일 변환
+public static ResourceResponse from(Resource resource) {
+    if (resource == null) {
+        return null;
+    }
+    return ResourceResponse.builder()
+            .id(resource.getId())
+            .name(resource.getName())
+            .build();
+}
+
+// 목록 변환
+public static List<ResourceResponse> fromList(List<Resource> resources) {
+    return resources.stream()
+            .map(ResourceResponse::from)
+            .collect(Collectors.toList());
+}
+
+// 페이지 변환
+public static Page<ResourceResponse> fromPage(Page<Resource> resourcePage) {
+    return resourcePage.map(ResourceResponse::from);
+}
+```
+
+### 5. API 응답 래퍼
+
+```java
+/**
+ * 표준 API 응답 형식
+ */
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponse<T> {
+    
+    private final boolean success;
+    private final String message;
+    private final T data;
+    private final String errorCode;
+    private final List<FieldErrorResponse> fieldErrors;
+    
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+    private final OffsetDateTime timestamp;
+    
+    public static <T> ApiResponse<T> success(T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .data(data)
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC))
+                .build();
+    }
+    
+    public static <T> ApiResponse<T> success(T data, String message) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .message(message)
+                .data(data)
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC))
+                .build();
+    }
+    
+    public static <T> ApiResponse<T> error(BaseErrorCode errorCode) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .errorCode(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC))
+                .build();
+    }
+    
+    public static <T> ApiResponse<T> error(BaseErrorCode errorCode, String message) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .errorCode(errorCode.getCode())
+                .message(message)
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC))
+                .build();
+    }
+    
+    public static <T> ApiResponse<T> error(BaseErrorCode errorCode, List<FieldErrorResponse> fieldErrors) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .errorCode(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .fieldErrors(fieldErrors)
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC))
+                .build();
+    }
+    
+    public record FieldErrorResponse(
+            String field,
+            Object value,
+            String reason
+    ) {}
+}
+```
+
+## 전체 예시
+
+### UserCreateRequest
+```java
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserCreateRequest {
+    
+    @NotBlank(message = "사용자명은 필수입니다")
+    @Size(min = 2, max = 50)
+    @Pattern(regexp = "^[a-zA-Z0-9_]+$")
+    private String username;
+    
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email
+    private String email;
+    
+    @NotBlank(message = "이름은 필수입니다")
+    @Size(max = 100)
+    private String name;
+    
+    @NotBlank(message = "비밀번호는 필수입니다")
+    @Size(min = 8, max = 100)
+    private String password;
+    
+    @NotNull(message = "역할은 필수입니다")
+    private UserRole role;
+}
+```
+
+### UserUpdateRequest
+```java
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserUpdateRequest {
+    
+    @NotBlank(message = "이름은 필수입니다")
+    @Size(max = 100)
+    private String name;
+    
+    @Email
+    private String email;
+    
+    private String phoneNumber;
+    private String department;
+    private String jobTitle;
+}
+```
+
+### UserResponse
+```java
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UserResponse {
+    
+    private Long id;
+    private String username;
+    private String email;
+    private String name;
+    private UserRole role;
+    private Status status;
+    private String phoneNumber;
+    private String department;
+    private String jobTitle;
+    private LocalDateTime lastLogin;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    
+    public static UserResponse from(User user) {
+        if (user == null) {
+            return null;
+        }
+        
+        return UserResponse.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .name(user.getName())
+                .role(user.getRole())
+                .status(user.getStatus())
+                .phoneNumber(user.getPhoneNumber())
+                .department(user.getDepartment())
+                .jobTitle(user.getJobTitle())
+                .lastLogin(user.getLastLogin())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+    
+    public static List<UserResponse> fromList(List<User> users) {
+        return users.stream()
+                .map(UserResponse::from)
+                .collect(Collectors.toList());
+    }
+    
+    public static Page<UserResponse> fromPage(Page<User> userPage) {
+        return userPage.map(UserResponse::from);
+    }
+}
+```

--- a/.cursor/rules/entity-pattern.mdc
+++ b/.cursor/rules/entity-pattern.mdc
@@ -1,0 +1,640 @@
+---
+globs: **/entity/*.java
+alwaysApply: false
+---
+# Entity Pattern (엔티티 패턴)
+
+## 기본 구조
+
+```java
+/**
+ * 리소스 엔티티
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Entity
+@Table(name = "resources", indexes = {
+    @Index(name = "idx_resources_name", columnList = "name"),
+    @Index(name = "idx_resources_tenant", columnList = "tenant_id"),
+    @Index(name = "idx_resources_status", columnList = "status")
+})
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Resource extends BaseEntity {
+    
+    @NotBlank(message = "리소스명은 필수입니다")
+    @Size(min = 2, max = 100, message = "리소스명은 2-100자 사이여야 합니다")
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+    
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tenant_id")
+    private Tenant tenant;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private Status status = Status.ACTIVE;
+    
+    @Column(name = "metadata", columnDefinition = "JSON")
+    private String metadata;
+    
+    // 비즈니스 메서드
+    public void activate() {
+        this.status = Status.ACTIVE;
+    }
+    
+    public void suspend() {
+        this.status = Status.SUSPENDED;
+    }
+    
+    public boolean isActive() {
+        return Status.ACTIVE.equals(this.status);
+    }
+}
+```
+
+## 필수 규칙
+
+### 1. 클래스 레벨 어노테이션
+
+```java
+@Entity
+@Table(name = "table_name", indexes = { /* 인덱스 정의 */ })
+@Data                    // Getter, Setter, toString, equals, hashCode
+@Builder                 // Builder 패턴
+@NoArgsConstructor      // JPA 필수 (기본 생성자)
+@AllArgsConstructor     // Builder와 함께 사용
+public class Entity extends BaseEntity {
+    // ...
+}
+```
+
+**Lombok 어노테이션 조합 이유**:
+- `@NoArgsConstructor`: JPA가 리플렉션으로 엔티티 인스턴스 생성 시 필수
+- `@AllArgsConstructor`: Builder가 내부적으로 사용
+- `@Builder`: 가독성 좋은 객체 생성
+
+### 2. 테이블과 컬럼 매핑
+
+```java
+// 테이블명: snake_case
+@Table(name = "user_profiles")
+
+// 컬럼명: snake_case
+@Column(name = "user_name", nullable = false, length = 50)
+private String userName;
+
+// 인덱스 정의
+@Table(name = "users", indexes = {
+    @Index(name = "idx_users_username", columnList = "username"),
+    @Index(name = "idx_users_email", columnList = "email"),
+    @Index(name = "idx_users_tenant_status", columnList = "tenant_id, status")
+})
+```
+
+### 3. 기본 키 전략
+
+```java
+@Id
+@GeneratedValue(strategy = GenerationType.IDENTITY)
+private Long id;
+```
+
+### 4. Validation 어노테이션
+
+```java
+@NotBlank(message = "사용자명은 필수입니다")
+@Size(min = 2, max = 50, message = "사용자명은 2-50자 사이여야 합니다")
+@Column(name = "username", unique = true, nullable = false, length = 50)
+private String username;
+
+@Email(message = "올바른 이메일 형식이 아닙니다")
+@Column(name = "email", nullable = false)
+private String email;
+
+@Pattern(regexp = "^[0-9]{3}-[0-9]{4}-[0-9]{4}$", message = "전화번호 형식이 올바르지 않습니다")
+private String phoneNumber;
+```
+
+### 5. Enum 타입
+
+```java
+// ✅ STRING 사용 (권장)
+@Enumerated(EnumType.STRING)
+@Column(name = "status", nullable = false, length = 20)
+private Status status = Status.ACTIVE;
+
+// ❌ ORDINAL 사용 금지 (순서 변경 시 데이터 오류)
+@Enumerated(EnumType.ORDINAL)  // 금지!
+private Status status;
+```
+
+### 6. 연관관계 매핑
+
+```java
+// ManyToOne: 항상 LAZY 로딩
+@ManyToOne(fetch = FetchType.LAZY)
+@JoinColumn(name = "tenant_id")
+private Tenant tenant;
+
+// OneToMany: 항상 LAZY 로딩, mappedBy 설정
+@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+private List<UserProfile> profiles = new ArrayList<>();
+
+// ManyToMany: 중간 테이블 명시
+@ManyToMany(fetch = FetchType.LAZY)
+@JoinTable(
+    name = "user_roles",
+    joinColumns = @JoinColumn(name = "user_id"),
+    inverseJoinColumns = @JoinColumn(name = "role_id")
+)
+private List<Role> roles = new ArrayList<>();
+```
+
+### 7. BaseEntity 상속
+
+```java
+// BaseEntity에 공통 필드 포함
+// - id, createdAt, createdBy, updatedAt, updatedBy, isDeleted
+public class Resource extends BaseEntity {
+    // BaseEntity의 필드를 상속받음
+    // 추가 필드만 정의
+}
+```
+
+### 8. 비즈니스 메서드
+
+```java
+// 엔티티에 비즈니스 로직 포함 (상태 변경, 검증 등)
+public class User extends BaseEntity {
+    
+    // 상태 변경
+    public void activate() {
+        this.status = Status.ACTIVE;
+    }
+    
+    public void suspend() {
+        this.status = Status.SUSPENDED;
+    }
+    
+    // 검증
+    public boolean isActive() {
+        return Status.ACTIVE.equals(this.status);
+    }
+    
+    public boolean isAccountLocked() {
+        return lockedUntil != null && lockedUntil.isAfter(LocalDateTime.now());
+    }
+    
+    // 비즈니스 로직
+    public void incrementFailedLoginAttempts() {
+        this.failedLoginAttempts++;
+    }
+    
+    public void resetFailedLoginAttempts() {
+        this.failedLoginAttempts = 0;
+        this.lockedUntil = null;
+    }
+    
+    public void lockAccount(int lockoutMinutes) {
+        this.lockedUntil = LocalDateTime.now().plusMinutes(lockoutMinutes);
+    }
+}
+```
+
+## 전체 예시
+
+```java
+/**
+ * 사용자 엔티티 - 멀티 테넌트 지원
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Entity
+@Table(name = "users", indexes = {
+    @Index(name = "idx_users_username", columnList = "username"),
+    @Index(name = "idx_users_email", columnList = "email"),
+    @Index(name = "idx_users_tenant", columnList = "tenant_id"),
+    @Index(name = "idx_users_active", columnList = "status")
+})
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User extends BaseEntity {
+
+    @NotBlank(message = "사용자명은 필수입니다")
+    @Size(min = 2, max = 50, message = "사용자명은 2-50자 사이여야 합니다")
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @NotBlank(message = "이름은 필수입니다")
+    @Size(max = 100, message = "이름은 100자를 초과할 수 없습니다")
+    @Column(nullable = false)
+    private String name;
+
+    @Column(name = "password_hash")
+    private String passwordHash;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tenant_id")
+    private Tenant tenant;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role")
+    private UserRole role = UserRole.VIEWER;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    private Status status = Status.ACTIVE;
+
+    @Column(name = "last_login")
+    private LocalDateTime lastLogin;
+
+    @Column(name = "failed_login_attempts")
+    private Integer failedLoginAttempts = 0;
+
+    @Column(name = "locked_until")
+    private LocalDateTime lockedUntil;
+
+    @Column(name = "password_changed_at")
+    private LocalDateTime passwordChangedAt;
+
+    @Column(name = "two_factor_enabled")
+    private Boolean twoFactorEnabled = false;
+
+    @Column(name = "timezone")
+    private String timezone = "UTC";
+
+    @Column(name = "language")
+    private String language = "ko";
+
+    @Column(name = "preferences", columnDefinition = "TEXT")
+    private String preferences; // JSON
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "user_roles",
+        joinColumns = @JoinColumn(name = "user_id"),
+        inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    private List<Role> roles = new ArrayList<>();
+
+    // 비즈니스 메서드
+    public boolean isAccountLocked() {
+        return lockedUntil != null && lockedUntil.isAfter(LocalDateTime.now());
+    }
+
+    public boolean isPasswordExpired(int maxPasswordAgeDays) {
+        if (passwordChangedAt == null) {
+            return true;
+        }
+        return passwordChangedAt.isBefore(LocalDateTime.now().minusDays(maxPasswordAgeDays));
+    }
+
+    public void incrementFailedLoginAttempts() {
+        this.failedLoginAttempts++;
+    }
+
+    public void resetFailedLoginAttempts() {
+        this.failedLoginAttempts = 0;
+        this.lockedUntil = null;
+    }
+
+    public void lockAccount(int lockoutMinutes) {
+        this.lockedUntil = LocalDateTime.now().plusMinutes(lockoutMinutes);
+    }
+}
+```
+# Entity Pattern (엔티티 패턴)
+
+## 기본 구조
+
+```java
+/**
+ * 리소스 엔티티
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Entity
+@Table(name = "resources", indexes = {
+    @Index(name = "idx_resources_name", columnList = "name"),
+    @Index(name = "idx_resources_tenant", columnList = "tenant_id"),
+    @Index(name = "idx_resources_status", columnList = "status")
+})
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Resource extends BaseEntity {
+    
+    @NotBlank(message = "리소스명은 필수입니다")
+    @Size(min = 2, max = 100, message = "리소스명은 2-100자 사이여야 합니다")
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+    
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tenant_id")
+    private Tenant tenant;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private Status status = Status.ACTIVE;
+    
+    @Column(name = "metadata", columnDefinition = "JSON")
+    private String metadata;
+    
+    // 비즈니스 메서드
+    public void activate() {
+        this.status = Status.ACTIVE;
+    }
+    
+    public void suspend() {
+        this.status = Status.SUSPENDED;
+    }
+    
+    public boolean isActive() {
+        return Status.ACTIVE.equals(this.status);
+    }
+}
+```
+
+## 필수 규칙
+
+### 1. 클래스 레벨 어노테이션
+
+```java
+@Entity
+@Table(name = "table_name", indexes = { /* 인덱스 정의 */ })
+@Data                    // Getter, Setter, toString, equals, hashCode
+@Builder                 // Builder 패턴
+@NoArgsConstructor      // JPA 필수 (기본 생성자)
+@AllArgsConstructor     // Builder와 함께 사용
+public class Entity extends BaseEntity {
+    // ...
+}
+```
+
+**Lombok 어노테이션 조합 이유**:
+- `@NoArgsConstructor`: JPA가 리플렉션으로 엔티티 인스턴스 생성 시 필수
+- `@AllArgsConstructor`: Builder가 내부적으로 사용
+- `@Builder`: 가독성 좋은 객체 생성
+
+### 2. 테이블과 컬럼 매핑
+
+```java
+// 테이블명: snake_case
+@Table(name = "user_profiles")
+
+// 컬럼명: snake_case
+@Column(name = "user_name", nullable = false, length = 50)
+private String userName;
+
+// 인덱스 정의
+@Table(name = "users", indexes = {
+    @Index(name = "idx_users_username", columnList = "username"),
+    @Index(name = "idx_users_email", columnList = "email"),
+    @Index(name = "idx_users_tenant_status", columnList = "tenant_id, status")
+})
+```
+
+### 3. 기본 키 전략
+
+```java
+@Id
+@GeneratedValue(strategy = GenerationType.IDENTITY)
+private Long id;
+```
+
+### 4. Validation 어노테이션
+
+```java
+@NotBlank(message = "사용자명은 필수입니다")
+@Size(min = 2, max = 50, message = "사용자명은 2-50자 사이여야 합니다")
+@Column(name = "username", unique = true, nullable = false, length = 50)
+private String username;
+
+@Email(message = "올바른 이메일 형식이 아닙니다")
+@Column(name = "email", nullable = false)
+private String email;
+
+@Pattern(regexp = "^[0-9]{3}-[0-9]{4}-[0-9]{4}$", message = "전화번호 형식이 올바르지 않습니다")
+private String phoneNumber;
+```
+
+### 5. Enum 타입
+
+```java
+// ✅ STRING 사용 (권장)
+@Enumerated(EnumType.STRING)
+@Column(name = "status", nullable = false, length = 20)
+private Status status = Status.ACTIVE;
+
+// ❌ ORDINAL 사용 금지 (순서 변경 시 데이터 오류)
+@Enumerated(EnumType.ORDINAL)  // 금지!
+private Status status;
+```
+
+### 6. 연관관계 매핑
+
+```java
+// ManyToOne: 항상 LAZY 로딩
+@ManyToOne(fetch = FetchType.LAZY)
+@JoinColumn(name = "tenant_id")
+private Tenant tenant;
+
+// OneToMany: 항상 LAZY 로딩, mappedBy 설정
+@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+private List<UserProfile> profiles = new ArrayList<>();
+
+// ManyToMany: 중간 테이블 명시
+@ManyToMany(fetch = FetchType.LAZY)
+@JoinTable(
+    name = "user_roles",
+    joinColumns = @JoinColumn(name = "user_id"),
+    inverseJoinColumns = @JoinColumn(name = "role_id")
+)
+private List<Role> roles = new ArrayList<>();
+```
+
+### 7. BaseEntity 상속
+
+```java
+// BaseEntity에 공통 필드 포함
+// - id, createdAt, createdBy, updatedAt, updatedBy, isDeleted
+public class Resource extends BaseEntity {
+    // BaseEntity의 필드를 상속받음
+    // 추가 필드만 정의
+}
+```
+
+### 8. 비즈니스 메서드
+
+```java
+// 엔티티에 비즈니스 로직 포함 (상태 변경, 검증 등)
+public class User extends BaseEntity {
+    
+    // 상태 변경
+    public void activate() {
+        this.status = Status.ACTIVE;
+    }
+    
+    public void suspend() {
+        this.status = Status.SUSPENDED;
+    }
+    
+    // 검증
+    public boolean isActive() {
+        return Status.ACTIVE.equals(this.status);
+    }
+    
+    public boolean isAccountLocked() {
+        return lockedUntil != null && lockedUntil.isAfter(LocalDateTime.now());
+    }
+    
+    // 비즈니스 로직
+    public void incrementFailedLoginAttempts() {
+        this.failedLoginAttempts++;
+    }
+    
+    public void resetFailedLoginAttempts() {
+        this.failedLoginAttempts = 0;
+        this.lockedUntil = null;
+    }
+    
+    public void lockAccount(int lockoutMinutes) {
+        this.lockedUntil = LocalDateTime.now().plusMinutes(lockoutMinutes);
+    }
+}
+```
+
+## 전체 예시
+
+```java
+/**
+ * 사용자 엔티티 - 멀티 테넌트 지원
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2024-01-01
+ */
+@Entity
+@Table(name = "users", indexes = {
+    @Index(name = "idx_users_username", columnList = "username"),
+    @Index(name = "idx_users_email", columnList = "email"),
+    @Index(name = "idx_users_tenant", columnList = "tenant_id"),
+    @Index(name = "idx_users_active", columnList = "status")
+})
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User extends BaseEntity {
+
+    @NotBlank(message = "사용자명은 필수입니다")
+    @Size(min = 2, max = 50, message = "사용자명은 2-50자 사이여야 합니다")
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @NotBlank(message = "이름은 필수입니다")
+    @Size(max = 100, message = "이름은 100자를 초과할 수 없습니다")
+    @Column(nullable = false)
+    private String name;
+
+    @Column(name = "password_hash")
+    private String passwordHash;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tenant_id")
+    private Tenant tenant;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role")
+    private UserRole role = UserRole.VIEWER;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    private Status status = Status.ACTIVE;
+
+    @Column(name = "last_login")
+    private LocalDateTime lastLogin;
+
+    @Column(name = "failed_login_attempts")
+    private Integer failedLoginAttempts = 0;
+
+    @Column(name = "locked_until")
+    private LocalDateTime lockedUntil;
+
+    @Column(name = "password_changed_at")
+    private LocalDateTime passwordChangedAt;
+
+    @Column(name = "two_factor_enabled")
+    private Boolean twoFactorEnabled = false;
+
+    @Column(name = "timezone")
+    private String timezone = "UTC";
+
+    @Column(name = "language")
+    private String language = "ko";
+
+    @Column(name = "preferences", columnDefinition = "TEXT")
+    private String preferences; // JSON
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "user_roles",
+        joinColumns = @JoinColumn(name = "user_id"),
+        inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    private List<Role> roles = new ArrayList<>();
+
+    // 비즈니스 메서드
+    public boolean isAccountLocked() {
+        return lockedUntil != null && lockedUntil.isAfter(LocalDateTime.now());
+    }
+
+    public boolean isPasswordExpired(int maxPasswordAgeDays) {
+        if (passwordChangedAt == null) {
+            return true;
+        }
+        return passwordChangedAt.isBefore(LocalDateTime.now().minusDays(maxPasswordAgeDays));
+    }
+
+    public void incrementFailedLoginAttempts() {
+        this.failedLoginAttempts++;
+    }
+
+    public void resetFailedLoginAttempts() {
+        this.failedLoginAttempts = 0;
+        this.lockedUntil = null;
+    }
+
+    public void lockAccount(int lockoutMinutes) {
+        this.lockedUntil = LocalDateTime.now().plusMinutes(lockoutMinutes);
+    }
+}
+```

--- a/.cursor/rules/repository-pattern.mdc
+++ b/.cursor/rules/repository-pattern.mdc
@@ -1,0 +1,476 @@
+---
+alwaysApply: false
+---
+
+# Repository Pattern (리포지토리 패턴)
+
+## 기본 구조
+
+```java
+@Repository
+public interface ResourceRepository extends JpaRepository<Resource, Long> {
+    
+    /**
+     * 이름으로 리소스 조회
+     */
+    Optional<Resource> findByName(String name);
+    
+    /**
+     * 활성 리소스 목록 조회
+     */
+    List<Resource> findByStatus(Status status);
+    
+    /**
+     * 테넌트별 활성 리소스 조회
+     */
+    @Query("SELECT r FROM Resource r WHERE r.tenant = :tenant AND r.status = :status AND r.isDeleted = false")
+    List<Resource> findActiveResourcesByTenant(@Param("tenant") Tenant tenant, @Param("status") Status status);
+    
+    /**
+     * 리소스명 중복 검사
+     */
+    boolean existsByName(String name);
+}
+```
+
+## 필수 규칙
+
+### 1. 인터페이스 선언
+- `@Repository` 어노테이션 필수
+- `JpaRepository<Entity, IdType>` 상속
+- 제네릭 타입 명시: `<Entity, Long>` 또는 `<Entity, String>` 등
+
+### 2. 메서드 명명 규칙
+- **조회 (단건)**: `findByXxx`, `findByXxxAndYyy`
+- **조회 (목록)**: `findAllBy`, `findByXxx`
+- **존재 여부**: `existsByXxx`
+- **개수**: `countByXxx`
+- **삭제**: `deleteByXxx` (사용 지양, Service에서 명시적 처리 권장)
+
+### 3. 반환 타입
+
+```java
+// 단건 조회 - Optional 사용
+Optional<User> findByUsername(String username);
+Optional<User> findById(Long id);  // JpaRepository에서 기본 제공
+
+// 목록 조회 - List 사용
+List<User> findByStatus(Status status);
+List<User> findAll();  // JpaRepository에서 기본 제공
+
+// 페이징 조회 - Page 사용
+Page<User> findByStatus(Status status, Pageable pageable);
+
+// 존재 여부 - boolean
+boolean existsByUsername(String username);
+
+// 개수 - Long
+Long countByStatus(Status status);
+```
+
+### 4. @Query 사용
+
+```java
+// JPQL 사용 (권장)
+@Query("SELECT u FROM User u WHERE u.status = :status AND u.createdAt >= :startDate")
+List<User> findActiveUsersSince(
+    @Param("status") Status status, 
+    @Param("startDate") LocalDateTime startDate
+);
+
+// 복잡한 조인
+@Query("""
+    SELECT u FROM User u 
+    JOIN FETCH u.tenant t 
+    WHERE u.status = :status 
+    AND t.tenantKey = :tenantKey
+    ORDER BY u.createdAt DESC
+    """)
+List<User> findUsersByTenantKey(
+    @Param("tenantKey") String tenantKey, 
+    @Param("status") Status status
+);
+
+// Native Query (최후의 수단)
+@Query(value = """
+    SELECT u.*, COUNT(r.id) as resource_count 
+    FROM users u 
+    LEFT JOIN resources r ON u.id = r.user_id 
+    WHERE u.status = :status 
+    GROUP BY u.id
+    """, nativeQuery = true)
+List<Object[]> findUsersWithResourceCount(@Param("status") String status);
+```
+
+### 5. 파라미터 바인딩
+
+```java
+// ✅ @Param 사용 (명시적, 권장)
+@Query("SELECT u FROM User u WHERE u.username = :username")
+Optional<User> findByUsername(@Param("username") String username);
+
+// ✅ 위치 기반 파라미터 (간단한 경우)
+@Query("SELECT u FROM User u WHERE u.username = ?1")
+Optional<User> findByUsername(String username);
+
+// ❌ SQL Injection 위험 (절대 금지)
+@Query("SELECT u FROM User u WHERE u.username = '" + username + "'")  // 위험!
+```
+
+### 6. 주석 작성
+
+```java
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    
+    /**
+     * 사용자명으로 사용자 조회
+     * @param username 사용자명
+     * @return 사용자 정보 (Optional)
+     */
+    Optional<User> findByUsername(String username);
+    
+    /**
+     * 테넌트별 활성 사용자 목록 조회
+     * 삭제되지 않은 사용자만 포함
+     * @param tenant 테넌트
+     * @param status 사용자 상태
+     * @return 활성 사용자 목록
+     */
+    @Query("SELECT u FROM User u WHERE u.tenant = :tenant AND u.status = :status AND u.isDeleted = false")
+    List<User> findActiveUsersByTenant(
+        @Param("tenant") Tenant tenant, 
+        @Param("status") Status status
+    );
+}
+```
+
+## 전체 예시
+
+```java
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    
+    /**
+     * 사용자명으로 사용자 조회
+     */
+    Optional<User> findByUsername(String username);
+    
+    /**
+     * 이메일로 사용자 조회
+     */
+    Optional<User> findByEmail(String email);
+    
+    /**
+     * 테넌트로 사용자 목록 조회
+     */
+    List<User> findByTenant(Tenant tenant);
+    
+    /**
+     * 역할로 사용자 목록 조회
+     */
+    List<User> findByRole(UserRole role);
+    
+    /**
+     * 상태로 사용자 목록 조회
+     */
+    List<User> findByStatus(Status status);
+    
+    /**
+     * 테넌트별 활성 사용자 조회
+     */
+    @Query("SELECT u FROM User u WHERE u.tenant = :tenant AND u.status = :status AND u.isDeleted = false")
+    List<User> findActiveUsersByTenant(
+        @Param("tenant") Tenant tenant, 
+        @Param("status") Status status
+    );
+    
+    /**
+     * 역할별 활성 사용자 조회
+     */
+    @Query("SELECT u FROM User u WHERE u.role = :role AND u.status = :status AND u.isDeleted = false")
+    List<User> findActiveUsersByRole(
+        @Param("role") UserRole role, 
+        @Param("status") Status status
+    );
+    
+    /**
+     * 비활성 사용자 조회 (특정 날짜 이전 마지막 로그인)
+     */
+    @Query("SELECT u FROM User u WHERE u.lastLogin < :before AND u.status = :status")
+    List<User> findInactiveUsers(
+        @Param("before") LocalDateTime before, 
+        @Param("status") Status status
+    );
+    
+    /**
+     * 로그인 실패 횟수가 많은 사용자 조회
+     */
+    @Query("SELECT u FROM User u WHERE u.failedLoginAttempts >= :maxAttempts AND u.status = :status")
+    List<User> findLockedUsers(
+        @Param("maxAttempts") Integer maxAttempts, 
+        @Param("status") Status status
+    );
+    
+    /**
+     * 테넌트별 활성 사용자 수
+     */
+    @Query("SELECT COUNT(u) FROM User u WHERE u.tenant = :tenant AND u.status = :status AND u.isDeleted = false")
+    Long countActiveUsersByTenant(
+        @Param("tenant") Tenant tenant, 
+        @Param("status") Status status
+    );
+    
+    /**
+     * 키워드로 사용자 검색 (사용자명, 이메일, 이름)
+     */
+    @Query("SELECT u FROM User u WHERE u.username LIKE %:keyword% OR u.email LIKE %:keyword% OR u.name LIKE %:keyword%")
+    List<User> searchUsers(@Param("keyword") String keyword);
+    
+    /**
+     * 사용자명 중복 검사
+     */
+    boolean existsByUsername(String username);
+    
+    /**
+     * 이메일 중복 검사
+     */
+    boolean existsByEmail(String email);
+}
+```
+# Repository Pattern (리포지토리 패턴)
+
+## 기본 구조
+
+```java
+@Repository
+public interface ResourceRepository extends JpaRepository<Resource, Long> {
+    
+    /**
+     * 이름으로 리소스 조회
+     */
+    Optional<Resource> findByName(String name);
+    
+    /**
+     * 활성 리소스 목록 조회
+     */
+    List<Resource> findByStatus(Status status);
+    
+    /**
+     * 테넌트별 활성 리소스 조회
+     */
+    @Query("SELECT r FROM Resource r WHERE r.tenant = :tenant AND r.status = :status AND r.isDeleted = false")
+    List<Resource> findActiveResourcesByTenant(@Param("tenant") Tenant tenant, @Param("status") Status status);
+    
+    /**
+     * 리소스명 중복 검사
+     */
+    boolean existsByName(String name);
+}
+```
+
+## 필수 규칙
+
+### 1. 인터페이스 선언
+- `@Repository` 어노테이션 필수
+- `JpaRepository<Entity, IdType>` 상속
+- 제네릭 타입 명시: `<Entity, Long>` 또는 `<Entity, String>` 등
+
+### 2. 메서드 명명 규칙
+- **조회 (단건)**: `findByXxx`, `findByXxxAndYyy`
+- **조회 (목록)**: `findAllBy`, `findByXxx`
+- **존재 여부**: `existsByXxx`
+- **개수**: `countByXxx`
+- **삭제**: `deleteByXxx` (사용 지양, Service에서 명시적 처리 권장)
+
+### 3. 반환 타입
+
+```java
+// 단건 조회 - Optional 사용
+Optional<User> findByUsername(String username);
+Optional<User> findById(Long id);  // JpaRepository에서 기본 제공
+
+// 목록 조회 - List 사용
+List<User> findByStatus(Status status);
+List<User> findAll();  // JpaRepository에서 기본 제공
+
+// 페이징 조회 - Page 사용
+Page<User> findByStatus(Status status, Pageable pageable);
+
+// 존재 여부 - boolean
+boolean existsByUsername(String username);
+
+// 개수 - Long
+Long countByStatus(Status status);
+```
+
+### 4. @Query 사용
+
+```java
+// JPQL 사용 (권장)
+@Query("SELECT u FROM User u WHERE u.status = :status AND u.createdAt >= :startDate")
+List<User> findActiveUsersSince(
+    @Param("status") Status status, 
+    @Param("startDate") LocalDateTime startDate
+);
+
+// 복잡한 조인
+@Query("""
+    SELECT u FROM User u 
+    JOIN FETCH u.tenant t 
+    WHERE u.status = :status 
+    AND t.tenantKey = :tenantKey
+    ORDER BY u.createdAt DESC
+    """)
+List<User> findUsersByTenantKey(
+    @Param("tenantKey") String tenantKey, 
+    @Param("status") Status status
+);
+
+// Native Query (최후의 수단)
+@Query(value = """
+    SELECT u.*, COUNT(r.id) as resource_count 
+    FROM users u 
+    LEFT JOIN resources r ON u.id = r.user_id 
+    WHERE u.status = :status 
+    GROUP BY u.id
+    """, nativeQuery = true)
+List<Object[]> findUsersWithResourceCount(@Param("status") String status);
+```
+
+### 5. 파라미터 바인딩
+
+```java
+// ✅ @Param 사용 (명시적, 권장)
+@Query("SELECT u FROM User u WHERE u.username = :username")
+Optional<User> findByUsername(@Param("username") String username);
+
+// ✅ 위치 기반 파라미터 (간단한 경우)
+@Query("SELECT u FROM User u WHERE u.username = ?1")
+Optional<User> findByUsername(String username);
+
+// ❌ SQL Injection 위험 (절대 금지)
+@Query("SELECT u FROM User u WHERE u.username = '" + username + "'")  // 위험!
+```
+
+### 6. 주석 작성
+
+```java
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    
+    /**
+     * 사용자명으로 사용자 조회
+     * @param username 사용자명
+     * @return 사용자 정보 (Optional)
+     */
+    Optional<User> findByUsername(String username);
+    
+    /**
+     * 테넌트별 활성 사용자 목록 조회
+     * 삭제되지 않은 사용자만 포함
+     * @param tenant 테넌트
+     * @param status 사용자 상태
+     * @return 활성 사용자 목록
+     */
+    @Query("SELECT u FROM User u WHERE u.tenant = :tenant AND u.status = :status AND u.isDeleted = false")
+    List<User> findActiveUsersByTenant(
+        @Param("tenant") Tenant tenant, 
+        @Param("status") Status status
+    );
+}
+```
+
+## 전체 예시
+
+```java
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    
+    /**
+     * 사용자명으로 사용자 조회
+     */
+    Optional<User> findByUsername(String username);
+    
+    /**
+     * 이메일로 사용자 조회
+     */
+    Optional<User> findByEmail(String email);
+    
+    /**
+     * 테넌트로 사용자 목록 조회
+     */
+    List<User> findByTenant(Tenant tenant);
+    
+    /**
+     * 역할로 사용자 목록 조회
+     */
+    List<User> findByRole(UserRole role);
+    
+    /**
+     * 상태로 사용자 목록 조회
+     */
+    List<User> findByStatus(Status status);
+    
+    /**
+     * 테넌트별 활성 사용자 조회
+     */
+    @Query("SELECT u FROM User u WHERE u.tenant = :tenant AND u.status = :status AND u.isDeleted = false")
+    List<User> findActiveUsersByTenant(
+        @Param("tenant") Tenant tenant, 
+        @Param("status") Status status
+    );
+    
+    /**
+     * 역할별 활성 사용자 조회
+     */
+    @Query("SELECT u FROM User u WHERE u.role = :role AND u.status = :status AND u.isDeleted = false")
+    List<User> findActiveUsersByRole(
+        @Param("role") UserRole role, 
+        @Param("status") Status status
+    );
+    
+    /**
+     * 비활성 사용자 조회 (특정 날짜 이전 마지막 로그인)
+     */
+    @Query("SELECT u FROM User u WHERE u.lastLogin < :before AND u.status = :status")
+    List<User> findInactiveUsers(
+        @Param("before") LocalDateTime before, 
+        @Param("status") Status status
+    );
+    
+    /**
+     * 로그인 실패 횟수가 많은 사용자 조회
+     */
+    @Query("SELECT u FROM User u WHERE u.failedLoginAttempts >= :maxAttempts AND u.status = :status")
+    List<User> findLockedUsers(
+        @Param("maxAttempts") Integer maxAttempts, 
+        @Param("status") Status status
+    );
+    
+    /**
+     * 테넌트별 활성 사용자 수
+     */
+    @Query("SELECT COUNT(u) FROM User u WHERE u.tenant = :tenant AND u.status = :status AND u.isDeleted = false")
+    Long countActiveUsersByTenant(
+        @Param("tenant") Tenant tenant, 
+        @Param("status") Status status
+    );
+    
+    /**
+     * 키워드로 사용자 검색 (사용자명, 이메일, 이름)
+     */
+    @Query("SELECT u FROM User u WHERE u.username LIKE %:keyword% OR u.email LIKE %:keyword% OR u.name LIKE %:keyword%")
+    List<User> searchUsers(@Param("keyword") String keyword);
+    
+    /**
+     * 사용자명 중복 검사
+     */
+    boolean existsByUsername(String username);
+    
+    /**
+     * 이메일 중복 검사
+     */
+    boolean existsByEmail(String email);
+}
+```

--- a/.cursor/rules/service-pattern.mdc
+++ b/.cursor/rules/service-pattern.mdc
@@ -1,0 +1,542 @@
+---
+alwaysApply: false
+---
+
+# Service Pattern (서비스 패턴)
+
+## 기본 구조
+
+```java
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ResourceService {
+    
+    private final ResourceRepository resourceRepository;
+    
+    public Resource getResourceById(Long id) {
+        log.info("[ResourceService] getResourceById - id={}", id);
+        Resource resource = resourceRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(ResourceErrorCode.RESOURCE_NOT_FOUND));
+        log.info("[ResourceService] getResourceById - success id={}", id);
+        return resource;
+    }
+    
+    @Transactional
+    public Resource createResource(ResourceCreateRequest request) {
+        log.info("[ResourceService] createResource - name={}", request.getName());
+        
+        // 비즈니스 검증
+        validateResourceUniqueness(request);
+        
+        // 엔티티 생성
+        Resource resource = Resource.builder()
+                .name(request.getName())
+                .status(Status.ACTIVE)
+                .build();
+        
+        Resource saved = resourceRepository.save(resource);
+        log.info("[ResourceService] createResource - success id={}", saved.getId());
+        return saved;
+    }
+}
+```
+
+## 필수 규칙
+
+### 1. 클래스 레벨 어노테이션
+- `@Slf4j`: 로깅 필수
+- `@Service`: 서비스 레이어 선언
+- `@RequiredArgsConstructor`: 생성자 주입 (필드 주입 금지)
+- `@Transactional(readOnly = true)`: 클래스 레벨에 기본 읽기 전용 설정
+
+### 2. 트랜잭션 관리
+- **기본**: 클래스 레벨에 `@Transactional(readOnly = true)`
+- **조회 메서드**: 별도 어노테이션 불필요 (클래스 레벨 상속)
+- **쓰기 메서드**: `@Transactional` 명시 (readOnly=false가 기본)
+
+```java
+@Transactional(readOnly = true)  // 클래스 레벨
+public class UserService {
+    
+    public User getUserById(Long id) {
+        // readOnly=true (클래스 레벨 상속)
+    }
+    
+    @Transactional  // 메서드 레벨로 오버라이드
+    public User createUser(UserCreateRequest request) {
+        // readOnly=false (쓰기 가능)
+    }
+}
+```
+
+### 3. 의존성 주입
+
+```java
+// ✅ 생성자 주입 (권장)
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final EmailService emailService;
+}
+
+// ❌ 필드 주입 (금지)
+@Service
+public class UserService {
+    @Autowired
+    private UserRepository userRepository;
+}
+```
+
+### 4. 로깅 패턴
+
+```java
+public Resource getResource(Long id) {
+    // 진입 로그
+    log.info("[ServiceName] methodName - id={}", id);
+    
+    // 비즈니스 로직
+    Resource resource = resourceRepository.findById(id)
+            .orElseThrow(() -> new ResourceNotFoundException(ResourceErrorCode.RESOURCE_NOT_FOUND));
+    
+    // 성공 로그
+    log.info("[ServiceName] methodName - success id={}", id);
+    return resource;
+}
+
+// 민감정보 마스킹
+log.info("[UserService] getUserByEmail - email={}", LogMaskingUtils.mask(email, 2, 2));
+log.info("[TenantService] getTenant - tenantKey={}", LogMaskingUtils.maskTenantKey(tenantKey));
+```
+
+### 5. 예외 처리
+
+```java
+// ✅ 명확한 예외 던지기
+public User getUserByIdOrThrow(Long id) {
+    return userRepository.findById(id)
+            .orElseThrow(() -> new ResourceNotFoundException(UserErrorCode.USER_NOT_FOUND));
+}
+
+// ✅ 비즈니스 검증
+public void createUser(UserCreateRequest request) {
+    if (userRepository.existsByUsername(request.getUsername())) {
+        throw new BusinessException(UserErrorCode.DUPLICATE_USERNAME);
+    }
+}
+
+// ❌ 예외 무시 (금지)
+public User getUser(Long id) {
+    try {
+        return userRepository.findById(id).orElse(null);
+    } catch (Exception e) {
+        return null;  // 예외 숨김 - 절대 금지
+    }
+}
+```
+
+### 6. 메서드 명명 규칙
+- **조회 (단건)**: `getXxxById`, `getXxxByUsername`
+- **조회 (목록)**: `getAllXxx`, `getActiveXxx`, `getXxxByTenant`
+- **생성**: `createXxx`, `saveXxx`
+- **수정**: `updateXxx`, `modifyXxx`
+- **삭제**: `deleteXxx`, `removeXxx`
+- **상태 변경**: `activateXxx`, `suspendXxx`, `lockXxx`
+
+### 7. 비즈니스 로직 구조화
+
+```java
+@Transactional
+public User createUser(UserCreateRequest request) {
+    // 1. 로깅
+    log.info("[UserService] createUser - username={}", request.getUsername());
+    
+    // 2. 검증
+    validateUserUniqueness(request);
+    
+    // 3. 엔티티 생성
+    User user = buildUser(request);
+    
+    // 4. 저장
+    User saved = userRepository.save(user);
+    
+    // 5. 후속 처리 (이벤트, 알림 등)
+    publishUserCreatedEvent(saved);
+    
+    // 6. 성공 로깅
+    log.info("[UserService] createUser - success userId={}", saved.getId());
+    return saved;
+}
+
+// 검증 로직 분리
+private void validateUserUniqueness(UserCreateRequest request) {
+    if (userRepository.existsByUsername(request.getUsername())) {
+        throw new BusinessException(UserErrorCode.DUPLICATE_USERNAME);
+    }
+    if (userRepository.existsByEmail(request.getEmail())) {
+        throw new BusinessException(UserErrorCode.DUPLICATE_EMAIL);
+    }
+}
+
+// 빌더 로직 분리
+private User buildUser(UserCreateRequest request) {
+    return User.builder()
+            .username(request.getUsername())
+            .email(request.getEmail())
+            .name(request.getName())
+            .passwordHash(passwordEncoder.encode(request.getPassword()))
+            .status(Status.ACTIVE)
+            .role(UserRole.VIEWER)
+            .build();
+}
+```
+
+## 전체 예시
+
+```java
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+    
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    
+    public List<User> getAllUsers() {
+        log.info("[UserService] getAllUsers");
+        List<User> result = userRepository.findAll();
+        log.info("[UserService] getAllUsers - success count={}", result.size());
+        return result;
+    }
+    
+    public User getUserByIdOrThrow(Long id) {
+        log.info("[UserService] getUserByIdOrThrow - id={}", id);
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(UserErrorCode.USER_NOT_FOUND));
+        log.info("[UserService] getUserByIdOrThrow - success id={}", id);
+        return user;
+    }
+    
+    @Transactional
+    public User createUser(UserCreateRequest request) {
+        log.info("[UserService] createUser - username={}", 
+                LogMaskingUtils.mask(request.getUsername(), 2, 2));
+        
+        validateUserUniqueness(request);
+        
+        User user = User.builder()
+                .username(request.getUsername())
+                .email(request.getEmail())
+                .passwordHash(passwordEncoder.encode(request.getPassword()))
+                .status(Status.ACTIVE)
+                .build();
+        
+        User saved = userRepository.save(user);
+        log.info("[UserService] createUser - success userId={}", saved.getId());
+        return saved;
+    }
+    
+    @Transactional
+    public User updateUser(Long id, UserUpdateRequest request) {
+        log.info("[UserService] updateUser - id={}", id);
+        
+        User user = getUserByIdOrThrow(id);
+        user.setName(request.getName());
+        user.setEmail(request.getEmail());
+        
+        User saved = userRepository.save(user);
+        log.info("[UserService] updateUser - success id={}", id);
+        return saved;
+    }
+    
+    @Transactional
+    public void deleteUser(Long id) {
+        log.info("[UserService] deleteUser - id={}", id);
+        User user = getUserByIdOrThrow(id);
+        user.setIsDeleted(true);
+        userRepository.save(user);
+        log.info("[UserService] deleteUser - success id={}", id);
+    }
+    
+    private void validateUserUniqueness(UserCreateRequest request) {
+        if (userRepository.existsByUsername(request.getUsername())) {
+            throw new BusinessException(UserErrorCode.DUPLICATE_USERNAME);
+        }
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new BusinessException(UserErrorCode.DUPLICATE_EMAIL);
+        }
+    }
+}
+```
+# Service Pattern (서비스 패턴)
+
+## 기본 구조
+
+```java
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ResourceService {
+    
+    private final ResourceRepository resourceRepository;
+    
+    public Resource getResourceById(Long id) {
+        log.info("[ResourceService] getResourceById - id={}", id);
+        Resource resource = resourceRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(ResourceErrorCode.RESOURCE_NOT_FOUND));
+        log.info("[ResourceService] getResourceById - success id={}", id);
+        return resource;
+    }
+    
+    @Transactional
+    public Resource createResource(ResourceCreateRequest request) {
+        log.info("[ResourceService] createResource - name={}", request.getName());
+        
+        // 비즈니스 검증
+        validateResourceUniqueness(request);
+        
+        // 엔티티 생성
+        Resource resource = Resource.builder()
+                .name(request.getName())
+                .status(Status.ACTIVE)
+                .build();
+        
+        Resource saved = resourceRepository.save(resource);
+        log.info("[ResourceService] createResource - success id={}", saved.getId());
+        return saved;
+    }
+}
+```
+
+## 필수 규칙
+
+### 1. 클래스 레벨 어노테이션
+- `@Slf4j`: 로깅 필수
+- `@Service`: 서비스 레이어 선언
+- `@RequiredArgsConstructor`: 생성자 주입 (필드 주입 금지)
+- `@Transactional(readOnly = true)`: 클래스 레벨에 기본 읽기 전용 설정
+
+### 2. 트랜잭션 관리
+- **기본**: 클래스 레벨에 `@Transactional(readOnly = true)`
+- **조회 메서드**: 별도 어노테이션 불필요 (클래스 레벨 상속)
+- **쓰기 메서드**: `@Transactional` 명시 (readOnly=false가 기본)
+
+```java
+@Transactional(readOnly = true)  // 클래스 레벨
+public class UserService {
+    
+    public User getUserById(Long id) {
+        // readOnly=true (클래스 레벨 상속)
+    }
+    
+    @Transactional  // 메서드 레벨로 오버라이드
+    public User createUser(UserCreateRequest request) {
+        // readOnly=false (쓰기 가능)
+    }
+}
+```
+
+### 3. 의존성 주입
+
+```java
+// ✅ 생성자 주입 (권장)
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final EmailService emailService;
+}
+
+// ❌ 필드 주입 (금지)
+@Service
+public class UserService {
+    @Autowired
+    private UserRepository userRepository;
+}
+```
+
+### 4. 로깅 패턴
+
+```java
+public Resource getResource(Long id) {
+    // 진입 로그
+    log.info("[ServiceName] methodName - id={}", id);
+    
+    // 비즈니스 로직
+    Resource resource = resourceRepository.findById(id)
+            .orElseThrow(() -> new ResourceNotFoundException(ResourceErrorCode.RESOURCE_NOT_FOUND));
+    
+    // 성공 로그
+    log.info("[ServiceName] methodName - success id={}", id);
+    return resource;
+}
+
+// 민감정보 마스킹
+log.info("[UserService] getUserByEmail - email={}", LogMaskingUtils.mask(email, 2, 2));
+log.info("[TenantService] getTenant - tenantKey={}", LogMaskingUtils.maskTenantKey(tenantKey));
+```
+
+### 5. 예외 처리
+
+```java
+// ✅ 명확한 예외 던지기
+public User getUserByIdOrThrow(Long id) {
+    return userRepository.findById(id)
+            .orElseThrow(() -> new ResourceNotFoundException(UserErrorCode.USER_NOT_FOUND));
+}
+
+// ✅ 비즈니스 검증
+public void createUser(UserCreateRequest request) {
+    if (userRepository.existsByUsername(request.getUsername())) {
+        throw new BusinessException(UserErrorCode.DUPLICATE_USERNAME);
+    }
+}
+
+// ❌ 예외 무시 (금지)
+public User getUser(Long id) {
+    try {
+        return userRepository.findById(id).orElse(null);
+    } catch (Exception e) {
+        return null;  // 예외 숨김 - 절대 금지
+    }
+}
+```
+
+### 6. 메서드 명명 규칙
+- **조회 (단건)**: `getXxxById`, `getXxxByUsername`
+- **조회 (목록)**: `getAllXxx`, `getActiveXxx`, `getXxxByTenant`
+- **생성**: `createXxx`, `saveXxx`
+- **수정**: `updateXxx`, `modifyXxx`
+- **삭제**: `deleteXxx`, `removeXxx`
+- **상태 변경**: `activateXxx`, `suspendXxx`, `lockXxx`
+
+### 7. 비즈니스 로직 구조화
+
+```java
+@Transactional
+public User createUser(UserCreateRequest request) {
+    // 1. 로깅
+    log.info("[UserService] createUser - username={}", request.getUsername());
+    
+    // 2. 검증
+    validateUserUniqueness(request);
+    
+    // 3. 엔티티 생성
+    User user = buildUser(request);
+    
+    // 4. 저장
+    User saved = userRepository.save(user);
+    
+    // 5. 후속 처리 (이벤트, 알림 등)
+    publishUserCreatedEvent(saved);
+    
+    // 6. 성공 로깅
+    log.info("[UserService] createUser - success userId={}", saved.getId());
+    return saved;
+}
+
+// 검증 로직 분리
+private void validateUserUniqueness(UserCreateRequest request) {
+    if (userRepository.existsByUsername(request.getUsername())) {
+        throw new BusinessException(UserErrorCode.DUPLICATE_USERNAME);
+    }
+    if (userRepository.existsByEmail(request.getEmail())) {
+        throw new BusinessException(UserErrorCode.DUPLICATE_EMAIL);
+    }
+}
+
+// 빌더 로직 분리
+private User buildUser(UserCreateRequest request) {
+    return User.builder()
+            .username(request.getUsername())
+            .email(request.getEmail())
+            .name(request.getName())
+            .passwordHash(passwordEncoder.encode(request.getPassword()))
+            .status(Status.ACTIVE)
+            .role(UserRole.VIEWER)
+            .build();
+}
+```
+
+## 전체 예시
+
+```java
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+    
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    
+    public List<User> getAllUsers() {
+        log.info("[UserService] getAllUsers");
+        List<User> result = userRepository.findAll();
+        log.info("[UserService] getAllUsers - success count={}", result.size());
+        return result;
+    }
+    
+    public User getUserByIdOrThrow(Long id) {
+        log.info("[UserService] getUserByIdOrThrow - id={}", id);
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(UserErrorCode.USER_NOT_FOUND));
+        log.info("[UserService] getUserByIdOrThrow - success id={}", id);
+        return user;
+    }
+    
+    @Transactional
+    public User createUser(UserCreateRequest request) {
+        log.info("[UserService] createUser - username={}", 
+                LogMaskingUtils.mask(request.getUsername(), 2, 2));
+        
+        validateUserUniqueness(request);
+        
+        User user = User.builder()
+                .username(request.getUsername())
+                .email(request.getEmail())
+                .passwordHash(passwordEncoder.encode(request.getPassword()))
+                .status(Status.ACTIVE)
+                .build();
+        
+        User saved = userRepository.save(user);
+        log.info("[UserService] createUser - success userId={}", saved.getId());
+        return saved;
+    }
+    
+    @Transactional
+    public User updateUser(Long id, UserUpdateRequest request) {
+        log.info("[UserService] updateUser - id={}", id);
+        
+        User user = getUserByIdOrThrow(id);
+        user.setName(request.getName());
+        user.setEmail(request.getEmail());
+        
+        User saved = userRepository.save(user);
+        log.info("[UserService] updateUser - success id={}", id);
+        return saved;
+    }
+    
+    @Transactional
+    public void deleteUser(Long id) {
+        log.info("[UserService] deleteUser - id={}", id);
+        User user = getUserByIdOrThrow(id);
+        user.setIsDeleted(true);
+        userRepository.save(user);
+        log.info("[UserService] deleteUser - success id={}", id);
+    }
+    
+    private void validateUserUniqueness(UserCreateRequest request) {
+        if (userRepository.existsByUsername(request.getUsername())) {
+            throw new BusinessException(UserErrorCode.DUPLICATE_USERNAME);
+        }
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new BusinessException(UserErrorCode.DUPLICATE_EMAIL);
+        }
+    }
+}
+```

--- a/.cursor/rules/unittest-pattern.mdc
+++ b/.cursor/rules/unittest-pattern.mdc
@@ -1,0 +1,983 @@
+---
+alwaysApply: false
+---
+# UnitTest Pattern (단위 테스트 패턴)
+
+## 기본 구조
+
+```java
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService 테스트")
+class UserServiceTest {
+    
+    @Mock
+    private UserRepository userRepository;
+    
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    
+    @InjectMocks
+    private UserService userService;
+    
+    @Nested
+    @DisplayName("사용자 생성 테스트")
+    class CreateUserTest {
+        
+        @Test
+        @DisplayName("정상적인 사용자 생성")
+        void createUser_WithValidRequest_Success() {
+            // Given
+            UserCreateRequest request = UserCreateRequest.builder()
+                    .username("testuser")
+                    .email("test@example.com")
+                    .name("테스트 사용자")
+                    .build();
+            
+            User savedUser = User.builder()
+                    .id(1L)
+                    .username("testuser")
+                    .email("test@example.com")
+                    .name("테스트 사용자")
+                    .status(Status.ACTIVE)
+                    .build();
+            
+            when(userRepository.existsByUsername("testuser")).thenReturn(false);
+            when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
+            when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
+            when(userRepository.save(any(User.class))).thenReturn(savedUser);
+            
+            // When
+            User result = userService.createUser(request);
+            
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getUsername()).isEqualTo("testuser");
+            assertThat(result.getEmail()).isEqualTo("test@example.com");
+            assertThat(result.getStatus()).isEqualTo(Status.ACTIVE);
+            
+            verify(userRepository).existsByUsername("testuser");
+            verify(userRepository).existsByEmail("test@example.com");
+            verify(userRepository).save(any(User.class));
+        }
+        
+        @Test
+        @DisplayName("중복된 사용자명으로 생성 시 예외 발생")
+        void createUser_WithDuplicateUsername_ThrowsException() {
+            // Given
+            UserCreateRequest request = UserCreateRequest.builder()
+                    .username("testuser")
+                    .email("test@example.com")
+                    .name("테스트 사용자")
+                    .build();
+            
+            when(userRepository.existsByUsername("testuser")).thenReturn(true);
+            
+            // When & Then
+            assertThatThrownBy(() -> userService.createUser(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("이미 사용 중인 사용자명");
+            
+            verify(userRepository).existsByUsername("testuser");
+            verify(userRepository, never()).save(any(User.class));
+        }
+    }
+    
+    @Nested
+    @DisplayName("사용자 조회 테스트")
+    class GetUserTest {
+        
+        @Test
+        @DisplayName("존재하는 사용자 조회 성공")
+        void getUserById_WithExistingUser_ReturnsUser() {
+            // Given
+            User user = User.builder()
+                    .id(1L)
+                    .username("testuser")
+                    .email("test@example.com")
+                    .build();
+            
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            
+            // When
+            User result = userService.getUserByIdOrThrow(1L);
+            
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getUsername()).isEqualTo("testuser");
+            verify(userRepository).findById(1L);
+        }
+        
+        @Test
+        @DisplayName("존재하지 않는 사용자 조회 시 예외 발생")
+        void getUserById_WithNonExistingUser_ThrowsException() {
+            // Given
+            when(userRepository.findById(999L)).thenReturn(Optional.empty());
+            
+            // When & Then
+            assertThatThrownBy(() -> userService.getUserByIdOrThrow(999L))
+                    .isInstanceOf(ResourceNotFoundException.class);
+            
+            verify(userRepository).findById(999L);
+        }
+    }
+}
+```
+
+## 필수 규칙
+
+### 1. 테스트 클래스 구조
+
+```java
+@ExtendWith(MockitoExtension.class)  // Mockito 사용
+@DisplayName("클래스명 테스트")
+class ServiceNameTest {
+    
+    @Mock
+    private Dependency1 dependency1;
+    
+    @Mock
+    private Dependency2 dependency2;
+    
+    @InjectMocks
+    private ServiceName serviceUnderTest;
+    
+    // @Nested로 테스트 그룹화
+    @Nested
+    @DisplayName("기능별 테스트 그룹")
+    class FeatureTest {
+        
+        @BeforeEach
+        void setUp() {
+            // 각 테스트 전 실행
+        }
+        
+        @Test
+        @DisplayName("구체적인 테스트 시나리오 설명")
+        void testMethod_WithCondition_ExpectedResult() {
+            // Given-When-Then 패턴
+        }
+    }
+}
+```
+
+### 2. Given-When-Then 패턴
+
+```java
+@Test
+@DisplayName("사용자 생성 성공")
+void createUser_Success() {
+    // Given: 테스트에 필요한 데이터와 Mock 설정
+    UserCreateRequest request = buildUserCreateRequest();
+    User expectedUser = buildUser();
+    when(userRepository.save(any(User.class))).thenReturn(expectedUser);
+    
+    // When: 테스트 대상 메서드 실행
+    User result = userService.createUser(request);
+    
+    // Then: 결과 검증
+    assertThat(result).isNotNull();
+    assertThat(result.getUsername()).isEqualTo("testuser");
+    verify(userRepository).save(any(User.class));
+}
+```
+
+### 3. Mock 설정
+
+```java
+// 반환값 설정
+when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+// 예외 던지기
+when(userRepository.findById(999L))
+    .thenThrow(new ResourceNotFoundException(UserErrorCode.USER_NOT_FOUND));
+
+// void 메서드
+doNothing().when(emailService).sendEmail(any());
+doThrow(new RuntimeException()).when(emailService).sendEmail(any());
+
+// 순차적 반환
+when(userRepository.findById(1L))
+    .thenReturn(Optional.of(user))
+    .thenReturn(Optional.empty());
+```
+
+### 4. Assertion (검증)
+
+```java
+// AssertJ 사용 (권장)
+assertThat(result).isNotNull();
+assertThat(result.getUsername()).isEqualTo("testuser");
+assertThat(result.getStatus()).isEqualTo(Status.ACTIVE);
+assertThat(result.getRoles()).hasSize(1);
+assertThat(result.getRoles()).contains(UserRole.VIEWER);
+
+// 예외 검증
+assertThatThrownBy(() -> userService.createUser(request))
+    .isInstanceOf(BusinessException.class)
+    .hasMessage("이미 사용 중인 사용자명입니다");
+
+// Mock 호출 검증
+verify(userRepository).save(any(User.class));
+verify(userRepository, times(1)).findById(1L);
+verify(userRepository, never()).delete(any(User.class));
+verify(emailService).sendWelcomeEmail(any(User.class));
+```
+
+### 5. 테스트 메서드 명명 규칙
+
+```java
+// 패턴: methodName_WithCondition_ExpectedResult
+void createUser_WithValidRequest_Success()
+void createUser_WithDuplicateUsername_ThrowsException()
+void getUserById_WithExistingId_ReturnsUser()
+void getUserById_WithNonExistingId_ThrowsNotFoundException()
+void updateUser_WithInvalidStatus_ThrowsBusinessException()
+```
+
+### 6. 테스트 데이터 빌더
+
+```java
+public class TestDataBuilder {
+    
+    public static User.UserBuilder defaultUser() {
+        return User.builder()
+                .username("testuser")
+                .email("test@example.com")
+                .name("테스트 사용자")
+                .status(Status.ACTIVE)
+                .role(UserRole.VIEWER)
+                .createdAt(LocalDateTime.now());
+    }
+    
+    public static UserCreateRequest.UserCreateRequestBuilder defaultUserCreateRequest() {
+        return UserCreateRequest.builder()
+                .username("newuser")
+                .email("new@example.com")
+                .name("새 사용자")
+                .password("password123");
+    }
+}
+
+// 사용
+@Test
+void testWithBuilder() {
+    User user = TestDataBuilder.defaultUser()
+            .username("customuser")
+            .build();
+    
+    UserCreateRequest request = TestDataBuilder.defaultUserCreateRequest()
+            .email("custom@example.com")
+            .build();
+}
+```
+
+### 7. 통합 테스트 (참고)
+
+```java
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+@DisplayName("UserController 통합 테스트")
+class UserControllerIntegrationTest {
+    
+    @Autowired
+    private TestRestTemplate restTemplate;
+    
+    @Autowired
+    private UserRepository userRepository;
+    
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+    }
+    
+    @Test
+    @DisplayName("사용자 생성 API 테스트")
+    void createUser_Success() {
+        // Given
+        UserCreateRequest request = UserCreateRequest.builder()
+                .username("apiuser")
+                .email("api@example.com")
+                .name("API 사용자")
+                .build();
+        
+        // When
+        ResponseEntity<ApiResponse> response = restTemplate.postForEntity(
+                "/api/v1/users", request, ApiResponse.class);
+        
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody().isSuccess()).isTrue();
+        
+        // DB 검증
+        List<User> users = userRepository.findAll();
+        assertThat(users).hasSize(1);
+        assertThat(users.get(0).getUsername()).isEqualTo("apiuser");
+    }
+}
+```
+
+## 전체 예시
+
+```java
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService 단위 테스트")
+class UserServiceTest {
+    
+    @Mock
+    private UserRepository userRepository;
+    
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    
+    @Mock
+    private EmailService emailService;
+    
+    @InjectMocks
+    private UserService userService;
+    
+    @Nested
+    @DisplayName("사용자 생성 테스트")
+    class CreateUserTest {
+        
+        private UserCreateRequest request;
+        private User savedUser;
+        
+        @BeforeEach
+        void setUp() {
+            request = UserCreateRequest.builder()
+                    .username("testuser")
+                    .email("test@example.com")
+                    .name("테스트 사용자")
+                    .password("password123")
+                    .build();
+            
+            savedUser = User.builder()
+                    .id(1L)
+                    .username("testuser")
+                    .email("test@example.com")
+                    .name("테스트 사용자")
+                    .status(Status.ACTIVE)
+                    .build();
+        }
+        
+        @Test
+        @DisplayName("정상적인 사용자 생성")
+        void createUser_Success() {
+            // Given
+            when(userRepository.existsByUsername("testuser")).thenReturn(false);
+            when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
+            when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
+            when(userRepository.save(any(User.class))).thenReturn(savedUser);
+            doNothing().when(emailService).sendWelcomeEmail(any(User.class));
+            
+            // When
+            User result = userService.createUser(request);
+            
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getId()).isEqualTo(1L);
+            assertThat(result.getUsername()).isEqualTo("testuser");
+            assertThat(result.getEmail()).isEqualTo("test@example.com");
+            assertThat(result.getStatus()).isEqualTo(Status.ACTIVE);
+            
+            verify(userRepository).existsByUsername("testuser");
+            verify(userRepository).existsByEmail("test@example.com");
+            verify(passwordEncoder).encode("password123");
+            verify(userRepository).save(any(User.class));
+            verify(emailService).sendWelcomeEmail(savedUser);
+        }
+        
+        @Test
+        @DisplayName("중복된 사용자명으로 생성 시 예외 발생")
+        void createUser_DuplicateUsername_ThrowsException() {
+            // Given
+            when(userRepository.existsByUsername("testuser")).thenReturn(true);
+            
+            // When & Then
+            assertThatThrownBy(() -> userService.createUser(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("이미 사용 중인 사용자명");
+            
+            verify(userRepository).existsByUsername("testuser");
+            verify(userRepository, never()).save(any(User.class));
+            verify(emailService, never()).sendWelcomeEmail(any(User.class));
+        }
+        
+        @Test
+        @DisplayName("중복된 이메일로 생성 시 예외 발생")
+        void createUser_DuplicateEmail_ThrowsException() {
+            // Given
+            when(userRepository.existsByUsername("testuser")).thenReturn(false);
+            when(userRepository.existsByEmail("test@example.com")).thenReturn(true);
+            
+            // When & Then
+            assertThatThrownBy(() -> userService.createUser(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("이미 사용 중인 이메일");
+            
+            verify(userRepository).existsByUsername("testuser");
+            verify(userRepository).existsByEmail("test@example.com");
+            verify(userRepository, never()).save(any(User.class));
+        }
+    }
+    
+    @Nested
+    @DisplayName("사용자 조회 테스트")
+    class GetUserTest {
+        
+        @Test
+        @DisplayName("ID로 사용자 조회 성공")
+        void getUserById_Success() {
+            // Given
+            User user = User.builder()
+                    .id(1L)
+                    .username("testuser")
+                    .email("test@example.com")
+                    .build();
+            
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            
+            // When
+            User result = userService.getUserByIdOrThrow(1L);
+            
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getId()).isEqualTo(1L);
+            assertThat(result.getUsername()).isEqualTo("testuser");
+            
+            verify(userRepository).findById(1L);
+        }
+        
+        @Test
+        @DisplayName("존재하지 않는 ID로 조회 시 예외 발생")
+        void getUserById_NotFound_ThrowsException() {
+            // Given
+            when(userRepository.findById(999L)).thenReturn(Optional.empty());
+            
+            // When & Then
+            assertThatThrownBy(() -> userService.getUserByIdOrThrow(999L))
+                    .isInstanceOf(ResourceNotFoundException.class);
+            
+            verify(userRepository).findById(999L);
+        }
+    }
+    
+    @Nested
+    @DisplayName("사용자 삭제 테스트")
+    class DeleteUserTest {
+        
+        @Test
+        @DisplayName("사용자 삭제 성공 (소프트 삭제)")
+        void deleteUser_Success() {
+            // Given
+            User user = User.builder()
+                    .id(1L)
+                    .username("testuser")
+                    .isDeleted(false)
+                    .build();
+            
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(userRepository.save(any(User.class))).thenReturn(user);
+            
+            // When
+            userService.deleteUser(1L);
+            
+            // Then
+            assertThat(user.getIsDeleted()).isTrue();
+            verify(userRepository).findById(1L);
+            verify(userRepository).save(user);
+        }
+    }
+}
+```
+# UnitTest Pattern (단위 테스트 패턴)
+
+## 기본 구조
+
+```java
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService 테스트")
+class UserServiceTest {
+    
+    @Mock
+    private UserRepository userRepository;
+    
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    
+    @InjectMocks
+    private UserService userService;
+    
+    @Nested
+    @DisplayName("사용자 생성 테스트")
+    class CreateUserTest {
+        
+        @Test
+        @DisplayName("정상적인 사용자 생성")
+        void createUser_WithValidRequest_Success() {
+            // Given
+            UserCreateRequest request = UserCreateRequest.builder()
+                    .username("testuser")
+                    .email("test@example.com")
+                    .name("테스트 사용자")
+                    .build();
+            
+            User savedUser = User.builder()
+                    .id(1L)
+                    .username("testuser")
+                    .email("test@example.com")
+                    .name("테스트 사용자")
+                    .status(Status.ACTIVE)
+                    .build();
+            
+            when(userRepository.existsByUsername("testuser")).thenReturn(false);
+            when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
+            when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
+            when(userRepository.save(any(User.class))).thenReturn(savedUser);
+            
+            // When
+            User result = userService.createUser(request);
+            
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getUsername()).isEqualTo("testuser");
+            assertThat(result.getEmail()).isEqualTo("test@example.com");
+            assertThat(result.getStatus()).isEqualTo(Status.ACTIVE);
+            
+            verify(userRepository).existsByUsername("testuser");
+            verify(userRepository).existsByEmail("test@example.com");
+            verify(userRepository).save(any(User.class));
+        }
+        
+        @Test
+        @DisplayName("중복된 사용자명으로 생성 시 예외 발생")
+        void createUser_WithDuplicateUsername_ThrowsException() {
+            // Given
+            UserCreateRequest request = UserCreateRequest.builder()
+                    .username("testuser")
+                    .email("test@example.com")
+                    .name("테스트 사용자")
+                    .build();
+            
+            when(userRepository.existsByUsername("testuser")).thenReturn(true);
+            
+            // When & Then
+            assertThatThrownBy(() -> userService.createUser(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("이미 사용 중인 사용자명");
+            
+            verify(userRepository).existsByUsername("testuser");
+            verify(userRepository, never()).save(any(User.class));
+        }
+    }
+    
+    @Nested
+    @DisplayName("사용자 조회 테스트")
+    class GetUserTest {
+        
+        @Test
+        @DisplayName("존재하는 사용자 조회 성공")
+        void getUserById_WithExistingUser_ReturnsUser() {
+            // Given
+            User user = User.builder()
+                    .id(1L)
+                    .username("testuser")
+                    .email("test@example.com")
+                    .build();
+            
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            
+            // When
+            User result = userService.getUserByIdOrThrow(1L);
+            
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getUsername()).isEqualTo("testuser");
+            verify(userRepository).findById(1L);
+        }
+        
+        @Test
+        @DisplayName("존재하지 않는 사용자 조회 시 예외 발생")
+        void getUserById_WithNonExistingUser_ThrowsException() {
+            // Given
+            when(userRepository.findById(999L)).thenReturn(Optional.empty());
+            
+            // When & Then
+            assertThatThrownBy(() -> userService.getUserByIdOrThrow(999L))
+                    .isInstanceOf(ResourceNotFoundException.class);
+            
+            verify(userRepository).findById(999L);
+        }
+    }
+}
+```
+
+## 필수 규칙
+
+### 1. 테스트 클래스 구조
+
+```java
+@ExtendWith(MockitoExtension.class)  // Mockito 사용
+@DisplayName("클래스명 테스트")
+class ServiceNameTest {
+    
+    @Mock
+    private Dependency1 dependency1;
+    
+    @Mock
+    private Dependency2 dependency2;
+    
+    @InjectMocks
+    private ServiceName serviceUnderTest;
+    
+    // @Nested로 테스트 그룹화
+    @Nested
+    @DisplayName("기능별 테스트 그룹")
+    class FeatureTest {
+        
+        @BeforeEach
+        void setUp() {
+            // 각 테스트 전 실행
+        }
+        
+        @Test
+        @DisplayName("구체적인 테스트 시나리오 설명")
+        void testMethod_WithCondition_ExpectedResult() {
+            // Given-When-Then 패턴
+        }
+    }
+}
+```
+
+### 2. Given-When-Then 패턴
+
+```java
+@Test
+@DisplayName("사용자 생성 성공")
+void createUser_Success() {
+    // Given: 테스트에 필요한 데이터와 Mock 설정
+    UserCreateRequest request = buildUserCreateRequest();
+    User expectedUser = buildUser();
+    when(userRepository.save(any(User.class))).thenReturn(expectedUser);
+    
+    // When: 테스트 대상 메서드 실행
+    User result = userService.createUser(request);
+    
+    // Then: 결과 검증
+    assertThat(result).isNotNull();
+    assertThat(result.getUsername()).isEqualTo("testuser");
+    verify(userRepository).save(any(User.class));
+}
+```
+
+### 3. Mock 설정
+
+```java
+// 반환값 설정
+when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+// 예외 던지기
+when(userRepository.findById(999L))
+    .thenThrow(new ResourceNotFoundException(UserErrorCode.USER_NOT_FOUND));
+
+// void 메서드
+doNothing().when(emailService).sendEmail(any());
+doThrow(new RuntimeException()).when(emailService).sendEmail(any());
+
+// 순차적 반환
+when(userRepository.findById(1L))
+    .thenReturn(Optional.of(user))
+    .thenReturn(Optional.empty());
+```
+
+### 4. Assertion (검증)
+
+```java
+// AssertJ 사용 (권장)
+assertThat(result).isNotNull();
+assertThat(result.getUsername()).isEqualTo("testuser");
+assertThat(result.getStatus()).isEqualTo(Status.ACTIVE);
+assertThat(result.getRoles()).hasSize(1);
+assertThat(result.getRoles()).contains(UserRole.VIEWER);
+
+// 예외 검증
+assertThatThrownBy(() -> userService.createUser(request))
+    .isInstanceOf(BusinessException.class)
+    .hasMessage("이미 사용 중인 사용자명입니다");
+
+// Mock 호출 검증
+verify(userRepository).save(any(User.class));
+verify(userRepository, times(1)).findById(1L);
+verify(userRepository, never()).delete(any(User.class));
+verify(emailService).sendWelcomeEmail(any(User.class));
+```
+
+### 5. 테스트 메서드 명명 규칙
+
+```java
+// 패턴: methodName_WithCondition_ExpectedResult
+void createUser_WithValidRequest_Success()
+void createUser_WithDuplicateUsername_ThrowsException()
+void getUserById_WithExistingId_ReturnsUser()
+void getUserById_WithNonExistingId_ThrowsNotFoundException()
+void updateUser_WithInvalidStatus_ThrowsBusinessException()
+```
+
+### 6. 테스트 데이터 빌더
+
+```java
+public class TestDataBuilder {
+    
+    public static User.UserBuilder defaultUser() {
+        return User.builder()
+                .username("testuser")
+                .email("test@example.com")
+                .name("테스트 사용자")
+                .status(Status.ACTIVE)
+                .role(UserRole.VIEWER)
+                .createdAt(LocalDateTime.now());
+    }
+    
+    public static UserCreateRequest.UserCreateRequestBuilder defaultUserCreateRequest() {
+        return UserCreateRequest.builder()
+                .username("newuser")
+                .email("new@example.com")
+                .name("새 사용자")
+                .password("password123");
+    }
+}
+
+// 사용
+@Test
+void testWithBuilder() {
+    User user = TestDataBuilder.defaultUser()
+            .username("customuser")
+            .build();
+    
+    UserCreateRequest request = TestDataBuilder.defaultUserCreateRequest()
+            .email("custom@example.com")
+            .build();
+}
+```
+
+### 7. 통합 테스트 (참고)
+
+```java
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+@DisplayName("UserController 통합 테스트")
+class UserControllerIntegrationTest {
+    
+    @Autowired
+    private TestRestTemplate restTemplate;
+    
+    @Autowired
+    private UserRepository userRepository;
+    
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+    }
+    
+    @Test
+    @DisplayName("사용자 생성 API 테스트")
+    void createUser_Success() {
+        // Given
+        UserCreateRequest request = UserCreateRequest.builder()
+                .username("apiuser")
+                .email("api@example.com")
+                .name("API 사용자")
+                .build();
+        
+        // When
+        ResponseEntity<ApiResponse> response = restTemplate.postForEntity(
+                "/api/v1/users", request, ApiResponse.class);
+        
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody().isSuccess()).isTrue();
+        
+        // DB 검증
+        List<User> users = userRepository.findAll();
+        assertThat(users).hasSize(1);
+        assertThat(users.get(0).getUsername()).isEqualTo("apiuser");
+    }
+}
+```
+
+## 전체 예시
+
+```java
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService 단위 테스트")
+class UserServiceTest {
+    
+    @Mock
+    private UserRepository userRepository;
+    
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    
+    @Mock
+    private EmailService emailService;
+    
+    @InjectMocks
+    private UserService userService;
+    
+    @Nested
+    @DisplayName("사용자 생성 테스트")
+    class CreateUserTest {
+        
+        private UserCreateRequest request;
+        private User savedUser;
+        
+        @BeforeEach
+        void setUp() {
+            request = UserCreateRequest.builder()
+                    .username("testuser")
+                    .email("test@example.com")
+                    .name("테스트 사용자")
+                    .password("password123")
+                    .build();
+            
+            savedUser = User.builder()
+                    .id(1L)
+                    .username("testuser")
+                    .email("test@example.com")
+                    .name("테스트 사용자")
+                    .status(Status.ACTIVE)
+                    .build();
+        }
+        
+        @Test
+        @DisplayName("정상적인 사용자 생성")
+        void createUser_Success() {
+            // Given
+            when(userRepository.existsByUsername("testuser")).thenReturn(false);
+            when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
+            when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
+            when(userRepository.save(any(User.class))).thenReturn(savedUser);
+            doNothing().when(emailService).sendWelcomeEmail(any(User.class));
+            
+            // When
+            User result = userService.createUser(request);
+            
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getId()).isEqualTo(1L);
+            assertThat(result.getUsername()).isEqualTo("testuser");
+            assertThat(result.getEmail()).isEqualTo("test@example.com");
+            assertThat(result.getStatus()).isEqualTo(Status.ACTIVE);
+            
+            verify(userRepository).existsByUsername("testuser");
+            verify(userRepository).existsByEmail("test@example.com");
+            verify(passwordEncoder).encode("password123");
+            verify(userRepository).save(any(User.class));
+            verify(emailService).sendWelcomeEmail(savedUser);
+        }
+        
+        @Test
+        @DisplayName("중복된 사용자명으로 생성 시 예외 발생")
+        void createUser_DuplicateUsername_ThrowsException() {
+            // Given
+            when(userRepository.existsByUsername("testuser")).thenReturn(true);
+            
+            // When & Then
+            assertThatThrownBy(() -> userService.createUser(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("이미 사용 중인 사용자명");
+            
+            verify(userRepository).existsByUsername("testuser");
+            verify(userRepository, never()).save(any(User.class));
+            verify(emailService, never()).sendWelcomeEmail(any(User.class));
+        }
+        
+        @Test
+        @DisplayName("중복된 이메일로 생성 시 예외 발생")
+        void createUser_DuplicateEmail_ThrowsException() {
+            // Given
+            when(userRepository.existsByUsername("testuser")).thenReturn(false);
+            when(userRepository.existsByEmail("test@example.com")).thenReturn(true);
+            
+            // When & Then
+            assertThatThrownBy(() -> userService.createUser(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("이미 사용 중인 이메일");
+            
+            verify(userRepository).existsByUsername("testuser");
+            verify(userRepository).existsByEmail("test@example.com");
+            verify(userRepository, never()).save(any(User.class));
+        }
+    }
+    
+    @Nested
+    @DisplayName("사용자 조회 테스트")
+    class GetUserTest {
+        
+        @Test
+        @DisplayName("ID로 사용자 조회 성공")
+        void getUserById_Success() {
+            // Given
+            User user = User.builder()
+                    .id(1L)
+                    .username("testuser")
+                    .email("test@example.com")
+                    .build();
+            
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            
+            // When
+            User result = userService.getUserByIdOrThrow(1L);
+            
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getId()).isEqualTo(1L);
+            assertThat(result.getUsername()).isEqualTo("testuser");
+            
+            verify(userRepository).findById(1L);
+        }
+        
+        @Test
+        @DisplayName("존재하지 않는 ID로 조회 시 예외 발생")
+        void getUserById_NotFound_ThrowsException() {
+            // Given
+            when(userRepository.findById(999L)).thenReturn(Optional.empty());
+            
+            // When & Then
+            assertThatThrownBy(() -> userService.getUserByIdOrThrow(999L))
+                    .isInstanceOf(ResourceNotFoundException.class);
+            
+            verify(userRepository).findById(999L);
+        }
+    }
+    
+    @Nested
+    @DisplayName("사용자 삭제 테스트")
+    class DeleteUserTest {
+        
+        @Test
+        @DisplayName("사용자 삭제 성공 (소프트 삭제)")
+        void deleteUser_Success() {
+            // Given
+            User user = User.builder()
+                    .id(1L)
+                    .username("testuser")
+                    .isDeleted(false)
+                    .build();
+            
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(userRepository.save(any(User.class))).thenReturn(user);
+            
+            // When
+            userService.deleteUser(1L);
+            
+            // Then
+            assertThat(user.getIsDeleted()).isTrue();
+            verify(userRepository).findById(1L);
+            verify(userRepository).save(user);
+        }
+    }
+}
+```

--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ CloudPlatform 2.0 Core Application - Spring Boot 기반의 멀티 클라우드 �
 
 ### 🚀 빠른 시작
 
+#### 환경변수 설정
+
+애플리케이션 실행 전에 필요한 환경변수를 설정해야 합니다:
+
+```bash
+# 환경변수 예시 파일 복사
+cp env.example .env
+
+# .env 파일을 편집하여 실제 값으로 변경
+# 특히 다음 값들은 반드시 변경하세요:
+# - DATABASE_PASSWORD: 안전한 데이터베이스 비밀번호
+# - JWT_SECRET: 안전한 JWT 시크릿 (base64 인코딩)
+# - CONFIG_CIPHER_KEY: 안전한 암호화 키 (base64 인코딩)
+```
+
 #### 방법 1: 하이브리드 모드 (권장) - 개발자 친화적
 ```bash
 # 1. 저장소 클론

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,12 +33,14 @@ services:
       - "8080:8080"
     environment:
       SPRING_PROFILES_ACTIVE: docker
-      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/agenticcp?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
-      SPRING_DATASOURCE_USERNAME: agenticcp
-      SPRING_DATASOURCE_PASSWORD: agenticcppassword
+      DATABASE_URL: jdbc:mysql://mysql:3306/agenticcp?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+      DATABASE_USERNAME: agenticcp
+      DATABASE_PASSWORD: agenticcppassword
       SPRING_DATA_REDIS_HOST: redis
       SPRING_DATA_REDIS_PORT: 6379
       APP_REDIS_ENABLED: "true"
+      JWT_SECRET: ZmFrZV9zZWNyZXRfZm9yX2Rldl9vbmx5X3VzZV9jaGFuZ2VfbWU=
+      CONFIG_CIPHER_KEY: MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=
     depends_on:
       mysql:
         condition: service_healthy

--- a/docs/AUDIT_LOGGING_GUIDE.md
+++ b/docs/AUDIT_LOGGING_GUIDE.md
@@ -1,0 +1,970 @@
+# AgenticCP 감사 로깅 가이드
+
+## 📋 목차
+
+1. [감사 로깅의 역할](#감사-로깅의-역할)
+2. [클래스 레벨 감사 로깅](#클래스-레벨-감사-로깅)
+3. [메서드 레벨 감사 로깅](#메서드-레벨-감사-로깅)
+4. [클래스와 메서드 레벨 조합 사용](#클래스와-메서드-레벨-조합-사용)
+5. [감사 로깅 저장 형식](#감사-로깅-저장-형식)
+6. [애플리케이션 로깅 vs 감사 로깅](#애플리케이션-로깅-vs-감사-로깅)
+7. [실제 사용 예시](#실제-사용-예시)
+8. [요약](#요약)
+
+---
+
+## 🎯 감사 로깅의 역할
+
+### 1. 감사 로깅이란?
+
+감사 로깅은 시스템의 중요한 작업과 이벤트를 기록하여 **보안, 컴플라이언스, 디버깅** 목적으로 사용되는 로깅 시스템입니다.
+
+### 2. 주요 목적
+
+- **보안 감사**: 사용자 행위 추적 및 보안 사고 대응
+- **컴플라이언스**: 규정 준수를 위한 감사 증적 생성
+- **운영 모니터링**: 시스템 사용 현황 및 성능 분석
+- **문제 해결**: 장애 발생 시 원인 분석 및 복구
+
+### 3. 감사 로깅 구조
+
+```mermaid
+graph TD
+    A[Controller Method] --> B{감사 로깅 적용}
+    B --> C[@AuditController 클래스 레벨]
+    B --> D[@AuditRequired 메서드 레벨]
+    C --> E[AuditAspect]
+    D --> E
+    E --> F[AuditService]
+    F --> G[AuditLogger]
+    G --> H[JSON 로그 출력]
+```
+
+---
+
+## 🏢 클래스 레벨 감사 로깅
+
+### 1. @AuditController 애노테이션
+
+클래스에 적용하여 **모든 메서드**에 자동으로 감사 로깅을 적용합니다.
+
+```java
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuditController {
+    AuditResourceType resourceType();              // 필수: 리소스 타입
+    AuditSeverity defaultSeverity() default AuditSeverity.MEDIUM;  // 심각도
+    boolean defaultIncludeRequestData() default false;             // 요청 데이터 포함 여부
+    boolean defaultIncludeResponseData() default false;            // 응답 데이터 포함 여부
+    String[] targetHttpMethods() default {"POST", "PUT", "PATCH", "DELETE"};  // 대상 HTTP 메서드
+    String[] excludeMethods() default {};          // 제외할 메서드명
+}
+```
+
+### 2. 언제 사용해야 하는가?
+
+**✅ 클래스 레벨 감사 로깅을 사용해야 하는 경우:**
+
+- **CRUD 컨트롤러**: 대부분의 메서드가 동일한 리소스 타입을 다룰 때
+- **관리자 기능**: 모든 작업이 중요하고 감사가 필요할 때
+- **보안 민감한 컨트롤러**: 모든 접근을 기록해야 할 때
+- **일관된 로깅**: 클래스 내 모든 메서드에 동일한 감사 정책 적용할 때
+
+**❌ 클래스 레벨 감사 로깅을 사용하지 말아야 하는 경우:**
+
+- **혼재된 리소스**: 서로 다른 리소스 타입을 다루는 메서드가 섞여 있을 때
+- **선택적 감사**: 일부 메서드만 감사가 필요할 때
+- **성능 민감**: 모든 메서드에 로깅이 성능에 영향을 줄 때
+
+### 3. 사용 예시
+
+```java
+// ✅ 좋은 예 - 사용자 관리 컨트롤러
+@RestController
+@RequestMapping("/api/v1/users")
+@AuditController(
+    resourceType = AuditResourceType.USER,
+    defaultSeverity = AuditSeverity.HIGH,
+    defaultIncludeRequestData = true,
+    targetHttpMethods = {"POST", "PUT", "PATCH", "DELETE"},
+    excludeMethods = {"healthCheck"}
+)
+public class UserController {
+    
+    @PostMapping
+    public ResponseEntity<UserResponse> createUser(@Valid @RequestBody UserCreateRequest request) {
+        // 자동으로 감사 로깅 적용됨
+        // - action: "createUser"
+        // - resourceType: USER
+        // - severity: HIGH
+        // - requestData 포함
+    }
+    
+    @PutMapping("/{id}")
+    public ResponseEntity<UserResponse> updateUser(
+            @PathVariable Long id, 
+            @Valid @RequestBody UserUpdateRequest request) {
+        // 자동으로 감사 로깅 적용됨
+        // - action: "updateUser"
+    }
+    
+    @GetMapping("/health")
+    public ResponseEntity<String> healthCheck() {
+        // excludeMethods에 포함되어 감사 로깅 제외됨
+        return ResponseEntity.ok("OK");
+    }
+}
+
+// ✅ 좋은 예 - 보안 컨트롤러
+@RestController
+@RequestMapping("/api/v1/security")
+@AuditController(
+    resourceType = AuditResourceType.SECURITY,
+    defaultSeverity = AuditSeverity.CRITICAL,
+    defaultIncludeRequestData = true,
+    defaultIncludeResponseData = true,
+    targetHttpMethods = {"GET", "POST", "PUT", "DELETE"}  // 모든 HTTP 메서드 감사
+)
+public class SecurityController {
+    
+    @GetMapping("/policies")
+    public ResponseEntity<List<SecurityPolicy>> getPolicies() {
+        // 모든 GET 요청도 감사 로깅됨
+    }
+    
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest request) {
+        // 로그인 시도 감사 로깅됨
+    }
+}
+```
+
+---
+
+## 🔧 메서드 레벨 감사 로깅
+
+### 1. @AuditRequired 애노테이션
+
+개별 메서드에 적용하여 **세밀한 감사 로깅**을 구현합니다.
+
+```java
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuditRequired {
+    String action();                              // 필수: 액션명
+    AuditResourceType resourceType();             // 필수: 리소스 타입
+    String description() default "";              // 설명
+    boolean includeRequestData() default false;   // 요청 데이터 포함 여부
+    boolean includeResponseData() default false;  // 응답 데이터 포함 여부
+    AuditSeverity severity() default AuditSeverity.INFO;  // 심각도
+}
+```
+
+### 2. 언제 사용해야 하는가?
+
+**✅ 메서드 레벨 감사 로깅을 사용해야 하는 경우:**
+
+- **특정 메서드만 감사**: 클래스 내 일부 메서드만 중요할 때
+- **세밀한 제어**: 메서드별로 다른 감사 정책이 필요할 때
+- **혼재된 리소스**: 클래스가 여러 리소스 타입을 다룰 때
+- **선택적 데이터 포함**: 특정 메서드에서만 요청/응답 데이터가 필요할 때
+
+**❌ 메서드 레벨 감사 로깅을 사용하지 말아야 하는 경우:**
+
+- **일괄 적용**: 클래스 내 모든 메서드에 동일한 정책 적용할 때
+- **보수적 접근**: 모든 메서드를 기본적으로 감사하고 싶을 때
+
+### 3. 사용 예시
+
+```java
+// ✅ 좋은 예 - 혼재된 리소스 타입 컨트롤러
+@RestController
+@RequestMapping("/api/v1/admin")
+public class AdminController {
+    
+    @PostMapping("/users")
+    @AuditRequired(
+        action = "createUser",
+        resourceType = AuditResourceType.USER,
+        severity = AuditSeverity.HIGH,
+        includeRequestData = true,
+        description = "관리자가 새 사용자를 생성합니다"
+    )
+    public ResponseEntity<UserResponse> createUser(@Valid @RequestBody UserCreateRequest request) {
+        // 사용자 생성만 감사 로깅됨
+    }
+    
+    @PostMapping("/tenants")
+    @AuditRequired(
+        action = "createTenant",
+        resourceType = AuditResourceType.TENANT,
+        severity = AuditSeverity.CRITICAL,
+        includeRequestData = true,
+        includeResponseData = true,
+        description = "새 테넌트를 생성합니다"
+    )
+    public ResponseEntity<TenantResponse> createTenant(@Valid @RequestBody TenantCreateRequest request) {
+        // 테넌트 생성만 감사 로깅됨 (더 높은 심각도)
+    }
+    
+    @GetMapping("/statistics")
+    public ResponseEntity<StatisticsResponse> getStatistics() {
+        // 감사 로깅 없음 (조회 작업)
+    }
+}
+
+// ✅ 좋은 예 - 특정 작업만 감사
+@RestController
+@RequestMapping("/api/v1/payments")
+public class PaymentController {
+    
+    @PostMapping("/process")
+    @AuditRequired(
+        action = "processPayment",
+        resourceType = AuditResourceType.PAYMENT,
+        severity = AuditSeverity.CRITICAL,
+        includeRequestData = true,
+        includeResponseData = true,
+        description = "결제 처리 작업"
+    )
+    public ResponseEntity<PaymentResponse> processPayment(@Valid @RequestBody PaymentRequest request) {
+        // 결제 처리만 감사 로깅됨
+    }
+    
+    @GetMapping("/history")
+    public ResponseEntity<List<PaymentHistory>> getPaymentHistory() {
+        // 감사 로깅 없음 (조회 작업)
+    }
+    
+    @PostMapping("/refund")
+    @AuditRequired(
+        action = "refundPayment",
+        resourceType = AuditResourceType.PAYMENT,
+        severity = AuditSeverity.HIGH,
+        includeRequestData = true,
+        description = "결제 환불 작업"
+    )
+    public ResponseEntity<RefundResponse> refundPayment(@Valid @RequestBody RefundRequest request) {
+        // 환불 처리만 감사 로깅됨
+    }
+}
+```
+
+---
+
+## 🔄 클래스와 메서드 레벨 조합 사용
+
+### 1. 우선순위 규칙
+
+**메서드 레벨 `@AuditRequired`가 클래스 레벨 `@AuditController`보다 우선합니다.**
+
+```java
+@AuditController(
+    resourceType = AuditResourceType.USER,
+    defaultSeverity = AuditSeverity.MEDIUM
+)
+public class UserController {
+    
+    @PostMapping
+    public ResponseEntity<UserResponse> createUser(@RequestBody UserCreateRequest request) {
+        // 클래스 레벨 설정 적용:
+        // - resourceType: USER
+        // - severity: MEDIUM
+    }
+    
+    @PostMapping("/admin")
+    @AuditRequired(
+        action = "createUserByAdmin",
+        resourceType = AuditResourceType.ADMIN,
+        severity = AuditSeverity.HIGH,
+        includeRequestData = true
+    )
+    public ResponseEntity<UserResponse> createUserByAdmin(@RequestBody UserCreateRequest request) {
+        // 메서드 레벨 설정 적용 (우선순위):
+        // - action: "createUserByAdmin" (명시적 지정)
+        // - resourceType: ADMIN (클래스 설정 덮어씀)
+        // - severity: HIGH (클래스 설정 덮어씀)
+        // - includeRequestData: true (메서드에서 설정)
+    }
+}
+```
+
+### 2. 조합 사용 시나리오
+
+```java
+// ✅ 좋은 예 - 기본 + 특별 처리
+@RestController
+@RequestMapping("/api/v1/security")
+@AuditController(
+    resourceType = AuditResourceType.SECURITY,
+    defaultSeverity = AuditSeverity.MEDIUM,
+    targetHttpMethods = {"POST", "PUT", "DELETE"}
+)
+public class SecurityController {
+    
+    // 클래스 레벨 설정 적용
+    @PostMapping("/policy")
+    public ResponseEntity<SecurityPolicy> createPolicy(@RequestBody PolicyRequest request) {
+        // - resourceType: SECURITY
+        // - severity: MEDIUM
+        // - action: "createPolicy" (자동 생성)
+    }
+    
+    // 메서드 레벨 설정으로 덮어씀
+    @PostMapping("/critical-action")
+    @AuditRequired(
+        action = "performCriticalSecurityAction",
+        resourceType = AuditResourceType.SECURITY,
+        severity = AuditSeverity.CRITICAL,
+        includeRequestData = true,
+        includeResponseData = true,
+        description = "중요한 보안 작업 수행"
+    )
+    public ResponseEntity<CriticalActionResponse> performCriticalAction(@RequestBody CriticalRequest request) {
+        // - action: "performCriticalSecurityAction" (명시적 지정)
+        // - resourceType: SECURITY (동일)
+        // - severity: CRITICAL (클래스 설정 덮어씀)
+        // - includeRequestData: true (추가 설정)
+        // - includeResponseData: true (추가 설정)
+    }
+    
+    // GET 메서드는 클래스 설정에서 제외됨
+    @GetMapping("/status")
+    public ResponseEntity<SecurityStatus> getStatus() {
+        // 감사 로깅 없음 (targetHttpMethods에 GET 없음)
+    }
+}
+```
+
+### 3. 실제 로깅 결과 비교
+
+```java
+// 클래스 레벨만 사용한 경우
+@AuditController(resourceType = AuditResourceType.USER)
+public class UserController {
+    public UserResponse createUser(UserCreateRequest request) {
+        // 로깅 결과:
+        // {
+        //   "action": "createUser",
+        //   "resourceType": "USER",
+        //   "severity": "MEDIUM",
+        //   "includeRequestData": false,
+        //   "includeResponseData": false
+        // }
+    }
+}
+
+// 메서드 레벨로 덮어쓴 경우
+@AuditController(resourceType = AuditResourceType.USER)
+public class UserController {
+    @AuditRequired(
+        action = "createUserByAdmin",
+        resourceType = AuditResourceType.ADMIN,
+        severity = AuditSeverity.HIGH,
+        includeRequestData = true
+    )
+    public UserResponse createUserByAdmin(UserCreateRequest request) {
+        // 로깅 결과:
+        // {
+        //   "action": "createUserByAdmin",        // 메서드 레벨 설정
+        //   "resourceType": "ADMIN",             // 메서드 레벨 설정
+        //   "severity": "HIGH",                  // 메서드 레벨 설정
+        //   "includeRequestData": true,          // 메서드 레벨 설정
+        //   "includeResponseData": false         // 클래스 레벨 기본값
+        // }
+    }
+}
+```
+
+---
+
+## 💾 감사 로깅 저장 형식
+
+### 1. AuditEventDto 구조
+
+```java
+public record AuditEventDto(
+    String action,                    // 액션명 (예: "createUser", "deletePost")
+    AuditResourceType resourceType,   // 리소스 타입 (USER, TENANT, SECURITY 등)
+    String httpMethod,               // HTTP 메서드 (GET, POST, PUT, DELETE)
+    String requestPath,              // 요청 경로 (예: "/api/v1/users")
+    String operationSummary,         // 작업 요약
+    String controllerName,           // 컨트롤러 클래스명
+    String methodName,               // 메서드명
+    AuditSeverity severity,          // 심각도 (CRITICAL, HIGH, MEDIUM, LOW, INFO)
+    Instant timestamp,               // 타임스탬프 (KST)
+    String requestId,                // 요청 ID (추적용)
+    String tenantId,                 // 테넌트 ID
+    String userId,                   // 사용자 ID
+    String clientIp,                 // 클라이언트 IP
+    boolean success,                 // 성공 여부
+    String error,                    // 에러 메시지 (실패 시)
+    Map<String, Object> requestData, // 요청 데이터 (includeRequestData=true 시)
+    Map<String, Object> responseData,// 응답 데이터 (includeResponseData=true 시)
+    Map<String, Object> metadata     // 추가 메타데이터
+)
+```
+
+### 2. JSON 로그 출력 예시
+
+```json
+// 성공한 사용자 생성 요청
+{
+  "action": "createUser",
+  "resourceType": "USER",
+  "httpMethod": "POST",
+  "requestPath": "/api/v1/users",
+  "operationSummary": "사용자 생성",
+  "controllerName": "UserController",
+  "methodName": "createUser",
+  "severity": "HIGH",
+  "timestamp": "2024-01-15T10:30:00.123Z",
+  "requestId": "req-12345678-1234-1234-1234-123456789abc",
+  "tenantId": "tenant-001",
+  "userId": "user-12345",
+  "clientIp": "192.168.1.100",
+  "success": true,
+  "error": null,
+  "requestData": {
+    "username": "john_doe",
+    "email": "john@example.com",
+    "name": "John Doe"
+  },
+  "responseData": {
+    "id": 12345,
+    "username": "john_doe",
+    "email": "john@example.com",
+    "status": "ACTIVE"
+  },
+  "metadata": {}
+}
+
+// 실패한 로그인 시도
+{
+  "action": "login",
+  "resourceType": "SECURITY",
+  "httpMethod": "POST",
+  "requestPath": "/api/v1/auth/login",
+  "operationSummary": "사용자 로그인",
+  "controllerName": "AuthController",
+  "methodName": "login",
+  "severity": "CRITICAL",
+  "timestamp": "2024-01-15T10:35:00.456Z",
+  "requestId": "req-87654321-4321-4321-4321-cba987654321",
+  "tenantId": "tenant-001",
+  "userId": null,
+  "clientIp": "192.168.1.200",
+  "success": false,
+  "error": "Invalid credentials",
+  "requestData": {
+    "username": "hacker",
+    "password": "***"  // 실제로는 마스킹됨
+  },
+  "responseData": null,
+  "metadata": {
+    "attemptCount": 3,
+    "blocked": true
+  }
+}
+```
+
+### 3. 로그 레벨별 출력
+
+```java
+// AuditLogger에서 심각도에 따라 다른 로그 레벨 사용
+private static final Map<AuditSeverity, BiConsumer<Logger, String>> logActions
+        = new EnumMap<>(AuditSeverity.class);
+
+static {
+    logActions.put(AuditSeverity.CRITICAL, Logger::error);  // ERROR 레벨
+    logActions.put(AuditSeverity.HIGH, Logger::warn);       // WARN 레벨
+    logActions.put(AuditSeverity.MEDIUM, Logger::info);     // INFO 레벨
+    logActions.put(AuditSeverity.LOW, Logger::info);        // INFO 레벨
+    logActions.put(AuditSeverity.INFO, Logger::info);       // INFO 레벨
+}
+```
+
+---
+
+## 🔄 애플리케이션 로깅 vs 감사 로깅
+
+### 1. 두 로깅의 차이점
+
+| 구분 | 감사 로깅 (Audit Logging) | 애플리케이션 로깅 (Application Logging) |
+|------|---------------------------|----------------------------------------|
+| **목적** | 보안, 컴플라이언스, 감사 증적 생성 | 개발, 디버깅, 운영 모니터링 |
+| **대상** | 중요한 비즈니스 작업 (생성, 수정, 삭제, 로그인) | 모든 작업 (조회, 생성, 수정, 삭제, 에러) |
+| **형식** | 구조화된 JSON 로그 | 일반적인 텍스트 로그 |
+| **저장 위치** | 별도의 감사 로그 파일 (`audit.log`) | 애플리케이션 로그 파일 (`application.log`) |
+| **사용자** | 보안팀, 감사팀, 컴플라이언스 담당자 | 개발자, 운영팀, DevOps |
+| **자동화** | `@AuditController`, `@AuditRequired`로 자동 생성 | `log.info()`, `log.error()` 등으로 수동 작성 |
+| **데이터 포함** | 요청/응답 데이터, 사용자 정보, IP 등 | 개발자가 필요한 정보만 선택적 포함 |
+
+### 2. 언제 애플리케이션 로깅을 사용하는가?
+
+**✅ 애플리케이션 로깅을 사용해야 하는 경우:**
+
+- **디버깅**: 코드 흐름 추적 및 문제 원인 파악
+- **성능 모니터링**: 처리 시간 및 성능 지표 측정
+- **운영 모니터링**: 시스템 상태 및 사용량 추적
+- **에러 추적**: 예외 발생 시 상세한 컨텍스트 정보
+- **비즈니스 로직 추적**: 복잡한 비즈니스 프로세스의 중간 단계
+
+**❌ 애플리케이션 로깅을 사용하지 않아도 되는 경우:**
+
+- **단순한 CRUD 작업**: 감사 로깅으로 충분한 경우
+- **성능이 중요한 경우**: 로깅 오버헤드를 최소화해야 할 때
+- **보안이 최우선**: 민감한 정보 노출 위험이 있는 경우
+
+### 3. 애플리케이션 로깅 사용 예시
+
+```java
+@RestController
+@RequestMapping("/api/v1/users")
+@Slf4j
+@AuditController(
+    resourceType = AuditResourceType.USER,
+    defaultSeverity = AuditSeverity.MEDIUM
+)
+public class UserController {
+    
+    private final UserService userService;
+    
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+    
+    @PostMapping
+    public ResponseEntity<UserResponse> createUser(@Valid @RequestBody UserCreateRequest request) {
+        // 1. 요청 시작 로깅 (디버깅용)
+        log.info("사용자 생성 요청 시작: username={}, email={}", 
+                request.getUsername(), request.getEmail());
+        
+        long startTime = System.currentTimeMillis();
+        
+        try {
+            // 2. 비즈니스 로직 실행
+            UserResponse user = userService.createUser(request);
+            
+            // 3. 성공 로깅 (성능 모니터링용)
+            long duration = System.currentTimeMillis() - startTime;
+            log.info("사용자 생성 성공: userId={}, username={}, 처리시간={}ms", 
+                    user.getId(), user.getUsername(), duration);
+            
+            return ResponseEntity.status(HttpStatus.CREATED).body(user);
+            
+        } catch (DuplicateUserException e) {
+            // 4. 비즈니스 예외 로깅 (문제 추적용)
+            log.warn("사용자 생성 실패 - 중복 사용자: username={}, error={}", 
+                    request.getUsername(), e.getMessage());
+            throw e;
+            
+        } catch (Exception e) {
+            // 5. 시스템 예외 로깅 (에러 추적용)
+            log.error("사용자 생성 중 예상치 못한 오류: username={}", 
+                    request.getUsername(), e);
+            throw e;
+        }
+    }
+    
+    @GetMapping("/{id}")
+    public ResponseEntity<UserResponse> getUser(@PathVariable Long id) {
+        // 조회 작업은 감사 로깅 없음, 애플리케이션 로깅만 사용
+        log.debug("사용자 조회 요청: userId={}", id);
+        
+        UserResponse user = userService.getUserById(id);
+        
+        log.debug("사용자 조회 완료: userId={}, username={}", 
+                user.getId(), user.getUsername());
+        
+        return ResponseEntity.ok(user);
+    }
+}
+```
+
+### 4. 로그 레벨별 사용 가이드
+
+```java
+@Service
+@Slf4j
+public class UserService {
+    
+    public UserResponse createUser(UserCreateRequest request) {
+        // ERROR: 시스템 오류, 복구 불가능한 문제
+        log.error("데이터베이스 연결 실패: {}", e.getMessage());
+        
+        // WARN: 비즈니스 예외, 예상 가능한 문제
+        log.warn("중복된 사용자명: username={}", request.getUsername());
+        
+        // INFO: 중요한 비즈니스 이벤트, 성능 모니터링
+        log.info("사용자 생성 시작: username={}", request.getUsername());
+        log.info("사용자 생성 완료: userId={}, 처리시간={}ms", userId, duration);
+        
+        // DEBUG: 개발/디버깅용 상세 정보
+        log.debug("사용자 중복 검사 시작: username={}", request.getUsername());
+        log.debug("사용자 중복 검사 완료: exists={}", exists);
+        
+        // TRACE: 매우 상세한 실행 흐름 (성능에 영향)
+        log.trace("메서드 진입: createUser(request={})", request);
+    }
+}
+```
+
+#### 로그 파일 구조
+
+```
+logs/
+├── application.log              # 애플리케이션 로그 (현재)
+├── application.2024-01-14.0.log # 애플리케이션 로그 (과거)
+├── application.2024-01-14.1.log
+├── audit.log                   # 감사 로그 (현재)
+├── audit.2024-01-14.0.log      # 감사 로그 (과거)
+└── audit.2024-01-14.1.log
+```
+
+### 5. 실제 로그 비교 예시
+
+#### 동일한 작업에 대한 두 로그 비교
+
+**애플리케이션 로그 (application.log):**
+```
+2024-01-15 10:30:00.123 INFO  [http-nio-8080-exec-1] c.a.c.controller.UserController : 사용자 생성 요청 시작: username=john_doe, email=john@example.com
+2024-01-15 10:30:00.145 INFO  [http-nio-8080-exec-1] c.a.c.service.UserService : 사용자 생성 시작: username=john_doe
+2024-01-15 10:30:00.156 DEBUG [http-nio-8080-exec-1] c.a.c.service.UserService : 사용자 중복 검사 시작: username=john_doe
+2024-01-15 10:30:00.167 DEBUG [http-nio-8080-exec-1] c.a.c.service.UserService : 사용자 중복 검사 완료: exists=false
+2024-01-15 10:30:00.178 INFO  [http-nio-8080-exec-1] c.a.c.repository.UserRepository : 사용자 저장 시작: username=john_doe
+2024-01-15 10:30:00.189 INFO  [http-nio-8080-exec-1] c.a.c.repository.UserRepository : 사용자 저장 완료: userId=12345
+2024-01-15 10:30:00.200 INFO  [http-nio-8080-exec-1] c.a.c.service.EmailService : 환영 이메일 발송 시작: userId=12345
+2024-01-15 10:30:00.345 INFO  [http-nio-8080-exec-1] c.a.c.service.EmailService : 환영 이메일 발송 완료: userId=12345
+2024-01-15 10:30:00.346 INFO  [http-nio-8080-exec-1] c.a.c.service.UserService : 사용자 생성 완료: userId=12345, 처리시간=201ms
+2024-01-15 10:30:00.347 INFO  [http-nio-8080-exec-1] c.a.c.controller.UserController : 사용자 생성 성공: userId=12345, username=john_doe, 처리시간=224ms
+```
+
+**감사 로그 (audit.log):**
+```json
+{
+  "action": "createUser",
+  "resourceType": "USER",
+  "httpMethod": "POST",
+  "requestPath": "/api/v1/users",
+  "operationSummary": "사용자 생성",
+  "controllerName": "UserController",
+  "methodName": "createUser",
+  "severity": "MEDIUM",
+  "timestamp": "2024-01-15T10:30:00.123Z",
+  "requestId": "req-12345678-1234-1234-1234-123456789abc",
+  "tenantId": "tenant-001",
+  "userId": "admin-001",
+  "clientIp": "192.168.1.100",
+  "success": true,
+  "error": null,
+  "requestData": {
+    "username": "john_doe",
+    "email": "john@example.com",
+    "name": "John Doe"
+  },
+  "responseData": null,
+  "metadata": {}
+}
+```
+
+### 6. 사용 시나리오별 로깅 전략
+
+#### 시나리오 1: 보안 사고 조사
+```
+🔍 보안팀: "어제 밤 11시경에 admin 계정이 삭제되었는데, 누가 했는지 추적해줘"
+
+📋 감사 로그에서 확인:
+- 2024-01-14 23:15:00 - action: "deleteUser", userId: "admin-001", clientIp: "192.168.1.100"
+
+📋 애플리케이션 로그에서 확인:
+- 2024-01-14 23:14:58 - "사용자 삭제 요청: userId=12345"
+- 2024-01-14 23:14:59 - "관련 데이터 정리 시작: userId=12345"
+- 2024-01-14 23:15:00 - "사용자 삭제 완료: userId=12345"
+```
+
+#### 시나리오 2: 성능 문제 해결
+```
+🐛 개발팀: "사용자 생성이 느린데 원인이 뭐야?"
+
+📋 애플리케이션 로그에서 확인:
+- 10:30:00.123 - "사용자 생성 요청: username=john_doe"
+- 10:30:00.145 - "사용자 생성 시작: username=john_doe"
+- 10:30:00.567 - "이메일 전송 완료: userId=12345"  ← 422ms 소요!
+- 10:30:00.568 - "사용자 생성 완료: userId=12345"
+
+💡 문제 발견: 이메일 전송이 422ms나 걸림
+```
+
+#### 시나리오 3: 비즈니스 로직 디버깅
+```
+🐛 개발팀: "사용자 생성 시 중복 검사가 제대로 안 되는 것 같아"
+
+📋 애플리케이션 로그에서 확인:
+- 10:30:00.156 - "사용자 중복 검사 시작: username=john_doe"
+- 10:30:00.167 - "사용자 중복 검사 완료: exists=false"
+- 10:30:00.178 - "사용자 저장 시작: username=john_doe"
+- 10:30:00.189 - "사용자 저장 완료: userId=12345"
+
+💡 중복 검사는 정상 작동, 다른 원인 추적 필요
+```
+
+### 7. 로깅 전략 요약
+
+| 상황 | 감사 로깅 | 애플리케이션 로깅 | 이유 |
+|------|-----------|------------------|------|
+| **CRUD 작업** | ✅ 필수 | ✅ 권장 | 보안 + 개발 편의성 |
+| **조회 작업** | ❌ 불필요 | ✅ 권장 | 개발/운영 모니터링 |
+| **로그인/로그아웃** | ✅ 필수 | ✅ 권장 | 보안 + 문제 추적 |
+| **에러 발생** | ✅ 필수 | ✅ 필수 | 보안 + 디버깅 |
+| **성능 모니터링** | ❌ 불필요 | ✅ 필수 | 성능 분석 |
+| **개발 중** | ✅ 권장 | ✅ 필수 | 학습 + 디버깅 |
+
+**결론**: 감사 로깅은 보안과 컴플라이언스를 위해 필수이고, 애플리케이션 로깅은 개발과 운영을 위해 권장됩니다.
+
+---
+
+## 🎯 실제 사용 예시
+
+### 1. 완전한 사용자 관리 컨트롤러
+
+```java
+@RestController
+@RequestMapping("/api/v1/users")
+@Validated
+@Slf4j
+@AuditController(
+    resourceType = AuditResourceType.USER,
+    defaultSeverity = AuditSeverity.MEDIUM,
+    defaultIncludeRequestData = true,
+    targetHttpMethods = {"POST", "PUT", "PATCH", "DELETE"},
+    excludeMethods = {"getCurrentUser", "updateProfile"}
+)
+public class UserController {
+    
+    private final UserService userService;
+    
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+    
+    // 클래스 레벨 감사 로깅 적용
+    @PostMapping
+    public ResponseEntity<UserResponse> createUser(@Valid @RequestBody UserCreateRequest request) {
+        log.info("사용자 생성 요청: username={}", request.getUsername());
+        
+        UserResponse user = userService.createUser(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(user);
+    }
+    
+    // 클래스 레벨 감사 로깅 적용
+    @PutMapping("/{id}")
+    public ResponseEntity<UserResponse> updateUser(
+            @PathVariable @Positive Long id,
+            @Valid @RequestBody UserUpdateRequest request) {
+        
+        log.info("사용자 수정 요청: userId={}", id);
+        
+        UserResponse user = userService.updateUser(id, request);
+        return ResponseEntity.ok(user);
+    }
+    
+    // 클래스 레벨 감사 로깅 적용
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteUser(@PathVariable @Positive Long id) {
+        log.info("사용자 삭제 요청: userId={}", id);
+        
+        userService.deleteUser(id);
+        return ResponseEntity.noContent().build();
+    }
+    
+    // 메서드 레벨 감사 로깅으로 덮어씀
+    @PatchMapping("/{id}/status")
+    @AuditRequired(
+        action = "changeUserStatus",
+        resourceType = AuditResourceType.USER,
+        severity = AuditSeverity.HIGH,
+        includeRequestData = true,
+        includeResponseData = true,
+        description = "사용자 상태 변경 (활성화/비활성화)"
+    )
+    public ResponseEntity<UserResponse> changeUserStatus(
+            @PathVariable @Positive Long id,
+            @Valid @RequestBody UserStatusChangeRequest request) {
+        
+        log.info("사용자 상태 변경 요청: userId={}, status={}", id, request.getStatus());
+        
+        UserResponse user = userService.changeUserStatus(id, request.getStatus());
+        return ResponseEntity.ok(user);
+    }
+    
+    // 클래스 레벨에서 제외됨 (excludeMethods)
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> getCurrentUser(Authentication authentication) {
+        UserResponse user = userService.getCurrentUser(authentication.getName());
+        return ResponseEntity.ok(user);
+    }
+    
+    // 클래스 레벨에서 제외됨 (excludeMethods)
+    @PutMapping("/me/profile")
+    public ResponseEntity<UserResponse> updateProfile(
+            Authentication authentication,
+            @Valid @RequestBody UserProfileUpdateRequest request) {
+        
+        UserResponse user = userService.updateProfile(authentication.getName(), request);
+        return ResponseEntity.ok(user);
+    }
+    
+    // GET 메서드는 클래스 레벨에서 제외됨
+    @GetMapping("/{id}")
+    public ResponseEntity<UserResponse> getUser(@PathVariable @Positive Long id) {
+        UserResponse user = userService.getUserById(id);
+        return ResponseEntity.ok(user);
+    }
+    
+    // GET 메서드는 클래스 레벨에서 제외됨
+    @GetMapping
+    public ResponseEntity<Page<UserResponse>> getUsers(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) String status) {
+        
+        Page<UserResponse> users = userService.getUsers(page, size, status);
+        return ResponseEntity.ok(users);
+    }
+}
+```
+
+### 2. 보안 컨트롤러 예시
+
+```java
+@RestController
+@RequestMapping("/api/v1/security")
+@Validated
+@Slf4j
+public class SecurityController {
+    
+    private final SecurityService securityService;
+    
+    public SecurityController(SecurityService securityService) {
+        this.securityService = securityService;
+    }
+    
+    // 메서드 레벨 감사 로깅만 사용
+    @PostMapping("/login")
+    @AuditRequired(
+        action = "userLogin",
+        resourceType = AuditResourceType.SECURITY,
+        severity = AuditSeverity.CRITICAL,
+        includeRequestData = true,
+        description = "사용자 로그인 시도"
+    )
+    public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
+        log.info("로그인 시도: username={}", request.getUsername());
+        
+        TokenResponse token = securityService.authenticate(request);
+        return ResponseEntity.ok(token);
+    }
+    
+    @PostMapping("/logout")
+    @AuditRequired(
+        action = "userLogout",
+        resourceType = AuditResourceType.SECURITY,
+        severity = AuditSeverity.MEDIUM,
+        description = "사용자 로그아웃"
+    )
+    public ResponseEntity<Void> logout(HttpServletRequest request) {
+        String token = extractToken(request);
+        securityService.logout(token);
+        return ResponseEntity.ok().build();
+    }
+    
+    @PostMapping("/change-password")
+    @AuditRequired(
+        action = "changePassword",
+        resourceType = AuditResourceType.SECURITY,
+        severity = AuditSeverity.HIGH,
+        includeRequestData = true,
+        description = "비밀번호 변경"
+    )
+    public ResponseEntity<Void> changePassword(
+            Authentication authentication,
+            @Valid @RequestBody ChangePasswordRequest request) {
+        
+        securityService.changePassword(authentication.getName(), request);
+        return ResponseEntity.ok().build();
+    }
+    
+    // 조회 작업은 감사 로깅 없음
+    @GetMapping("/profile")
+    public ResponseEntity<SecurityProfile> getSecurityProfile(Authentication authentication) {
+        SecurityProfile profile = securityService.getSecurityProfile(authentication.getName());
+        return ResponseEntity.ok(profile);
+    }
+}
+```
+
+### 3. 생성된 감사 로그 예시
+
+```json
+// 로그인 시도 감사 로그
+{
+  "action": "userLogin",
+  "resourceType": "SECURITY",
+  "httpMethod": "POST",
+  "requestPath": "/api/v1/security/login",
+  "operationSummary": "사용자 로그인",
+  "controllerName": "SecurityController",
+  "methodName": "login",
+  "severity": "CRITICAL",
+  "timestamp": "2024-01-15T10:40:00.789Z",
+  "requestId": "req-11111111-2222-3333-4444-555555555555",
+  "tenantId": "tenant-001",
+  "userId": "user-12345",
+  "clientIp": "192.168.1.200",
+  "success": true,
+  "error": null,
+  "requestData": {
+    "username": "john_doe",
+    "password": "***"  // 실제로는 마스킹됨
+  },
+  "responseData": null,
+  "metadata": {}
+}
+```
+
+---
+
+## 📋 요약
+
+### 1. 감사 로깅 선택 가이드
+
+| 상황 | 추천 방법 | 이유 |
+|------|-----------|------|
+| CRUD 컨트롤러 | 클래스 레벨 `@AuditController` | 모든 메서드가 동일한 리소스 타입 |
+| 보안 컨트롤러 | 클래스 레벨 `@AuditController` | 모든 작업이 중요하고 감사 필요 |
+| 혼재된 리소스 | 메서드 레벨 `@AuditRequired` | 리소스 타입이 다양함 |
+| 선택적 감사 | 메서드 레벨 `@AuditRequired` | 일부 메서드만 감사 필요 |
+| 세밀한 제어 | 메서드 레벨 `@AuditRequired` | 메서드별로 다른 감사 정책 |
+
+### 2. 주요 원칙
+
+- **메서드 레벨이 클래스 레벨보다 우선**
+- **보안 관련 작업은 높은 심각도 사용**
+- **민감한 데이터는 마스킹 처리**
+- **성능을 고려하여 필요한 경우에만 데이터 포함**
+- **일관된 액션명과 리소스 타입 사용**
+
+### 3. 체크리스트
+
+**감사 로깅 적용 전:**
+- [ ] 어떤 작업을 감사할지 명확히 정의
+- [ ] 적절한 리소스 타입 선택
+- [ ] 심각도 레벨 결정
+- [ ] 요청/응답 데이터 포함 여부 결정
+
+**감사 로깅 적용 후:**
+- [ ] 로그 출력 확인
+- [ ] 보안 정책 준수 확인
+
+이 가이드를 따라 일관되고 효과적인 감사 로깅을 구현하시기 바랍니다.

--- a/env.example
+++ b/env.example
@@ -1,0 +1,23 @@
+# AgenticCP-Core 환경변수 예시 파일
+# 실제 사용 시 .env 파일로 복사하여 사용하세요
+
+# 데이터베이스 설정
+DATABASE_URL=jdbc:mysql://localhost:3306/agenticcp?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+DATABASE_USERNAME=agenticcp
+DATABASE_PASSWORD=your_secure_password_here
+
+# JWT 설정
+JWT_SECRET=your_base64_encoded_jwt_secret_here
+JWT_ACCESS_EXP_MS=3600000
+JWT_REFRESH_EXP_MS=604800000
+
+# Redis 설정
+SPRING_DATA_REDIS_HOST=localhost
+SPRING_DATA_REDIS_PORT=6379
+APP_REDIS_ENABLED=false
+
+# 암호화 설정
+CONFIG_CIPHER_KEY=your_base64_encoded_cipher_key_here
+
+# Spring 프로파일
+SPRING_PROFILES_ACTIVE=local

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,15 +5,6 @@ spring:
     password: agenticcppassword
     driver-class-name: com.mysql.cj.jdbc.Driver
   
-  jpa:
-    hibernate:
-      ddl-auto: update
-  
-  security:
-    user:
-      name: admin
-      password: admin123
-      roles: ADMIN
   
   cache:
     type: simple
@@ -24,10 +15,11 @@ spring:
       timeout: 2000ms
       connect-timeout: 2000ms
 
-logging:
 app:
   redis:
     enabled: ${APP_REDIS_ENABLED:false}
+
+logging:
   level:
     root: INFO
     com.agenticcp.core: DEBUG

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -16,8 +16,8 @@ spring:
         
   data:
     redis:
-      host: ${SPRING_REDIS_HOST:localhost}
-      port: ${SPRING_REDIS_PORT:6379}
+      host: ${SPRING_DATA_REDIS_HOST:localhost}
+      port: ${SPRING_DATA_REDIS_PORT:6379}
       timeout: 2000ms
       
   cache:
@@ -50,10 +50,11 @@ config:
     missingKeyBehavior: READ_ONLY
 
 # 테스트용 JWT 설정
-jwt:
-  secret: test-secret-key-for-testing-purposes-only-very-long-key
-  expiration: 3600000 # 1시간
-  refresh-expiration: 86400000 # 24시간
+security:
+  jwt:
+    secret: test-secret-key-for-testing-purposes-only-very-long-key
+    access-token-expiration-ms: 3600000 # 1시간
+    refresh-token-expiration-ms: 86400000 # 24시간
 
 # Actuator 설정
 management:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,9 +6,9 @@ spring:
     active: local
   
   datasource:
-    url: jdbc:mysql://localhost:3306/agenticcp?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
-    username: agenticcp
-    password: agenticcppassword
+    url: ${DATABASE_URL:jdbc:mysql://localhost:3306/agenticcp?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC}
+    username: ${DATABASE_USERNAME:agenticcp}
+    password: ${DATABASE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
     
   jpa:
@@ -35,7 +35,7 @@ app:
 security:
   jwt:
     # base64 인코딩된 256비트 이상 키를 사용하세요. 예시는 개발용입니다.
-    secret: ${JWT_SECRET:ZmFrZV9zZWNyZXRfZm9yX2Rldl9vbmx5X3VzZV9jaGFuZ2VfbWU=}
+    secret: ${JWT_SECRET:}
     access-token-expiration-ms: ${JWT_ACCESS_EXP_MS:3600000}
     refresh-token-expiration-ms: ${JWT_REFRESH_EXP_MS:604800000}
 

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -48,4 +48,14 @@ echo ""
 echo "애플리케이션을 중지하려면 Ctrl+C를 누르세요."
 
 # Spring Boot 실행
+echo "🔧 환경변수를 설정합니다..."
+export DATABASE_URL="jdbc:mysql://localhost:3306/agenticcp?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC"
+export DATABASE_USERNAME="agenticcp"
+export DATABASE_PASSWORD="agenticcppassword"
+export JWT_SECRET="ZmFrZV9zZWNyZXRfZm9yX2Rldl9vbmx5X3VzZV9jaGFuZ2VfbWU="
+export CONFIG_CIPHER_KEY="MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA="
+export SPRING_DATA_REDIS_HOST="localhost"
+export SPRING_DATA_REDIS_PORT="6379"
+export APP_REDIS_ENABLED="false"
+
 mvn spring-boot:run -Dspring-boot.run.profiles=local


### PR DESCRIPTION
## 📋 변경 사항

AgenticCP 프로젝트의 코드 작성 표준을 정의하는 9개의 Cursor rule 파일을 추가했습니다.

### 추가된 Cursor Rules

#### 1. controller-pattern.mdc (9.2KB)
- REST API 컨트롤러 작성 표준
- URL 설계 원칙 및 HTTP 메서드 사용
- Swagger/OpenAPI 문서화 어노테이션 (@Operation, @ApiResponses, @Parameter)
- 로깅 규칙 및 예외 처리

#### 2. service-pattern.mdc (8.1KB)
- 서비스 레이어 작성 표준
- @Transactional(readOnly = true) 기본 사용
- 생성자 주입 및 의존성 관리
- 비즈니스 로직 구조화 및 메서드 명명 규칙

#### 3. repository-pattern.mdc (6.4KB)
- JPA Repository 작성 표준
- 메서드 명명 규칙 (findBy, existsBy, countBy)
- @Query 사용법 및 파라미터 바인딩
- JPQL vs Native Query 가이드

#### 4. entity-pattern.mdc (8.4KB)
- JPA Entity 작성 표준
- Lombok 어노테이션 조합 (@NoArgsConstructor + @AllArgsConstructor + @Builder)
- 테이블/컬럼 매핑 및 인덱스 정의
- 연관관계 매핑 (LAZY 로딩 필수)
- 비즈니스 메서드 포함

#### 5. dto-pattern.mdc (8.7KB)
- DTO 작성 표준 (Request/Response 분리)
- Validation 어노테이션 사용법
- JsonInclude 및 from() 메서드 패턴
- ApiResponse 표준 응답 래퍼

#### 6. businessexception-pattern.mdc (10KB)
- 비즈니스 예외 처리 표준
- ErrorCategory 및 도메인별 에러 코드 관리 (USER: 2000-2999, TENANT: 3000-3999 등)
- BaseErrorCode 인터페이스 구현
- 예외 계층 (BusinessException, ResourceNotFoundException, AuthorizationException)
- GlobalExceptionHandler 패턴

#### 7. unittest-pattern.mdc (16KB)
- 단위 테스트 작성 표준
- Given-When-Then 패턴
- Mock 설정 및 