### PR TITLE
Refactor/116

### DIFF
--- a/src/main/java/com/agenticcp/core/domain/security/annotation/RequirePermission.java
+++ b/src/main/java/com/agenticcp/core/domain/security/annotation/RequirePermission.java
@@ -5,6 +5,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * 권한 검증이 필요한 클래스나 메서드에 부여하는 애노테이션입니다.
+ *
+ * @author AgenticCP Team
+ * @version 1.0
+ * @since 2025-11-08
+ */
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RequirePermission {

--- a/src/main/java/com/agenticcp/core/domain/security/annotation/RequireRole.java
+++ b/src/main/java/com/agenticcp/core/domain/security/annotation/RequireRole.java
@@ -5,6 +5,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * 특정 역할 보유 여부를 검증하는 애노테이션입니다.
+ *
+ * @author AgenticCP Team
+ * @version 1.0
+ * @since 2025-11-08
+ */
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RequireRole {

--- a/src/main/java/com/agenticcp/core/domain/security/aop/AuthorizationAspect.java
+++ b/src/main/java/com/agenticcp/core/domain/security/aop/AuthorizationAspect.java
@@ -13,6 +13,17 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
+
+/**
+ * 권한 및 역할 기반 접근 제어를 처리하는 AOP 컴포넌트입니다.
+ *
+ * <p>보안 애노테이션을 해석하여 현재 인증된 사용자의 권한을 검사합니다.</p>
+ *
+ * @author AgenticCP Team
+ * @version 1.0
+ * @since 2025-11-08
+ */
 @Aspect
 @Component
 @RequiredArgsConstructor
@@ -21,35 +32,61 @@ public class AuthorizationAspect {
 
     private final AuthorizationService authorizationService;
 
+    /**
+     * 권한 애노테이션을 검사하여 접근 가능 여부를 판단합니다.
+     *
+     * @param joinPoint        실행 대상 조인 포인트
+     * @param requirePermission 권한 검증 애노테이션
+     * @return 원본 메서드 실행 결과
+     * @throws Throwable 접근 권한이 없거나 원본 메서드 실행 중 예외가 발생한 경우
+     */
     @Around("@annotation(requirePermission)")
     public Object checkPermission(ProceedingJoinPoint joinPoint, RequirePermission requirePermission) throws Throwable {
         String username = getCurrentUsername();
         String permissionKey = requirePermission.value();
+        log.debug("[AuthorizationAspect] checkPermission - username={}, permissionKey={}", username, permissionKey);
 
         if (!authorizationService.hasPermission(username, permissionKey)) {
+            log.warn("[AuthorizationAspect] Permission denied - username={}, permissionKey={}", username, permissionKey);
             throw new AccessDeniedException("접근 권한이 없습니다");
         }
 
         return joinPoint.proceed();
     }
 
+    /**
+     * 역할 애노테이션을 검사하여 접근 가능 여부를 판단합니다.
+     *
+     * @param joinPoint  실행 대상 조인 포인트
+     * @param requireRole 역할 검증 애노테이션
+     * @return 원본 메서드 실행 결과
+     * @throws Throwable 접근 권한이 없거나 원본 메서드 실행 중 예외가 발생한 경우
+     */
     @Around("@annotation(requireRole)")
     public Object checkRole(ProceedingJoinPoint joinPoint, RequireRole requireRole) throws Throwable {
         String username = getCurrentUsername();
         String[] roles = requireRole.value();
         boolean requireAll = requireRole.requireAll();
+        log.debug("[AuthorizationAspect] checkRole - username={}, roles={}, requireAll={}", username, Arrays.toString(roles), requireAll);
 
         boolean allowed = requireAll
                 ? authorizationService.hasAllRoles(username, roles)
                 : authorizationService.hasAnyRole(username, roles);
 
         if (!allowed) {
+            log.warn("[AuthorizationAspect] Role check failed - username={}, roles={}, requireAll={}", username, Arrays.toString(roles), requireAll);
             throw new AccessDeniedException("접근 권한이 없습니다");
         }
 
         return joinPoint.proceed();
     }
 
+    /**
+     * 현재 인증된 사용자의 사용자명을 반환합니다.
+     *
+     * @return 인증된 사용자명
+     * @throws AccessDeniedException 인증 정보가 없는 경우
+     */
     private String getCurrentUsername() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null && authentication.isAuthenticated()) {

--- a/src/main/java/com/agenticcp/core/domain/security/controller/PolicyEngineController.java
+++ b/src/main/java/com/agenticcp/core/domain/security/controller/PolicyEngineController.java
@@ -1,12 +1,15 @@
 package com.agenticcp.core.domain.security.controller;
 
+import com.agenticcp.core.common.dto.exception.ApiResponse;
 import com.agenticcp.core.domain.security.dto.PolicyEvaluationRequest;
 import com.agenticcp.core.domain.security.dto.PolicyEvaluationResult;
 import com.agenticcp.core.domain.security.service.PolicyEngineService;
+import com.agenticcp.core.domain.security.enums.SecurityErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,12 +19,12 @@ import java.util.Map;
 
 /**
  * 정책 엔진 REST API 컨트롤러
- * 
+ *
  * <p>정책 평가 및 관리를 위한 REST API 엔드포인트를 제공합니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @RestController
 @RequestMapping("/v1/security/policy")
@@ -35,96 +38,93 @@ public class PolicyEngineController {
 
     /**
      * 정책 평가 API
-     * 
+     *
      * @param request 정책 평가 요청
      * @return 정책 평가 결과
      */
     @PostMapping("/evaluate")
     @Operation(summary = "정책 평가", description = "정책 평가 요청을 처리하고 결과를 반환합니다.")
-    public ResponseEntity<PolicyEvaluationResult> evaluatePolicy(
+    public ResponseEntity<ApiResponse<PolicyEvaluationResult>> evaluatePolicy(
             @Valid @RequestBody PolicyEvaluationRequest request) {
-        
+
         log.info("정책 평가 요청: {}", request);
-        
+
         try {
             PolicyEvaluationResult result = policyEngineService.evaluatePolicy(request);
             log.info("정책 평가 결과: {}", result);
-            return ResponseEntity.ok(result);
+            return ResponseEntity.ok(ApiResponse.success(result, "정책 평가가 성공적으로 수행되었습니다."));
         } catch (Exception e) {
             log.error("정책 평가 중 오류 발생", e);
-            PolicyEvaluationResult errorResult = PolicyEvaluationResult.inconclusive("정책 평가 중 오류가 발생했습니다: " + e.getMessage());
-            return ResponseEntity.ok(errorResult);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.error(SecurityErrorCode.POLICY_EVALUATION_FAILED,
+                            "정책 평가 중 오류가 발생했습니다: " + e.getMessage()));
         }
     }
 
     /**
      * 정책 캐시 무효화 API
-     * 
+     *
      * @param resourceType 리소스 타입 (선택사항)
      * @param action 액션 (선택사항)
      * @return 무효화 결과
      */
     @DeleteMapping("/cache")
     @Operation(summary = "캐시 무효화", description = "정책 평가 결과 캐시를 무효화합니다.")
-    public ResponseEntity<Map<String, Object>> evictPolicyCache(
+    public ResponseEntity<ApiResponse<Map<String, Object>>> evictPolicyCache(
             @RequestParam(required = false) String resourceType,
             @RequestParam(required = false) String action) {
-        
+
         log.info("정책 캐시 무효화 요청: resourceType={}, action={}", resourceType, action);
-        
+
         try {
-            if (resourceType != null && !resourceType.isEmpty() && 
+            if (resourceType != null && !resourceType.isEmpty() &&
                 action != null && !action.isEmpty()) {
                 policyEngineService.evictPolicyCache(resourceType, action);
             } else {
                 policyEngineService.evictAllPolicyCache();
             }
-            
+
             Map<String, Object> response = new HashMap<>();
-            response.put("success", true);
-            response.put("message", "캐시가 성공적으로 무효화되었습니다");
             response.put("resourceType", resourceType);
             response.put("action", action);
-            
-            return ResponseEntity.ok(response);
+
+            return ResponseEntity.ok(ApiResponse.success(response, "캐시가 성공적으로 무효화되었습니다."));
         } catch (Exception e) {
             log.error("캐시 무효화 중 오류 발생", e);
-            
-            Map<String, Object> response = new HashMap<>();
-            response.put("success", false);
-            response.put("message", "캐시 무효화 중 오류가 발생했습니다: " + e.getMessage());
-            
-            return ResponseEntity.ok(response);
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.error(SecurityErrorCode.POLICY_CACHE_ERROR,
+                            "캐시 무효화 중 오류가 발생했습니다: " + e.getMessage()));
         }
     }
 
     /**
      * 정책 엔진 상태 확인 API
-     * 
+     *
      * @return 정책 엔진 상태 정보
      */
     @GetMapping("/health")
     @Operation(summary = "헬스 체크", description = "정책 엔진 서비스 상태를 확인합니다.")
-    public ResponseEntity<Map<String, Object>> healthCheck() {
+    public ResponseEntity<ApiResponse<Map<String, Object>>> healthCheck() {
         Map<String, Object> response = new HashMap<>();
         response.put("status", "UP");
         response.put("service", "PolicyEngine");
         response.put("version", "1.0.0");
         response.put("timestamp", System.currentTimeMillis());
-        
-        return ResponseEntity.ok(response);
+
+        return ResponseEntity.ok(ApiResponse.success(response, "정책 엔진이 정상적으로 동작 중입니다."));
     }
 
     /**
      * 간단한 정책 평가 테스트 API
-     * 
+     *
      * @return 테스트 결과
      */
     @GetMapping("/test")
     @Operation(summary = "정책 엔진 테스트", description = "정책 엔진 기본 기능을 테스트합니다.")
-    public ResponseEntity<Map<String, Object>> testPolicyEngine() {
+    public ResponseEntity<ApiResponse<Map<String, Object>>> testPolicyEngine() {
         log.info("정책 엔진 테스트 요청");
-        
+
         try {
             // 테스트용 요청 생성
             PolicyEvaluationRequest testRequest = PolicyEvaluationRequest.builder()
@@ -135,23 +135,21 @@ public class PolicyEngineController {
                     .tenantKey("test-tenant")
                     .clientIp("127.0.0.1")
                     .build();
-            
+
             PolicyEvaluationResult result = policyEngineService.evaluatePolicy(testRequest);
-            
+
             Map<String, Object> response = new HashMap<>();
             response.put("success", true);
             response.put("message", "정책 엔진이 정상적으로 동작합니다");
             response.put("testResult", result);
-            
-            return ResponseEntity.ok(response);
+
+            return ResponseEntity.ok(ApiResponse.success(response, "정책 엔진이 정상적으로 동작합니다."));
         } catch (Exception e) {
             log.error("정책 엔진 테스트 중 오류 발생", e);
-            
-            Map<String, Object> response = new HashMap<>();
-            response.put("success", false);
-            response.put("message", "정책 엔진 테스트 중 오류가 발생했습니다: " + e.getMessage());
-            
-            return ResponseEntity.ok(response);
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.error(SecurityErrorCode.POLICY_EVALUATION_FAILED,
+                            "정책 엔진 테스트 중 오류가 발생했습니다: " + e.getMessage()));
         }
     }
 }

--- a/src/main/java/com/agenticcp/core/domain/security/controller/PolicyPriorityController.java
+++ b/src/main/java/com/agenticcp/core/domain/security/controller/PolicyPriorityController.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,10 +26,15 @@ import java.util.stream.Collectors;
 /**
  * 정책 우선순위 및 충돌 해결 테스트용 컨트롤러
  * Feature 2 기능을 수동으로 테스트하기 위한 API 제공
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-11-08
  */
 @RestController
 @RequestMapping("/security/priority")
 @RequiredArgsConstructor
+@Slf4j
 @Tag(name = "Policy Priority Management", description = "정책 우선순위 및 충돌 해결 테스트 API")
 public class PolicyPriorityController {
 
@@ -43,6 +49,7 @@ public class PolicyPriorityController {
     public ResponseEntity<ApiResponse<Map<String, Object>>> validatePriority(
             @PathVariable Integer priority) {
         
+        log.info("[PolicyPriorityController] validatePriority - priority={}", priority);
         boolean isValid = policyPriorityService.isValidPriority(priority);
         
         Map<String, Object> result = new HashMap<>();
@@ -62,6 +69,7 @@ public class PolicyPriorityController {
     public ResponseEntity<ApiResponse<Map<String, Object>>> assignAutoPriority(
             @RequestParam(required = false) String tenantId) {
         
+        log.info("[PolicyPriorityController] assignAutoPriority - tenantId={}", tenantId);
         Integer assignedPriority = policyPriorityService.assignAutoPriority(tenantId != null ? Long.valueOf(tenantId) : null);
         
         Map<String, Object> result = new HashMap<>();
@@ -81,6 +89,7 @@ public class PolicyPriorityController {
             @RequestParam(required = false) String tenantId,
             @RequestParam(required = false) Integer currentPriority) {
         
+        log.info("[PolicyPriorityController] findNextAvailablePriority - tenantId={}, currentPriority={}", tenantId, currentPriority);
         Integer nextPriority = policyPriorityService.findNextAvailablePriority(tenantId != null ? Long.valueOf(tenantId) : null, currentPriority);
         
         Map<String, Object> result = new HashMap<>();
@@ -101,6 +110,7 @@ public class PolicyPriorityController {
             @RequestParam(required = false) String tenantId,
             @RequestParam(defaultValue = "false") boolean ascending) {
         
+        log.info("[PolicyPriorityController] getSortedPolicies - tenantId={}, ascending={}", tenantId, ascending);
         List<SecurityPolicy> policies;
         if (tenantId != null) {
             policies = policyRepository.findByTenantIdAndIsEnabledTrue(Long.valueOf(tenantId));
@@ -139,6 +149,7 @@ public class PolicyPriorityController {
     public ResponseEntity<ApiResponse<PolicyConflictResolution>> resolveConflict(
             @RequestBody ConflictSimulationRequest request) {
         
+        log.info("[PolicyPriorityController] resolveConflict - request={}", request);
         // 정책 ID 목록으로 정책 조회
         List<SecurityPolicy> policies = request.getPolicyIds().stream()
             .map(id -> policyRepository.findById(id).orElse(null))
@@ -178,6 +189,7 @@ public class PolicyPriorityController {
     @GetMapping("/strategies")
     @Operation(summary = "충돌 해결 전략 목록", description = "사용 가능한 모든 충돌 해결 전략을 조회합니다")
     public ResponseEntity<ApiResponse<List<Map<String, String>>>> getStrategies() {
+        log.info("[PolicyPriorityController] getStrategies");
         List<Map<String, String>> strategies = java.util.Arrays.stream(ConflictResolutionStrategy.values())
             .map(s -> {
                 Map<String, String> map = new HashMap<>();

--- a/src/main/java/com/agenticcp/core/domain/security/controller/SecurityInspectorController.java
+++ b/src/main/java/com/agenticcp/core/domain/security/controller/SecurityInspectorController.java
@@ -5,139 +5,88 @@ import com.agenticcp.core.domain.security.annotation.RequirePermission;
 import com.agenticcp.core.domain.security.annotation.RequireRole;
 import com.agenticcp.core.domain.security.service.AuthorizationService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.Map;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.Authentication;
 
-/**
- * 보안 인스펙터 REST API 컨트롤러
- *
- * <p>인증된 사용자의 권한 및 역할 상태를 조회하고 캐시를 관리하기 위한 진단용 API를 제공합니다.</p>
- *
- * @author AgenticCP Team
- * @version 1.0.0
- * @since 2025-11-08
- */
 @RestController
-@RequestMapping("/v1/security")
+@RequestMapping("/api/v1/security")
 @RequiredArgsConstructor
-@Slf4j
-@Tag(name = "Security Inspector", description = "권한 및 역할 검증, 캐시 진단 API")
 public class SecurityInspectorController {
 
     private final AuthorizationService authorizationService;
 
     @GetMapping("/check/permission")
-    @Operation(summary = "권한 확인", description = "현재 사용자에게 특정 권한이 있는지 확인합니다.")
     public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkPermission(@RequestParam String permissionKey) {
-        String username = getCurrentUsername();
-        log.info("[SecurityInspectorController] checkPermission - username={}, permissionKey={}", username, permissionKey);
+        String username = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication().getName();
         boolean result = authorizationService.hasPermission(username, permissionKey);
-        return ResponseEntity.ok(ApiResponse.success(Map.of("hasPermission", result), "권한 확인을 완료했습니다."));
+        return ResponseEntity.ok(ApiResponse.success(Map.of("hasPermission", result)));
     }
 
     @GetMapping("/check/role")
-    @Operation(summary = "역할 확인", description = "현재 사용자에게 특정 역할이 있는지 확인합니다.")
     public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkRole(@RequestParam String roleKey) {
-        String username = getCurrentUsername();
-        log.info("[SecurityInspectorController] checkRole - username={}, roleKey={}", username, roleKey);
+        String username = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication().getName();
         boolean result = authorizationService.hasRole(username, roleKey);
-        return ResponseEntity.ok(ApiResponse.success(Map.of("hasRole", result), "역할 확인을 완료했습니다."));
+        return ResponseEntity.ok(ApiResponse.success(Map.of("hasRole", result)));
     }
 
     @PostMapping("/tenant/validate")
-    @Operation(summary = "테넌트 검증", description = "현재 사용자가 요청한 테넌트에 접근할 수 있는지 검증합니다.")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> validateTenant(
-            @RequestHeader(value = "X-Tenant-Key", required = false) String tenantHeader,
-            @RequestBody(required = false) Map<String, String> body) {
+    public ResponseEntity<Void> validateTenant(@RequestHeader(value = "X-Tenant-Key", required = false) String tenantHeader,
+                                               @RequestBody(required = false) Map<String, String> body) {
         String tenantKey = tenantHeader != null ? tenantHeader : (body != null ? body.get("tenantKey") : null);
-        String username = getCurrentUsername();
-        log.info("[SecurityInspectorController] validateTenant - username={}, tenantKey={}", username, tenantKey);
+        String username = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication().getName();
         authorizationService.validateTenantAccess(username, tenantKey);
-        return ResponseEntity.ok(ApiResponse.success(Map.of("tenantKey", tenantKey), "테넌트 접근이 허용되었습니다."));
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/me")
-    @Operation(summary = "현재 사용자 정보", description = "인증된 사용자의 기본 정보를 조회합니다.")
     public ResponseEntity<ApiResponse<Map<String, String>>> me() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        var auth = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication();
         String username = auth.getName();
-        log.info("[SecurityInspectorController] me - username={}", username);
-        return ResponseEntity.ok(ApiResponse.success(Map.of("username", username), "사용자 정보를 조회했습니다."));
+        // displayName/tenantKey는 실제 UserService를 통해 가져올 수 있으나 여기서는 username만 반환
+        return ResponseEntity.ok(ApiResponse.success(Map.of("username", username)));
     }
 
     @GetMapping("/me/permissions")
-    @Operation(summary = "현재 사용자 권한", description = "인증된 사용자가 보유한 권한 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<Map<String, Object>>> myPermissions() {
-        String username = getCurrentUsername();
-        log.info("[SecurityInspectorController] myPermissions - username={}", username);
+        String username = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication().getName();
         var permissions = authorizationService.getUserPermissions(username);
-        return ResponseEntity.ok(ApiResponse.success(Map.of("permissions", permissions), "사용자 권한을 조회했습니다."));
+        return ResponseEntity.ok(ApiResponse.success(Map.of("permissions", permissions)));
     }
 
     @PostMapping("/cache/permissions/evict")
-    @Operation(summary = "권한 캐시 무효화", description = "사용자 권한 캐시를 무효화합니다.")
-    public ResponseEntity<ApiResponse<Map<String, String>>> evictCache(
-            @RequestBody(required = false) Map<String, String> body) {
-        String username = getCurrentUsername();
+    public ResponseEntity<Void> evictCache(@RequestBody(required = false) Map<String, String> body) {
+        String username = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication().getName();
         String target = body != null && body.get("username") != null ? body.get("username") : username;
-        log.info("[SecurityInspectorController] evictCache - requester={}, target={}", username, target);
         authorizationService.evictUserPermissionCache(target);
-        return ResponseEntity.ok(ApiResponse.success(Map.of("username", target), "권한 캐시를 무효화했습니다."));
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/cache/permissions/warm")
-    @Operation(summary = "권한 캐시 워밍업", description = "사용자 권한 캐시를 선제적으로 로드합니다.")
-    public ResponseEntity<ApiResponse<Map<String, String>>> warmCache(
-            @RequestBody(required = false) Map<String, String> body) {
-        String username = getCurrentUsername();
+    public ResponseEntity<Void> warmCache(@RequestBody(required = false) Map<String, String> body) {
+        String username = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication().getName();
         String target = body != null && body.get("username") != null ? body.get("username") : username;
-        log.info("[SecurityInspectorController] warmCache - requester={}, target={}", username, target);
         authorizationService.warmUserPermissionCache(target);
-        return ResponseEntity.ok(ApiResponse.success(Map.of("username", target), "권한 캐시를 워밍업했습니다."));
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/_test/protected/permission")
     @RequirePermission("sample.permission")
-    @Operation(summary = "권한 보호 테스트", description = "권한 기반 보호가 정상 동작하는지 확인합니다.")
     public ResponseEntity<ApiResponse<String>> protectedByPermission() {
-        String username = getCurrentUsername();
-        log.info("[SecurityInspectorController] protectedByPermission - username={}", username);
-        return ResponseEntity.ok(ApiResponse.success("OK", "권한 검증을 통과했습니다."));
+        return ResponseEntity.ok(ApiResponse.success("OK"));
     }
 
     @GetMapping("/_test/protected/role")
     @RequireRole({"TESTER"})
-    @Operation(summary = "역할 보호 테스트", description = "역할 기반 보호가 정상 동작하는지 확인합니다.")
     public ResponseEntity<ApiResponse<String>> protectedByRole() {
-        String username = getCurrentUsername();
-        log.info("[SecurityInspectorController] protectedByRole - username={}", username);
-        return ResponseEntity.ok(ApiResponse.success("OK", "역할 검증을 통과했습니다."));
+        return ResponseEntity.ok(ApiResponse.success("OK"));
     }
 
     @GetMapping("/_test/protected/preauthorize")
     @org.springframework.security.access.prepost.PreAuthorize("hasAnyRole('ADMIN','AUDITOR')")
-    @Operation(summary = "PreAuthorize 테스트", description = "Spring Security의 PreAuthorize 보호를 검증합니다.")
     public ResponseEntity<ApiResponse<String>> protectedByPreAuthorize() {
-        String username = getCurrentUsername();
-        log.info("[SecurityInspectorController] protectedByPreAuthorize - username={}", username);
-        return ResponseEntity.ok(ApiResponse.success("OK", "PreAuthorize 검증을 통과했습니다."));
-    }
-
-    private String getCurrentUsername() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            log.warn("[SecurityInspectorController] getCurrentUsername - unauthenticated access detected");
-            throw new AccessDeniedException("인증되지 않은 사용자입니다");
-        }
-        return authentication.getName();
+        return ResponseEntity.ok(ApiResponse.success("OK"));
     }
 }
 

--- a/src/main/java/com/agenticcp/core/domain/security/controller/SecurityInspectorController.java
+++ b/src/main/java/com/agenticcp/core/domain/security/controller/SecurityInspectorController.java
@@ -5,88 +5,139 @@ import com.agenticcp.core.domain.security.annotation.RequirePermission;
 import com.agenticcp.core.domain.security.annotation.RequireRole;
 import com.agenticcp.core.domain.security.service.AuthorizationService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.Map;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.Authentication;
 
+/**
+ * 보안 인스펙터 REST API 컨트롤러
+ *
+ * <p>인증된 사용자의 권한 및 역할 상태를 조회하고 캐시를 관리하기 위한 진단용 API를 제공합니다.</p>
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-11-08
+ */
 @RestController
-@RequestMapping("/api/v1/security")
+@RequestMapping("/v1/security")
 @RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Security Inspector", description = "권한 및 역할 검증, 캐시 진단 API")
 public class SecurityInspectorController {
 
     private final AuthorizationService authorizationService;
 
     @GetMapping("/check/permission")
+    @Operation(summary = "권한 확인", description = "현재 사용자에게 특정 권한이 있는지 확인합니다.")
     public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkPermission(@RequestParam String permissionKey) {
-        String username = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication().getName();
+        String username = getCurrentUsername();
+        log.info("[SecurityInspectorController] checkPermission - username={}, permissionKey={}", username, permissionKey);
         boolean result = authorizationService.hasPermission(username, permissionKey);
-        return ResponseEntity.ok(ApiResponse.success(Map.of("hasPermission", result)));
+        return ResponseEntity.ok(ApiResponse.success(Map.of("hasPermission", result), "권한 확인을 완료했습니다."));
     }
 
     @GetMapping("/check/role")
+    @Operation(summary = "역할 확인", description = "현재 사용자에게 특정 역할이 있는지 확인합니다.")
     public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkRole(@RequestParam String roleKey) {
-        String username = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication().getName();
+        String username = getCurrentUsername();
+        log.info("[SecurityInspectorController] checkRole - username={}, roleKey={}", username, roleKey);
         boolean result = authorizationService.hasRole(username, roleKey);
-        return ResponseEntity.ok(ApiResponse.success(Map.of("hasRole", result)));
+        return ResponseEntity.ok(ApiResponse.success(Map.of("hasRole", result), "역할 확인을 완료했습니다."));
     }
 
     @PostMapping("/tenant/validate")
-    public ResponseEntity<Void> validateTenant(@RequestHeader(value = "X-Tenant-Key", required = false) String tenantHeader,
-                                               @RequestBody(required = false) Map<String, String> body) {
+    @Operation(summary = "테넌트 검증", description = "현재 사용자가 요청한 테넌트에 접근할 수 있는지 검증합니다.")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> validateTenant(
+            @RequestHeader(value = "X-Tenant-Key", required = false) String tenantHeader,
+            @RequestBody(required = false) Map<String, String> body) {
         String tenantKey = tenantHeader != null ? tenantHeader : (body != null ? body.get("tenantKey") : null);
-        String username = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication().getName();
+        String username = getCurrentUsername();
+        log.info("[SecurityInspectorController] validateTenant - username={}, tenantKey={}", username, tenantKey);
         authorizationService.validateTenantAccess(username, tenantKey);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.success(Map.of("tenantKey", tenantKey), "테넌트 접근이 허용되었습니다."));
     }
 
     @GetMapping("/me")
+    @Operation(summary = "현재 사용자 정보", description = "인증된 사용자의 기본 정보를 조회합니다.")
     public ResponseEntity<ApiResponse<Map<String, String>>> me() {
-        var auth = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication();
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         String username = auth.getName();
-        // displayName/tenantKey는 실제 UserService를 통해 가져올 수 있으나 여기서는 username만 반환
-        return ResponseEntity.ok(ApiResponse.success(Map.of("username", username)));
+        log.info("[SecurityInspectorController] me - username={}", username);
+        return ResponseEntity.ok(ApiResponse.success(Map.of("username", username), "사용자 정보를 조회했습니다."));
     }
 
     @GetMapping("/me/permissions")
+    @Operation(summary = "현재 사용자 권한", description = "인증된 사용자가 보유한 권한 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<Map<String, Object>>> myPermissions() {
-        String username = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication().getName();
+        String username = getCurrentUsername();
+        log.info("[SecurityInspectorController] myPermissions - username={}", username);
         var permissions = authorizationService.getUserPermissions(username);
-        return ResponseEntity.ok(ApiResponse.success(Map.of("permissions", permissions)));
+        return ResponseEntity.ok(ApiResponse.success(Map.of("permissions", permissions), "사용자 권한을 조회했습니다."));
     }
 
     @PostMapping("/cache/permissions/evict")
-    public ResponseEntity<Void> evictCache(@RequestBody(required = false) Map<String, String> body) {
-        String username = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication().getName();
+    @Operation(summary = "권한 캐시 무효화", description = "사용자 권한 캐시를 무효화합니다.")
+    public ResponseEntity<ApiResponse<Map<String, String>>> evictCache(
+            @RequestBody(required = false) Map<String, String> body) {
+        String username = getCurrentUsername();
         String target = body != null && body.get("username") != null ? body.get("username") : username;
+        log.info("[SecurityInspectorController] evictCache - requester={}, target={}", username, target);
         authorizationService.evictUserPermissionCache(target);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.success(Map.of("username", target), "권한 캐시를 무효화했습니다."));
     }
 
     @PostMapping("/cache/permissions/warm")
-    public ResponseEntity<Void> warmCache(@RequestBody(required = false) Map<String, String> body) {
-        String username = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication().getName();
+    @Operation(summary = "권한 캐시 워밍업", description = "사용자 권한 캐시를 선제적으로 로드합니다.")
+    public ResponseEntity<ApiResponse<Map<String, String>>> warmCache(
+            @RequestBody(required = false) Map<String, String> body) {
+        String username = getCurrentUsername();
         String target = body != null && body.get("username") != null ? body.get("username") : username;
+        log.info("[SecurityInspectorController] warmCache - requester={}, target={}", username, target);
         authorizationService.warmUserPermissionCache(target);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.success(Map.of("username", target), "권한 캐시를 워밍업했습니다."));
     }
 
     @GetMapping("/_test/protected/permission")
     @RequirePermission("sample.permission")
+    @Operation(summary = "권한 보호 테스트", description = "권한 기반 보호가 정상 동작하는지 확인합니다.")
     public ResponseEntity<ApiResponse<String>> protectedByPermission() {
-        return ResponseEntity.ok(ApiResponse.success("OK"));
+        String username = getCurrentUsername();
+        log.info("[SecurityInspectorController] protectedByPermission - username={}", username);
+        return ResponseEntity.ok(ApiResponse.success("OK", "권한 검증을 통과했습니다."));
     }
 
     @GetMapping("/_test/protected/role")
     @RequireRole({"TESTER"})
+    @Operation(summary = "역할 보호 테스트", description = "역할 기반 보호가 정상 동작하는지 확인합니다.")
     public ResponseEntity<ApiResponse<String>> protectedByRole() {
-        return ResponseEntity.ok(ApiResponse.success("OK"));
+        String username = getCurrentUsername();
+        log.info("[SecurityInspectorController] protectedByRole - username={}", username);
+        return ResponseEntity.ok(ApiResponse.success("OK", "역할 검증을 통과했습니다."));
     }
 
     @GetMapping("/_test/protected/preauthorize")
     @org.springframework.security.access.prepost.PreAuthorize("hasAnyRole('ADMIN','AUDITOR')")
+    @Operation(summary = "PreAuthorize 테스트", description = "Spring Security의 PreAuthorize 보호를 검증합니다.")
     public ResponseEntity<ApiResponse<String>> protectedByPreAuthorize() {
-        return ResponseEntity.ok(ApiResponse.success("OK"));
+        String username = getCurrentUsername();
+        log.info("[SecurityInspectorController] protectedByPreAuthorize - username={}", username);
+        return ResponseEntity.ok(ApiResponse.success("OK", "PreAuthorize 검증을 통과했습니다."));
+    }
+
+    private String getCurrentUsername() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            log.warn("[SecurityInspectorController] getCurrentUsername - unauthenticated access detected");
+            throw new AccessDeniedException("인증되지 않은 사용자입니다");
+        }
+        return authentication.getName();
     }
 }
 

--- a/src/main/java/com/agenticcp/core/domain/security/controller/SecurityPolicyController.java
+++ b/src/main/java/com/agenticcp/core/domain/security/controller/SecurityPolicyController.java
@@ -2,126 +2,201 @@ package com.agenticcp.core.domain.security.controller;
 
 import com.agenticcp.core.common.dto.exception.ApiResponse;
 import com.agenticcp.core.domain.security.entity.SecurityPolicy;
+import com.agenticcp.core.domain.security.enums.SecurityErrorCode;
 import com.agenticcp.core.domain.security.service.SecurityPolicyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * 보안 정책 관리 REST API 컨트롤러
+ *
+ * <p>보안 정책의 조회, 생성, 수정 및 삭제 기능을 제공합니다.</p>
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-11-08
+ */
 @RestController
-@RequestMapping("/security/policies")
+@RequestMapping("/v1/security/policies")
 @RequiredArgsConstructor
+@Slf4j
 @Tag(name = "Security Policy Management", description = "보안 정책 관리 API")
 public class SecurityPolicyController {
 
     private final SecurityPolicyService securityPolicyService;
 
+    /**
+     * 모든 보안 정책을 조회합니다.
+     */
     @GetMapping
-    @Operation(summary = "모든 보안 정책 조회")
+    @Operation(summary = "모든 보안 정책 조회", description = "시스템에 등록된 모든 보안 정책 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<List<SecurityPolicy>>> getAllPolicies() {
+        log.info("[SecurityPolicyController] getAllPolicies");
         List<SecurityPolicy> policies = securityPolicyService.getAllPolicies();
-        return ResponseEntity.ok(ApiResponse.success(policies));
+        return ResponseEntity.ok(ApiResponse.success(policies, "보안 정책 목록을 조회했습니다."));
     }
 
+    /**
+     * 활성화된 보안 정책을 조회합니다.
+     */
     @GetMapping("/active")
-    @Operation(summary = "활성 보안 정책 조회")
+    @Operation(summary = "활성 보안 정책 조회", description = "현재 활성화된 보안 정책 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<List<SecurityPolicy>>> getActivePolicies() {
+        log.info("[SecurityPolicyController] getActivePolicies");
         List<SecurityPolicy> policies = securityPolicyService.getActivePolicies();
-        return ResponseEntity.ok(ApiResponse.success(policies));
+        return ResponseEntity.ok(ApiResponse.success(policies, "활성 보안 정책을 조회했습니다."));
     }
 
+    /**
+     * 정책 키로 보안 정책을 조회합니다.
+     */
     @GetMapping("/{policyKey}")
-    @Operation(summary = "특정 보안 정책 조회")
+    @Operation(summary = "특정 보안 정책 조회", description = "정책 키로 보안 정책을 조회합니다.")
     public ResponseEntity<ApiResponse<SecurityPolicy>> getPolicyByKey(@PathVariable String policyKey) {
+        log.info("[SecurityPolicyController] getPolicyByKey - policyKey={}", policyKey);
         return securityPolicyService.getPolicyByKey(policyKey)
-                .map(policy -> ResponseEntity.ok(ApiResponse.success(policy)))
-                .orElse(ResponseEntity.notFound().build());
+                .map(policy -> ResponseEntity.ok(ApiResponse.success(policy, "보안 정책을 조회했습니다.")))
+                .orElseGet(() -> {
+                    log.warn("[SecurityPolicyController] getPolicyByKey - not found, policyKey={}", policyKey);
+                    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                            .body(ApiResponse.error(SecurityErrorCode.POLICY_NOT_FOUND,
+                                    "보안 정책을 찾을 수 없습니다: " + policyKey));
+                });
     }
 
+    /**
+     * 정책 타입별로 보안 정책을 조회합니다.
+     */
     @GetMapping("/type/{policyType}")
-    @Operation(summary = "정책 타입별 조회")
+    @Operation(summary = "정책 타입별 조회", description = "정책 타입에 따라 보안 정책 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<List<SecurityPolicy>>> getPoliciesByType(
             @PathVariable SecurityPolicy.PolicyType policyType) {
+        log.info("[SecurityPolicyController] getPoliciesByType - policyType={}", policyType);
         List<SecurityPolicy> policies = securityPolicyService.getPoliciesByType(policyType);
-        return ResponseEntity.ok(ApiResponse.success(policies));
+        return ResponseEntity.ok(ApiResponse.success(policies, "정책 타입별 정책을 조회했습니다."));
     }
 
+    /**
+     * 글로벌 보안 정책을 조회합니다.
+     */
     @GetMapping("/global")
-    @Operation(summary = "글로벌 보안 정책 조회")
+    @Operation(summary = "글로벌 보안 정책 조회", description = "모든 테넌트에 적용되는 글로벌 보안 정책을 조회합니다.")
     public ResponseEntity<ApiResponse<List<SecurityPolicy>>> getGlobalPolicies() {
+        log.info("[SecurityPolicyController] getGlobalPolicies");
         List<SecurityPolicy> policies = securityPolicyService.getGlobalPolicies();
-        return ResponseEntity.ok(ApiResponse.success(policies));
+        return ResponseEntity.ok(ApiResponse.success(policies, "글로벌 보안 정책을 조회했습니다."));
     }
 
+    /**
+     * 시스템 보안 정책을 조회합니다.
+     */
     @GetMapping("/system")
-    @Operation(summary = "시스템 보안 정책 조회")
+    @Operation(summary = "시스템 보안 정책 조회", description = "시스템에서 관리하는 보안 정책을 조회합니다.")
     public ResponseEntity<ApiResponse<List<SecurityPolicy>>> getSystemPolicies() {
+        log.info("[SecurityPolicyController] getSystemPolicies");
         List<SecurityPolicy> policies = securityPolicyService.getSystemPolicies();
-        return ResponseEntity.ok(ApiResponse.success(policies));
+        return ResponseEntity.ok(ApiResponse.success(policies, "시스템 보안 정책을 조회했습니다."));
     }
 
+    /**
+     * 유효한 보안 정책을 조회합니다.
+     */
     @GetMapping("/effective")
-    @Operation(summary = "유효한 보안 정책 조회")
+    @Operation(summary = "유효한 보안 정책 조회", description = "현재 유효한 보안 정책 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<List<SecurityPolicy>>> getEffectivePolicies() {
+        log.info("[SecurityPolicyController] getEffectivePolicies");
         List<SecurityPolicy> policies = securityPolicyService.getEffectivePolicies();
-        return ResponseEntity.ok(ApiResponse.success(policies));
+        return ResponseEntity.ok(ApiResponse.success(policies, "유효한 보안 정책을 조회했습니다."));
     }
 
+    /**
+     * 정책 타입별로 우선순위 순 정렬된 보안 정책을 조회합니다.
+     */
     @GetMapping("/type/{policyType}/ordered")
-    @Operation(summary = "우선순위별 정책 조회")
+    @Operation(summary = "우선순위별 정책 조회", description = "정책 타입별로 우선순위 순으로 정렬된 보안 정책을 조회합니다.")
     public ResponseEntity<ApiResponse<List<SecurityPolicy>>> getPoliciesByTypeOrderedByPriority(
             @PathVariable SecurityPolicy.PolicyType policyType) {
+        log.info("[SecurityPolicyController] getPoliciesByTypeOrderedByPriority - policyType={}", policyType);
         List<SecurityPolicy> policies = securityPolicyService.getPoliciesByTypeOrderedByPriority(policyType);
-        return ResponseEntity.ok(ApiResponse.success(policies));
+        return ResponseEntity.ok(ApiResponse.success(policies, "우선순위 순으로 정책을 조회했습니다."));
     }
 
+    /**
+     * 보안 정책을 생성합니다.
+     */
     @PostMapping
-    @Operation(summary = "보안 정책 생성")
+    @Operation(summary = "보안 정책 생성", description = "새로운 보안 정책을 생성합니다.")
     public ResponseEntity<ApiResponse<SecurityPolicy>> createPolicy(@RequestBody SecurityPolicy securityPolicy) {
+        String policyKeyLog = securityPolicy != null ? securityPolicy.getPolicyKey() : "null";
+        log.info("[SecurityPolicyController] createPolicy - policyKey={}", policyKeyLog);
         SecurityPolicy createdPolicy = securityPolicyService.createPolicy(securityPolicy);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(createdPolicy, "보안 정책이 생성되었습니다."));
     }
 
+    /**
+     * 보안 정책을 수정합니다.
+     */
     @PutMapping("/{policyKey}")
-    @Operation(summary = "보안 정책 수정")
+    @Operation(summary = "보안 정책 수정", description = "보안 정책을 전체 수정합니다.")
     public ResponseEntity<ApiResponse<SecurityPolicy>> updatePolicy(
-            @PathVariable String policyKey, 
+            @PathVariable String policyKey,
             @RequestBody SecurityPolicy securityPolicy) {
+        log.info("[SecurityPolicyController] updatePolicy - policyKey={}, payloadKey={}", policyKey,
+                securityPolicy != null ? securityPolicy.getPolicyKey() : "null");
         SecurityPolicy updatedPolicy = securityPolicyService.updatePolicy(policyKey, securityPolicy);
         return ResponseEntity.ok(ApiResponse.success(updatedPolicy, "보안 정책이 수정되었습니다."));
     }
 
+    /**
+     * 보안 정책의 활성화 상태를 토글합니다.
+     */
     @PatchMapping("/{policyKey}/toggle")
-    @Operation(summary = "보안 정책 토글")
+    @Operation(summary = "보안 정책 토글", description = "보안 정책의 활성화 상태를 토글합니다.")
     public ResponseEntity<ApiResponse<SecurityPolicy>> togglePolicy(
-            @PathVariable String policyKey, 
+            @PathVariable String policyKey,
             @RequestParam boolean enabled) {
+        log.info("[SecurityPolicyController] togglePolicy - policyKey={}, enabled={}", policyKey, enabled);
         SecurityPolicy toggledPolicy = securityPolicyService.togglePolicy(policyKey, enabled);
         return ResponseEntity.ok(ApiResponse.success(toggledPolicy, "보안 정책이 토글되었습니다."));
     }
 
+    /**
+     * 보안 정책을 활성화합니다.
+     */
     @PatchMapping("/{policyKey}/activate")
-    @Operation(summary = "보안 정책 활성화")
+    @Operation(summary = "보안 정책 활성화", description = "비활성화된 보안 정책을 활성화합니다.")
     public ResponseEntity<ApiResponse<SecurityPolicy>> activatePolicy(@PathVariable String policyKey) {
+        log.info("[SecurityPolicyController] activatePolicy - policyKey={}", policyKey);
         SecurityPolicy activatedPolicy = securityPolicyService.activatePolicy(policyKey);
         return ResponseEntity.ok(ApiResponse.success(activatedPolicy, "보안 정책이 활성화되었습니다."));
     }
 
+    /**
+     * 보안 정책을 비활성화합니다.
+     */
     @PatchMapping("/{policyKey}/deactivate")
-    @Operation(summary = "보안 정책 비활성화")
+    @Operation(summary = "보안 정책 비활성화", description = "보안 정책을 비활성화합니다.")
     public ResponseEntity<ApiResponse<SecurityPolicy>> deactivatePolicy(@PathVariable String policyKey) {
+        log.info("[SecurityPolicyController] deactivatePolicy - policyKey={}", policyKey);
         SecurityPolicy deactivatedPolicy = securityPolicyService.deactivatePolicy(policyKey);
         return ResponseEntity.ok(ApiResponse.success(deactivatedPolicy, "보안 정책이 비활성화되었습니다."));
     }
 
+    /**
+     * 보안 정책을 삭제합니다.
+     */
     @DeleteMapping("/{policyKey}")
-    @Operation(summary = "보안 정책 삭제")
+    @Operation(summary = "보안 정책 삭제", description = "보안 정책을 삭제합니다.")
     public ResponseEntity<ApiResponse<Void>> deletePolicy(@PathVariable String policyKey) {
+        log.info("[SecurityPolicyController] deletePolicy - policyKey={}", policyKey);
         securityPolicyService.deletePolicy(policyKey);
         return ResponseEntity.ok(ApiResponse.success(null, "보안 정책이 삭제되었습니다."));
     }

--- a/src/main/java/com/agenticcp/core/domain/security/controller/SecurityPolicyController.java
+++ b/src/main/java/com/agenticcp/core/domain/security/controller/SecurityPolicyController.java
@@ -2,201 +2,126 @@ package com.agenticcp.core.domain.security.controller;
 
 import com.agenticcp.core.common.dto.exception.ApiResponse;
 import com.agenticcp.core.domain.security.entity.SecurityPolicy;
-import com.agenticcp.core.domain.security.enums.SecurityErrorCode;
 import com.agenticcp.core.domain.security.service.SecurityPolicyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-/**
- * 보안 정책 관리 REST API 컨트롤러
- *
- * <p>보안 정책의 조회, 생성, 수정 및 삭제 기능을 제공합니다.</p>
- *
- * @author AgenticCP Team
- * @version 1.0.0
- * @since 2025-11-08
- */
 @RestController
-@RequestMapping("/v1/security/policies")
+@RequestMapping("/security/policies")
 @RequiredArgsConstructor
-@Slf4j
 @Tag(name = "Security Policy Management", description = "보안 정책 관리 API")
 public class SecurityPolicyController {
 
     private final SecurityPolicyService securityPolicyService;
 
-    /**
-     * 모든 보안 정책을 조회합니다.
-     */
     @GetMapping
-    @Operation(summary = "모든 보안 정책 조회", description = "시스템에 등록된 모든 보안 정책 목록을 조회합니다.")
+    @Operation(summary = "모든 보안 정책 조회")
     public ResponseEntity<ApiResponse<List<SecurityPolicy>>> getAllPolicies() {
-        log.info("[SecurityPolicyController] getAllPolicies");
         List<SecurityPolicy> policies = securityPolicyService.getAllPolicies();
-        return ResponseEntity.ok(ApiResponse.success(policies, "보안 정책 목록을 조회했습니다."));
+        return ResponseEntity.ok(ApiResponse.success(policies));
     }
 
-    /**
-     * 활성화된 보안 정책을 조회합니다.
-     */
     @GetMapping("/active")
-    @Operation(summary = "활성 보안 정책 조회", description = "현재 활성화된 보안 정책 목록을 조회합니다.")
+    @Operation(summary = "활성 보안 정책 조회")
     public ResponseEntity<ApiResponse<List<SecurityPolicy>>> getActivePolicies() {
-        log.info("[SecurityPolicyController] getActivePolicies");
         List<SecurityPolicy> policies = securityPolicyService.getActivePolicies();
-        return ResponseEntity.ok(ApiResponse.success(policies, "활성 보안 정책을 조회했습니다."));
+        return ResponseEntity.ok(ApiResponse.success(policies));
     }
 
-    /**
-     * 정책 키로 보안 정책을 조회합니다.
-     */
     @GetMapping("/{policyKey}")
-    @Operation(summary = "특정 보안 정책 조회", description = "정책 키로 보안 정책을 조회합니다.")
+    @Operation(summary = "특정 보안 정책 조회")
     public ResponseEntity<ApiResponse<SecurityPolicy>> getPolicyByKey(@PathVariable String policyKey) {
-        log.info("[SecurityPolicyController] getPolicyByKey - policyKey={}", policyKey);
         return securityPolicyService.getPolicyByKey(policyKey)
-                .map(policy -> ResponseEntity.ok(ApiResponse.success(policy, "보안 정책을 조회했습니다.")))
-                .orElseGet(() -> {
-                    log.warn("[SecurityPolicyController] getPolicyByKey - not found, policyKey={}", policyKey);
-                    return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                            .body(ApiResponse.error(SecurityErrorCode.POLICY_NOT_FOUND,
-                                    "보안 정책을 찾을 수 없습니다: " + policyKey));
-                });
+                .map(policy -> ResponseEntity.ok(ApiResponse.success(policy)))
+                .orElse(ResponseEntity.notFound().build());
     }
 
-    /**
-     * 정책 타입별로 보안 정책을 조회합니다.
-     */
     @GetMapping("/type/{policyType}")
-    @Operation(summary = "정책 타입별 조회", description = "정책 타입에 따라 보안 정책 목록을 조회합니다.")
+    @Operation(summary = "정책 타입별 조회")
     public ResponseEntity<ApiResponse<List<SecurityPolicy>>> getPoliciesByType(
             @PathVariable SecurityPolicy.PolicyType policyType) {
-        log.info("[SecurityPolicyController] getPoliciesByType - policyType={}", policyType);
         List<SecurityPolicy> policies = securityPolicyService.getPoliciesByType(policyType);
-        return ResponseEntity.ok(ApiResponse.success(policies, "정책 타입별 정책을 조회했습니다."));
+        return ResponseEntity.ok(ApiResponse.success(policies));
     }
 
-    /**
-     * 글로벌 보안 정책을 조회합니다.
-     */
     @GetMapping("/global")
-    @Operation(summary = "글로벌 보안 정책 조회", description = "모든 테넌트에 적용되는 글로벌 보안 정책을 조회합니다.")
+    @Operation(summary = "글로벌 보안 정책 조회")
     public ResponseEntity<ApiResponse<List<SecurityPolicy>>> getGlobalPolicies() {
-        log.info("[SecurityPolicyController] getGlobalPolicies");
         List<SecurityPolicy> policies = securityPolicyService.getGlobalPolicies();
-        return ResponseEntity.ok(ApiResponse.success(policies, "글로벌 보안 정책을 조회했습니다."));
+        return ResponseEntity.ok(ApiResponse.success(policies));
     }
 
-    /**
-     * 시스템 보안 정책을 조회합니다.
-     */
     @GetMapping("/system")
-    @Operation(summary = "시스템 보안 정책 조회", description = "시스템에서 관리하는 보안 정책을 조회합니다.")
+    @Operation(summary = "시스템 보안 정책 조회")
     public ResponseEntity<ApiResponse<List<SecurityPolicy>>> getSystemPolicies() {
-        log.info("[SecurityPolicyController] getSystemPolicies");
         List<SecurityPolicy> policies = securityPolicyService.getSystemPolicies();
-        return ResponseEntity.ok(ApiResponse.success(policies, "시스템 보안 정책을 조회했습니다."));
+        return ResponseEntity.ok(ApiResponse.success(policies));
     }
 
-    /**
-     * 유효한 보안 정책을 조회합니다.
-     */
     @GetMapping("/effective")
-    @Operation(summary = "유효한 보안 정책 조회", description = "현재 유효한 보안 정책 목록을 조회합니다.")
+    @Operation(summary = "유효한 보안 정책 조회")
     public ResponseEntity<ApiResponse<List<SecurityPolicy>>> getEffectivePolicies() {
-        log.info("[SecurityPolicyController] getEffectivePolicies");
         List<SecurityPolicy> policies = securityPolicyService.getEffectivePolicies();
-        return ResponseEntity.ok(ApiResponse.success(policies, "유효한 보안 정책을 조회했습니다."));
+        return ResponseEntity.ok(ApiResponse.success(policies));
     }
 
-    /**
-     * 정책 타입별로 우선순위 순 정렬된 보안 정책을 조회합니다.
-     */
     @GetMapping("/type/{policyType}/ordered")
-    @Operation(summary = "우선순위별 정책 조회", description = "정책 타입별로 우선순위 순으로 정렬된 보안 정책을 조회합니다.")
+    @Operation(summary = "우선순위별 정책 조회")
     public ResponseEntity<ApiResponse<List<SecurityPolicy>>> getPoliciesByTypeOrderedByPriority(
             @PathVariable SecurityPolicy.PolicyType policyType) {
-        log.info("[SecurityPolicyController] getPoliciesByTypeOrderedByPriority - policyType={}", policyType);
         List<SecurityPolicy> policies = securityPolicyService.getPoliciesByTypeOrderedByPriority(policyType);
-        return ResponseEntity.ok(ApiResponse.success(policies, "우선순위 순으로 정책을 조회했습니다."));
+        return ResponseEntity.ok(ApiResponse.success(policies));
     }
 
-    /**
-     * 보안 정책을 생성합니다.
-     */
     @PostMapping
-    @Operation(summary = "보안 정책 생성", description = "새로운 보안 정책을 생성합니다.")
+    @Operation(summary = "보안 정책 생성")
     public ResponseEntity<ApiResponse<SecurityPolicy>> createPolicy(@RequestBody SecurityPolicy securityPolicy) {
-        String policyKeyLog = securityPolicy != null ? securityPolicy.getPolicyKey() : "null";
-        log.info("[SecurityPolicyController] createPolicy - policyKey={}", policyKeyLog);
         SecurityPolicy createdPolicy = securityPolicyService.createPolicy(securityPolicy);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(createdPolicy, "보안 정책이 생성되었습니다."));
     }
 
-    /**
-     * 보안 정책을 수정합니다.
-     */
     @PutMapping("/{policyKey}")
-    @Operation(summary = "보안 정책 수정", description = "보안 정책을 전체 수정합니다.")
+    @Operation(summary = "보안 정책 수정")
     public ResponseEntity<ApiResponse<SecurityPolicy>> updatePolicy(
-            @PathVariable String policyKey,
+            @PathVariable String policyKey, 
             @RequestBody SecurityPolicy securityPolicy) {
-        log.info("[SecurityPolicyController] updatePolicy - policyKey={}, payloadKey={}", policyKey,
-                securityPolicy != null ? securityPolicy.getPolicyKey() : "null");
         SecurityPolicy updatedPolicy = securityPolicyService.updatePolicy(policyKey, securityPolicy);
         return ResponseEntity.ok(ApiResponse.success(updatedPolicy, "보안 정책이 수정되었습니다."));
     }
 
-    /**
-     * 보안 정책의 활성화 상태를 토글합니다.
-     */
     @PatchMapping("/{policyKey}/toggle")
-    @Operation(summary = "보안 정책 토글", description = "보안 정책의 활성화 상태를 토글합니다.")
+    @Operation(summary = "보안 정책 토글")
     public ResponseEntity<ApiResponse<SecurityPolicy>> togglePolicy(
-            @PathVariable String policyKey,
+            @PathVariable String policyKey, 
             @RequestParam boolean enabled) {
-        log.info("[SecurityPolicyController] togglePolicy - policyKey={}, enabled={}", policyKey, enabled);
         SecurityPolicy toggledPolicy = securityPolicyService.togglePolicy(policyKey, enabled);
         return ResponseEntity.ok(ApiResponse.success(toggledPolicy, "보안 정책이 토글되었습니다."));
     }
 
-    /**
-     * 보안 정책을 활성화합니다.
-     */
     @PatchMapping("/{policyKey}/activate")
-    @Operation(summary = "보안 정책 활성화", description = "비활성화된 보안 정책을 활성화합니다.")
+    @Operation(summary = "보안 정책 활성화")
     public ResponseEntity<ApiResponse<SecurityPolicy>> activatePolicy(@PathVariable String policyKey) {
-        log.info("[SecurityPolicyController] activatePolicy - policyKey={}", policyKey);
         SecurityPolicy activatedPolicy = securityPolicyService.activatePolicy(policyKey);
         return ResponseEntity.ok(ApiResponse.success(activatedPolicy, "보안 정책이 활성화되었습니다."));
     }
 
-    /**
-     * 보안 정책을 비활성화합니다.
-     */
     @PatchMapping("/{policyKey}/deactivate")
-    @Operation(summary = "보안 정책 비활성화", description = "보안 정책을 비활성화합니다.")
+    @Operation(summary = "보안 정책 비활성화")
     public ResponseEntity<ApiResponse<SecurityPolicy>> deactivatePolicy(@PathVariable String policyKey) {
-        log.info("[SecurityPolicyController] deactivatePolicy - policyKey={}", policyKey);
         SecurityPolicy deactivatedPolicy = securityPolicyService.deactivatePolicy(policyKey);
         return ResponseEntity.ok(ApiResponse.success(deactivatedPolicy, "보안 정책이 비활성화되었습니다."));
     }
 
-    /**
-     * 보안 정책을 삭제합니다.
-     */
     @DeleteMapping("/{policyKey}")
-    @Operation(summary = "보안 정책 삭제", description = "보안 정책을 삭제합니다.")
+    @Operation(summary = "보안 정책 삭제")
     public ResponseEntity<ApiResponse<Void>> deletePolicy(@PathVariable String policyKey) {
-        log.info("[SecurityPolicyController] deletePolicy - policyKey={}", policyKey);
         securityPolicyService.deletePolicy(policyKey);
         return ResponseEntity.ok(ApiResponse.success(null, "보안 정책이 삭제되었습니다."));
     }

--- a/src/main/java/com/agenticcp/core/domain/security/controller/TenantPolicyController.java
+++ b/src/main/java/com/agenticcp/core/domain/security/controller/TenantPolicyController.java
@@ -1,6 +1,7 @@
 package com.agenticcp.core.domain.security.controller;
 
 import com.agenticcp.core.common.dto.exception.ApiResponse;
+import com.agenticcp.core.common.exception.ResourceNotFoundException;
 import com.agenticcp.core.domain.security.dto.EffectivePolicySetDTO;
 import com.agenticcp.core.domain.security.dto.SecurityPolicyDTO;
 import com.agenticcp.core.domain.security.entity.SecurityPolicy;
@@ -20,16 +21,16 @@ import java.util.List;
 
 /**
  * 테넌트 정책 관리 컨트롤러
- * 
+ *
  * <p>테넌트별 정책 조회, 초기화, 캐시 관리 API를 제공합니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Slf4j
 @RestController
-@RequestMapping("/api/security/tenant-policies")
+@RequestMapping("/v1/security/tenant-policies")
 @RequiredArgsConstructor
 @Tag(name = "Tenant Policy Management", description = "테넌트별 정책 관리 API")
 public class TenantPolicyController {
@@ -122,7 +123,7 @@ public class TenantPolicyController {
         log.info("[TenantPolicyController] initializeDefaultPolicies - tenantId={}", tenantId);
         
         Tenant tenant = tenantRepository.findById(tenantId)
-                .orElseThrow(() -> new RuntimeException("테넌트를 찾을 수 없습니다: " + tenantId));
+                .orElseThrow(() -> new ResourceNotFoundException("Tenant", "id", tenantId));
         
         List<SecurityPolicy> policies = tenantPolicyService.initializeDefaultPolicies(tenant);
         List<SecurityPolicyDTO> policyDTOs = SecurityPolicyMapper.toDTOList(policies);

--- a/src/main/java/com/agenticcp/core/domain/security/controller/TenantPolicyController.java
+++ b/src/main/java/com/agenticcp/core/domain/security/controller/TenantPolicyController.java
@@ -1,7 +1,6 @@
 package com.agenticcp.core.domain.security.controller;
 
 import com.agenticcp.core.common.dto.exception.ApiResponse;
-import com.agenticcp.core.common.exception.ResourceNotFoundException;
 import com.agenticcp.core.domain.security.dto.EffectivePolicySetDTO;
 import com.agenticcp.core.domain.security.dto.SecurityPolicyDTO;
 import com.agenticcp.core.domain.security.entity.SecurityPolicy;
@@ -21,16 +20,16 @@ import java.util.List;
 
 /**
  * 테넌트 정책 관리 컨트롤러
- *
+ * 
  * <p>테넌트별 정책 조회, 초기화, 캐시 관리 API를 제공합니다.</p>
- *
+ * 
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2025-11-08
+ * @since 2024-01-01
  */
 @Slf4j
 @RestController
-@RequestMapping("/v1/security/tenant-policies")
+@RequestMapping("/api/security/tenant-policies")
 @RequiredArgsConstructor
 @Tag(name = "Tenant Policy Management", description = "테넌트별 정책 관리 API")
 public class TenantPolicyController {
@@ -123,7 +122,7 @@ public class TenantPolicyController {
         log.info("[TenantPolicyController] initializeDefaultPolicies - tenantId={}", tenantId);
         
         Tenant tenant = tenantRepository.findById(tenantId)
-                .orElseThrow(() -> new ResourceNotFoundException("Tenant", "id", tenantId));
+                .orElseThrow(() -> new RuntimeException("테넌트를 찾을 수 없습니다: " + tenantId));
         
         List<SecurityPolicy> policies = tenantPolicyService.initializeDefaultPolicies(tenant);
         List<SecurityPolicyDTO> policyDTOs = SecurityPolicyMapper.toDTOList(policies);

--- a/src/main/java/com/agenticcp/core/domain/security/dto/DefaultPolicyTemplate.java
+++ b/src/main/java/com/agenticcp/core/domain/security/dto/DefaultPolicyTemplate.java
@@ -8,12 +8,12 @@ import lombok.NoArgsConstructor;
 
 /**
  * 기본 정책 템플릿
- * 
+ *
  * <p>테넌트 생성 시 자동으로 생성되는 기본 보안 정책 템플릿을 정의합니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Data
 @Builder

--- a/src/main/java/com/agenticcp/core/domain/security/dto/EffectivePolicySetDTO.java
+++ b/src/main/java/com/agenticcp/core/domain/security/dto/EffectivePolicySetDTO.java
@@ -13,12 +13,12 @@ import java.util.List;
 
 /**
  * 유효한 정책 집합 DTO
- * 
+ *
  * <p>테넌트별 유효한 정책 집합(글로벌 + 테넌트 정책)을 표현합니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Schema(description = "유효한 정책 집합 DTO")
 @Data

--- a/src/main/java/com/agenticcp/core/domain/security/dto/EnvironmentConditions.java
+++ b/src/main/java/com/agenticcp/core/domain/security/dto/EnvironmentConditions.java
@@ -14,7 +14,7 @@ import java.util.List;
  * 
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Data
 @Builder

--- a/src/main/java/com/agenticcp/core/domain/security/dto/IpConditions.java
+++ b/src/main/java/com/agenticcp/core/domain/security/dto/IpConditions.java
@@ -9,12 +9,12 @@ import java.util.List;
 
 /**
  * IP 조건 데이터 전송 객체
- * 
+ *
  * <p>정책의 IP 관련 조건을 정의합니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Data
 @Builder

--- a/src/main/java/com/agenticcp/core/domain/security/dto/NetworkConditions.java
+++ b/src/main/java/com/agenticcp/core/domain/security/dto/NetworkConditions.java
@@ -14,7 +14,7 @@ import java.util.List;
  * 
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Data
 @Builder

--- a/src/main/java/com/agenticcp/core/domain/security/dto/PolicyAction.java
+++ b/src/main/java/com/agenticcp/core/domain/security/dto/PolicyAction.java
@@ -17,7 +17,7 @@ import java.util.Map;
  * 
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Data
 @Builder

--- a/src/main/java/com/agenticcp/core/domain/security/dto/PolicyConditions.java
+++ b/src/main/java/com/agenticcp/core/domain/security/dto/PolicyConditions.java
@@ -9,13 +9,13 @@ import lombok.NoArgsConstructor;
 
 /**
  * 정책 조건 데이터 전송 객체
- * 
+ *
  * <p>정책의 조건들을 정의하는 DTO입니다.
  * JSON 형태로 저장되어 정책 엔진에서 파싱하여 사용됩니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Data
 @Builder

--- a/src/main/java/com/agenticcp/core/domain/security/dto/PolicyConflictResolution.java
+++ b/src/main/java/com/agenticcp/core/domain/security/dto/PolicyConflictResolution.java
@@ -16,6 +16,10 @@ import java.util.HashMap;
 /**
  * 정책 충돌 해결 결과를 표현하는 DTO
  * 충돌이 발생한 정책들과 해결 과정, 최종 결정을 담음
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-11-08
  */
 @Data
 @Builder

--- a/src/main/java/com/agenticcp/core/domain/security/dto/PolicyEvaluationRequest.java
+++ b/src/main/java/com/agenticcp/core/domain/security/dto/PolicyEvaluationRequest.java
@@ -13,13 +13,13 @@ import java.util.Map;
 
 /**
  * 정책 평가 요청 데이터 전송 객체
- * 
+ *
  * <p>정책 엔진에 전달되는 요청 정보를 담는 DTO입니다.
  * 정책 평가에 필요한 모든 컨텍스트 정보를 포함합니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Data
 @Builder

--- a/src/main/java/com/agenticcp/core/domain/security/dto/PolicyEvaluationResult.java
+++ b/src/main/java/com/agenticcp/core/domain/security/dto/PolicyEvaluationResult.java
@@ -13,13 +13,13 @@ import java.util.Map;
 
 /**
  * 정책 평가 결과 데이터 전송 객체
- * 
+ *
  * <p>정책 엔진이 평가한 결과를 담는 DTO입니다.
  * 정책 평가 결과에 대한 모든 정보를 포함합니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Data
 @Builder

--- a/src/main/java/com/agenticcp/core/domain/security/dto/PolicyRule.java
+++ b/src/main/java/com/agenticcp/core/domain/security/dto/PolicyRule.java
@@ -10,12 +10,12 @@ import java.util.Map;
 
 /**
  * 개별 정책 규칙 데이터 전송 객체
- * 
+ *
  * <p>정책의 개별 규칙을 정의하는 DTO입니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Data
 @Builder

--- a/src/main/java/com/agenticcp/core/domain/security/dto/PolicyRules.java
+++ b/src/main/java/com/agenticcp/core/domain/security/dto/PolicyRules.java
@@ -9,13 +9,13 @@ import java.util.List;
 
 /**
  * 정책 규칙 데이터 전송 객체
- * 
+ *
  * <p>정책의 규칙들을 정의하는 DTO입니다.
  * JSON 형태로 저장되어 정책 엔진에서 파싱하여 사용됩니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Data
 @Builder

--- a/src/main/java/com/agenticcp/core/domain/security/dto/ResourceConditions.java
+++ b/src/main/java/com/agenticcp/core/domain/security/dto/ResourceConditions.java
@@ -11,12 +11,12 @@ import java.time.LocalDateTime;
 
 /**
  * 리소스 조건 데이터 전송 객체
- * 
+ *
  * <p>정책의 리소스 관련 조건을 정의합니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Data
 @Builder

--- a/src/main/java/com/agenticcp/core/domain/security/dto/SecurityPolicyDTO.java
+++ b/src/main/java/com/agenticcp/core/domain/security/dto/SecurityPolicyDTO.java
@@ -12,12 +12,12 @@ import java.time.LocalDateTime;
 
 /**
  * 보안 정책 DTO
- * 
+ *
  * <p>SecurityPolicy 엔티티의 데이터 전송 객체로, JSON 직렬화 시 Lazy Loading 문제를 해결합니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Schema(description = "보안 정책 DTO")
 @Data

--- a/src/main/java/com/agenticcp/core/domain/security/dto/TimeConditions.java
+++ b/src/main/java/com/agenticcp/core/domain/security/dto/TimeConditions.java
@@ -10,12 +10,12 @@ import java.util.List;
 
 /**
  * 시간 조건 데이터 전송 객체
- * 
+ *
  * <p>정책의 시간 관련 조건을 정의합니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Data
 @Builder

--- a/src/main/java/com/agenticcp/core/domain/security/dto/UserConditions.java
+++ b/src/main/java/com/agenticcp/core/domain/security/dto/UserConditions.java
@@ -11,12 +11,12 @@ import java.time.LocalDateTime;
 
 /**
  * 사용자 조건 데이터 전송 객체
- * 
+ *
  * <p>정책의 사용자 관련 조건을 정의합니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Data
 @Builder

--- a/src/main/java/com/agenticcp/core/domain/security/entity/Compliance.java
+++ b/src/main/java/com/agenticcp/core/domain/security/entity/Compliance.java
@@ -7,16 +7,27 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+/**
+ * 컴플라이언스 엔티티
+ *
+ * <p>테넌트별 컴플라이언스 표준 및 준수 상태를 관리합니다.</p>
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-11-08
+ */
 @Entity
 @Table(name = "compliance")
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class Compliance extends BaseEntity {
 
     @Column(name = "compliance_key", nullable = false, unique = true)
@@ -34,6 +45,7 @@ public class Compliance extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
+    @Builder.Default
     private Status status = Status.ACTIVE;
 
     @Enumerated(EnumType.STRING)
@@ -48,9 +60,11 @@ public class Compliance extends BaseEntity {
     private String version;
 
     @Column(name = "is_mandatory")
+    @Builder.Default
     private Boolean isMandatory = false;
 
     @Column(name = "is_global")
+    @Builder.Default
     private Boolean isGlobal = false;
 
     @Column(name = "requirements", columnDefinition = "TEXT")

--- a/src/main/java/com/agenticcp/core/domain/security/entity/SecurityPolicy.java
+++ b/src/main/java/com/agenticcp/core/domain/security/entity/SecurityPolicy.java
@@ -7,16 +7,27 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+/**
+ * 보안 정책 엔티티
+ *
+ * <p>테넌트별 보안 정책을 정의하고 관리합니다.</p>
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-11-08
+ */
 @Entity
 @Table(name = "security_policies")
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class SecurityPolicy extends BaseEntity {
 
     @Column(name = "policy_key", nullable = false, unique = true)
@@ -34,6 +45,7 @@ public class SecurityPolicy extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
+    @Builder.Default
     private Status status = Status.ACTIVE;
 
     @Enumerated(EnumType.STRING)
@@ -42,15 +54,19 @@ public class SecurityPolicy extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "severity")
+    @Builder.Default
     private Severity severity = Severity.MEDIUM;
 
     @Column(name = "is_global")
+    @Builder.Default
     private Boolean isGlobal = false;
 
     @Column(name = "is_system")
+    @Builder.Default
     private Boolean isSystem = false;
 
     @Column(name = "is_enabled")
+    @Builder.Default
     private Boolean isEnabled = true;
 
     @Column(name = "rules", columnDefinition = "TEXT")
@@ -75,9 +91,11 @@ public class SecurityPolicy extends BaseEntity {
     private LocalDateTime effectiveUntil;
 
     @Column(name = "priority")
+    @Builder.Default
     private Integer priority = 0;
 
     @Column(name = "version")
+    @Builder.Default
     private String version = "1.0";
 
     @Column(name = "metadata", columnDefinition = "TEXT")

--- a/src/main/java/com/agenticcp/core/domain/security/entity/ThreatDetection.java
+++ b/src/main/java/com/agenticcp/core/domain/security/entity/ThreatDetection.java
@@ -7,16 +7,27 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+/**
+ * 위협 탐지 엔티티
+ *
+ * <p>테넌트 환경에서 탐지된 보안 위협 정보를 관리합니다.</p>
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-11-08
+ */
 @Entity
 @Table(name = "threat_detections")
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class ThreatDetection extends BaseEntity {
 
     @Column(name = "threat_id", nullable = false, unique = true)
@@ -34,6 +45,7 @@ public class ThreatDetection extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
+    @Builder.Default
     private Status status = Status.ACTIVE;
 
     @Enumerated(EnumType.STRING)
@@ -42,16 +54,20 @@ public class ThreatDetection extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "severity")
+    @Builder.Default
     private Severity severity = Severity.MEDIUM;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "confidence_level")
+    @Builder.Default
     private ConfidenceLevel confidenceLevel = ConfidenceLevel.MEDIUM;
 
     @Column(name = "is_active")
+    @Builder.Default
     private Boolean isActive = true;
 
     @Column(name = "is_auto_remediate")
+    @Builder.Default
     private Boolean isAutoRemediate = false;
 
     @Column(name = "detection_rules", columnDefinition = "TEXT")
@@ -73,12 +89,15 @@ public class ThreatDetection extends BaseEntity {
     private LocalDateTime lastDetected;
 
     @Column(name = "detection_count")
+    @Builder.Default
     private Long detectionCount = 0L;
 
     @Column(name = "false_positive_count")
+    @Builder.Default
     private Long falsePositiveCount = 0L;
 
     @Column(name = "true_positive_count")
+    @Builder.Default
     private Long truePositiveCount = 0L;
 
     @Column(name = "metadata", columnDefinition = "TEXT")

--- a/src/main/java/com/agenticcp/core/domain/security/enums/ConflictResolutionStrategy.java
+++ b/src/main/java/com/agenticcp/core/domain/security/enums/ConflictResolutionStrategy.java
@@ -5,6 +5,10 @@ import lombok.Getter;
 /**
  * 정책 충돌 해결 전략
  * 여러 정책이 동일한 리소스에 적용될 때 충돌을 해결하는 방법을 정의
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-11-08
  */
 @Getter
 public enum ConflictResolutionStrategy {

--- a/src/main/java/com/agenticcp/core/domain/security/enums/PolicyDecision.java
+++ b/src/main/java/com/agenticcp/core/domain/security/enums/PolicyDecision.java
@@ -2,12 +2,12 @@ package com.agenticcp.core.domain.security.enums;
 
 /**
  * 정책 평가 결과를 나타내는 열거형
- * 
+ *
  * <p>정책 엔진이 요청을 평가한 후 내리는 결정을 정의합니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 public enum PolicyDecision {
     

--- a/src/main/java/com/agenticcp/core/domain/security/enums/SecurityErrorCode.java
+++ b/src/main/java/com/agenticcp/core/domain/security/enums/SecurityErrorCode.java
@@ -6,12 +6,12 @@ import org.springframework.http.HttpStatus;
 
 /**
  * 보안 도메인 에러 코드
- * 
+ *
  * <p>보안 정책, 정책 엔진, 위협 탐지 등 보안 관련 비즈니스 예외를 정의합니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 public enum SecurityErrorCode implements BaseErrorCode {
     

--- a/src/main/java/com/agenticcp/core/domain/security/mapper/SecurityPolicyMapper.java
+++ b/src/main/java/com/agenticcp/core/domain/security/mapper/SecurityPolicyMapper.java
@@ -8,13 +8,13 @@ import java.util.stream.Collectors;
 
 /**
  * SecurityPolicy Entity <-> DTO 변환 유틸리티
- * 
+ *
  * <p>SecurityPolicy 엔티티와 SecurityPolicyDTO 간의 변환을 담당합니다.</p>
  * <p>Lazy Loading 문제 해결을 위해 tenant는 tenantId만 포함합니다.</p>
- * 
+ *
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 public class SecurityPolicyMapper {
     

--- a/src/main/java/com/agenticcp/core/domain/security/repository/SecurityPolicyRepository.java
+++ b/src/main/java/com/agenticcp/core/domain/security/repository/SecurityPolicyRepository.java
@@ -12,8 +12,22 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * 보안 정책 리포지토리
+ *
+ * <p>SecurityPolicy 엔티티에 대한 조회 및 통계 기능을 제공합니다.</p>
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-11-08
+ */
 @Repository
 public interface SecurityPolicyRepository extends JpaRepository<SecurityPolicy, Long> {
+
+    String TENANT_ID_PARAM = "tenantId";
+    String STATUS_PARAM = "status";
+    String POLICY_TYPE_PARAM = "policyType";
+    String NOW_PARAM = "now";
 
     Optional<SecurityPolicy> findByPolicyKey(String policyKey);
 
@@ -23,26 +37,26 @@ public interface SecurityPolicyRepository extends JpaRepository<SecurityPolicy, 
 
     List<SecurityPolicy> findByPolicyType(SecurityPolicy.PolicyType policyType);
 
-    @Query("SELECT sp FROM SecurityPolicy sp WHERE sp.status = :status AND sp.isEnabled = true AND sp.isDeleted = false")
-    List<SecurityPolicy> findActivePolicies(@Param("status") Status status);
+    @Query("SELECT sp FROM SecurityPolicy sp WHERE sp.status = :" + STATUS_PARAM + " AND sp.isEnabled = true AND sp.isDeleted = false")
+    List<SecurityPolicy> findActivePolicies(@Param(STATUS_PARAM) Status status);
 
-    @Query("SELECT sp FROM SecurityPolicy sp WHERE sp.isGlobal = true AND sp.status = :status AND sp.isEnabled = true")
-    List<SecurityPolicy> findGlobalPolicies(@Param("status") Status status);
+    @Query("SELECT sp FROM SecurityPolicy sp WHERE sp.isGlobal = true AND sp.status = :" + STATUS_PARAM + " AND sp.isEnabled = true")
+    List<SecurityPolicy> findGlobalPolicies(@Param(STATUS_PARAM) Status status);
 
-    @Query("SELECT sp FROM SecurityPolicy sp WHERE sp.isSystem = true AND sp.status = :status")
-    List<SecurityPolicy> findSystemPolicies(@Param("status") Status status);
+    @Query("SELECT sp FROM SecurityPolicy sp WHERE sp.isSystem = true AND sp.status = :" + STATUS_PARAM)
+    List<SecurityPolicy> findSystemPolicies(@Param(STATUS_PARAM) Status status);
 
-    @Query("SELECT sp FROM SecurityPolicy sp WHERE sp.tenant = :tenant AND sp.status = :status AND sp.isEnabled = true")
-    List<SecurityPolicy> findActivePoliciesByTenant(@Param("tenant") Tenant tenant, @Param("status") Status status);
+    @Query("SELECT sp FROM SecurityPolicy sp WHERE sp.tenant = :tenant AND sp.status = :" + STATUS_PARAM + " AND sp.isEnabled = true")
+    List<SecurityPolicy> findActivePoliciesByTenant(@Param("tenant") Tenant tenant, @Param(STATUS_PARAM) Status status);
 
-    @Query("SELECT sp FROM SecurityPolicy sp WHERE sp.effectiveFrom <= :now AND (sp.effectiveUntil IS NULL OR sp.effectiveUntil >= :now) AND sp.status = :status")
-    List<SecurityPolicy> findEffectivePolicies(@Param("now") LocalDateTime now, @Param("status") Status status);
+    @Query("SELECT sp FROM SecurityPolicy sp WHERE sp.effectiveFrom <= :" + NOW_PARAM + " AND (sp.effectiveUntil IS NULL OR sp.effectiveUntil >= :" + NOW_PARAM + ") AND sp.status = :" + STATUS_PARAM)
+    List<SecurityPolicy> findEffectivePolicies(@Param(NOW_PARAM) LocalDateTime now, @Param(STATUS_PARAM) Status status);
 
-    @Query("SELECT sp FROM SecurityPolicy sp WHERE sp.policyType = :policyType AND sp.status = :status AND sp.isEnabled = true ORDER BY sp.priority DESC")
-    List<SecurityPolicy> findPoliciesByTypeOrderedByPriority(@Param("policyType") SecurityPolicy.PolicyType policyType, @Param("status") Status status);
+    @Query("SELECT sp FROM SecurityPolicy sp WHERE sp.policyType = :" + POLICY_TYPE_PARAM + " AND sp.status = :" + STATUS_PARAM + " AND sp.isEnabled = true ORDER BY sp.priority DESC")
+    List<SecurityPolicy> findPoliciesByTypeOrderedByPriority(@Param(POLICY_TYPE_PARAM) SecurityPolicy.PolicyType policyType, @Param(STATUS_PARAM) Status status);
 
-    @Query("SELECT COUNT(sp) FROM SecurityPolicy sp WHERE sp.tenant = :tenant AND sp.status = :status")
-    Long countPoliciesByTenant(@Param("tenant") Tenant tenant, @Param("status") Status status);
+    @Query("SELECT COUNT(sp) FROM SecurityPolicy sp WHERE sp.tenant = :tenant AND sp.status = :" + STATUS_PARAM)
+    Long countPoliciesByTenant(@Param("tenant") Tenant tenant, @Param(STATUS_PARAM) Status status);
     
     /**
      * 테넌트별 활성화된 정책 조회 (Feature 2 & 3)
@@ -50,8 +64,8 @@ public interface SecurityPolicyRepository extends JpaRepository<SecurityPolicy, 
      * @param tenantId 테넌트 ID
      * @return 활성화된 정책 목록
      */
-    @Query("SELECT sp FROM SecurityPolicy sp WHERE sp.tenant.id = :tenantId AND sp.isEnabled = true AND sp.isDeleted = false")
-    List<SecurityPolicy> findByTenantIdAndIsEnabledTrue(@Param("tenantId") Long tenantId);
+    @Query("SELECT sp FROM SecurityPolicy sp WHERE sp.tenant.id = :" + TENANT_ID_PARAM + " AND sp.isEnabled = true AND sp.isDeleted = false")
+    List<SecurityPolicy> findByTenantIdAndIsEnabledTrue(@Param(TENANT_ID_PARAM) Long tenantId);
     
     /**
      * 글로벌 활성화된 정책 조회 (Feature 2 & 3)

--- a/src/main/java/com/agenticcp/core/domain/security/service/PolicyEngineService.java
+++ b/src/main/java/com/agenticcp/core/domain/security/service/PolicyEngineService.java
@@ -7,8 +7,8 @@ import com.agenticcp.core.domain.security.enums.PolicyDecision;
 import com.agenticcp.core.domain.security.enums.SecurityErrorCode;
 import com.agenticcp.core.domain.security.repository.SecurityPolicyRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.ObjectProvider;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
  * 
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Service
 @Slf4j
@@ -34,17 +34,16 @@ import java.util.stream.Collectors;
 public class PolicyEngineService {
     
     private final SecurityPolicyRepository securityPolicyRepository;
-    
-    @Autowired(required = false) // RedisTemplate이 필수가 아님을 명시
-    private RedisTemplate<String, Object> redisTemplate;
-    
+    private final RedisTemplate<String, Object> redisTemplate;
     private final PolicyJsonParser policyJsonParser;
     private final ObjectMapper objectMapper;
     
-    public PolicyEngineService(SecurityPolicyRepository securityPolicyRepository, 
-                              PolicyJsonParser policyJsonParser, 
+    public PolicyEngineService(SecurityPolicyRepository securityPolicyRepository,
+                              ObjectProvider<RedisTemplate<String, Object>> redisTemplateProvider,
+                              PolicyJsonParser policyJsonParser,
                               ObjectMapper objectMapper) {
         this.securityPolicyRepository = securityPolicyRepository;
+        this.redisTemplate = redisTemplateProvider.getIfAvailable();
         this.policyJsonParser = policyJsonParser;
         this.objectMapper = objectMapper;
     }

--- a/src/main/java/com/agenticcp/core/domain/security/service/PolicyJsonParser.java
+++ b/src/main/java/com/agenticcp/core/domain/security/service/PolicyJsonParser.java
@@ -16,7 +16,7 @@ import java.util.List;
  * 
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-11-08
  */
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/agenticcp/core/domain/security/service/PolicyPriorityService.java
+++ b/src/main/java/com/agenticcp/core/domain/security/service/PolicyPriorityService.java
@@ -16,8 +16,13 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * 정책 우선순위 및 충돌 해결 서비스
- * 정책 간 우선순위를 관리하고 충돌을 해결하는 핵심 로직
+ * 정책 우선순위 및 충돌 해결 서비스.
+ *
+ * <p>정책 간 우선순위를 관리하고 충돌을 해결하는 핵심 로직을 제공합니다.</p>
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-11-08
  */
 @Slf4j
 @Service

--- a/src/test/java/com/agenticcp/core/domain/security/service/PolicyEngineServiceTest.java
+++ b/src/test/java/com/agenticcp/core/domain/security/service/PolicyEngineServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.springframework.beans.factory.ObjectProvider;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -45,6 +46,9 @@ class PolicyEngineServiceTest {
     
     @Mock
     private RedisTemplate<String, Object> redisTemplate;
+    
+    @Mock
+    private ObjectProvider<RedisTemplate<String, Object>> redisTemplateProvider;
     
     @Mock
     private ValueOperations<String, Object> valueOperations;
@@ -89,6 +93,7 @@ class PolicyEngineServiceTest {
         
         // Redis 템플릿 모킹
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(redisTemplateProvider.getIfAvailable()).thenReturn(redisTemplate);
         
         // ObjectMapper 모킹
         when(objectMapper.getTypeFactory()).thenReturn(com.fasterxml.jackson.databind.type.TypeFactory.defaultInstance());


### PR DESCRIPTION
# Security Module Review Checklist

## ✅ 완료된 파일

### annotation/RequirePermission.java
- [x] JavaDoc 메타데이터(2025-11-08) 추가
- [x] 표준 가이드 준수 확인

### annotation/RequireRole.java
- [x] JavaDoc 메타데이터(2025-11-08) 추가
- [x] 표준 가이드 준수 확인

### aop/AuthorizationAspect.java
- [x] JavaDoc 보강 및 2025-11-08 메타데이터 반영
- [x] 접근/실패 로그 추가 및 `Arrays.toString` 적용
- [x] 보안 예외 처리 및 표준 준수 확인

### controller/PolicyEngineController.java
- [x] `@since` 2025-11-08 갱신
- [x] `ApiResponse` 기반 표준 응답 적용 및 오류 코드 정비
- [x] 로깅 및 예외 처리 정돈

### controller/PolicyPriorityController.java
- [x] JavaDoc 보강 및 2025-11-08 메타데이터 반영
- [x] `@Slf4j` 적용 및 진입 로그 추가
- [x] Swagger `@Operation` 설명 확인


### dto/DefaultPolicyTemplate.java
- [x] JavaDoc `@since 2025-11-08` 갱신

### dto/EffectivePolicySetDTO.java
- [x] JavaDoc `@since 2025-11-08` 갱신

### dto/EnvironmentConditions.java
- [x] JavaDoc `@since 2025-11-08` 갱신

### dto/IpConditions.java
- [x] JavaDoc `@since 2025-11-08` 갱신

### dto/NetworkConditions.java
- [x] JavaDoc `@since 2025-11-08` 갱신

### dto/PolicyAction.java
- [x] JavaDoc `@since 2025-11-08` 갱신

### dto/PolicyConditions.java
- [x] JavaDoc `@since 2025-11-08` 갱신

### dto/PolicyRule.java
- [x] JavaDoc `@since 2025-11-08` 갱신

### dto/PolicyRules.java
- [x] JavaDoc `@since 2025-11-08` 갱신

### dto/PolicyConflictResolution.java
- [x] JavaDoc `@since 2025-11-08` 갱신

### dto/PolicyEvaluationRequest.java
- [x] JavaDoc `@since 2025-11-08` 갱신 및 서식 정리

### dto/PolicyEvaluationResult.java
- [x] JavaDoc `@since 2025-11-08` 갱신

### dto/ResourceConditions.java
- [x] JavaDoc `@since 2025-11-08` 갱신

### dto/SecurityPolicyDTO.java
- [x] JavaDoc `@since 2025-11-08` 갱신

### dto/TimeConditions.java
- [x] JavaDoc `@since 2025-11-08` 갱신

### dto/UserConditions.java
- [x] JavaDoc `@since 2025-11-08` 갱신


## 기능 분해도 (Security)

| 기능 번호 | DEPTH 1 | DEPTH 2 | DEPTH 3 | 기능명 | 핵심 비즈니스 로직 | 관련 테이블 | 작업자 | API METHOD | API ENDPOINT | 상태 | 메모 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | Security | Security Policy Engine | Policy Evaluation | 정책 평가 API | 요청 컨텍스트를 검증하고 적용 가능한 정책을 조회한 뒤 우선순위/충돌 규칙에 따라 최종 결정을 반환 | security_policies | 임유빈 | POST | /v1/security/policy/evaluate | 완료 | Redis 캐시 조회 및 갱신 포함 |
| 2 | Security | Security Policy Engine | Cache Management | 정책 평가 캐시 무효화 | 리소스/액션 조건에 맞춰 정책 평가 및 정책 목록 캐시를 제거하여 최신 정책 반영 | security_policies | 임유빈 | DELETE | /v1/security/policy/cache | 완료 | 파라미터 미지정 시 전체 캐시 삭제 |
| 3 | Security | Security Policy Engine | Observability | 정책 엔진 헬스 체크 | 엔진 가용 상태, 버전, 타임스탬프를 반환하여 모니터링 지표 제공 | - | 임유빈 | GET | /v1/security/policy/health | 완료 |  |
| 4 | Security | Security Policy Engine | Policy Evaluation | 정책 엔진 테스트 | 샘플 요청으로 정책 엔진을 실행해 구성 유효성 및 응답 포맷을 확인 | security_policies | 임유빈 | GET | /v1/security/policy/test | 완료 | 테스트 요청은 내부에서 생성 |
| 5 | Security | Policy Priority | Validation | 우선순위 유효성 검증 | 입력 우선순위가 허용 범위(1~1000)에 속하는지 검증하고 메시지를 반환 | security_policies | 임유빈 | GET | /security/priority/validate/{priority} | 완료 |  |
| 6 | Security | Policy Priority | Assignment | 자동 우선순위 할당 | 테넌트 또는 글로벌 정책 집합을 분석하여 가장 낮은 우선순위보다 낮은 새 우선순위를 산출 | security_policies | 임유빈 | GET | /security/priority/auto-assign | 완료 | tenantId 미지정 시 글로벌 정책 기준 |
| 7 | Security | Policy Priority | Assignment | 다음 사용 가능 우선순위 조회 | 현재 우선순위와 정책 목록을 기반으로 겹치지 않는 다음 우선순위를 계산 | security_policies | 임유빈 | GET | /security/priority/next-available | 완료 |  |
| 8 | Security | Policy Priority | Inquiry | 우선순위 정렬 정책 조회 | 테넌트/글로벌 활성 정책을 우선순위 기준으로 정렬하여 간략 정보 목록을 반환 | security_policies | 임유빈 | GET | /security/priority/sorted | 완료 |  |
| 9 | Security | Policy Priority | Conflict Resolution | 정책 충돌 해결 시뮬레이션 | 선택한 정책과 결정 값을 입력받아 지정 전략으로 충돌을 분석하고 최종 결정을 계산 | security_policies | 임유빈 | POST | /security/priority/resolve-conflict | 완료 | ConflictResolutionStrategy 전반 지원 |
| 10 | Security | Policy Priority | Reference | 충돌 해결 전략 목록 | 사용 가능한 모든 충돌 해결 전략의 식별자와 설명을 제공 | - | 임유빈 | GET | /security/priority/strategies | 완료 |  |
