### PR TITLE
[REFACTOR] 인증 프로세스 논리적 오점 개선

### DIFF
--- a/src/main/java/com/agenticcp/core/common/config/SecurityConfig.java
+++ b/src/main/java/com/agenticcp/core/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.agenticcp.core.common.config;
 
 import com.agenticcp.core.common.security.JwtAuthenticationFilter;
+import com.agenticcp.core.common.security.PendingUserAccessFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,7 +25,7 @@ import java.util.Arrays;
  * 
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-10-24
  */
 @Configuration
 @EnableWebSecurity
@@ -33,6 +34,7 @@ import java.util.Arrays;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final PendingUserAccessFilter pendingUserAccessFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -57,7 +59,8 @@ public class SecurityConfig {
                 .anyRequest().authenticated()
             )
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+            .addFilterAfter(pendingUserAccessFilter, JwtAuthenticationFilter.class);
         
         return http.build();
     }

--- a/src/main/java/com/agenticcp/core/common/config/SecurityConfig.java
+++ b/src/main/java/com/agenticcp/core/common/config/SecurityConfig.java
@@ -2,9 +2,10 @@ package com.agenticcp.core.common.config;
 
 import com.agenticcp.core.common.security.JwtAuthenticationFilter;
 import com.agenticcp.core.common.security.PendingUserAccessFilter;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -30,11 +31,17 @@ import java.util.Arrays;
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity(prePostEnabled = true)
-@RequiredArgsConstructor
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final PendingUserAccessFilter pendingUserAccessFilter;
+
+    @Autowired
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter, 
+                         @Lazy PendingUserAccessFilter pendingUserAccessFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.pendingUserAccessFilter = pendingUserAccessFilter;
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/agenticcp/core/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/agenticcp/core/common/security/JwtAuthenticationFilter.java
@@ -27,7 +27,7 @@ import static com.agenticcp.core.common.security.JwtConstants.*;
  * 
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-10-24
  */
 @Slf4j
 @Component
@@ -42,6 +42,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         this.jwtService = jwtService;
     }
 
+    /**
+     * 필터 내부 로직 처리
+     * JWT 토큰을 추출하고 검증하여 SecurityContext에 인증 정보를 설정합니다.
+     * 블랙리스트 확인을 토큰 검증 전에 수행합니다.
+     * 
+     * @param request HTTP 요청
+     * @param response HTTP 응답
+     * @param filterChain 필터 체인
+     * @throws ServletException 서블릿 예외
+     * @throws IOException IO 예외
+     */
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, 
                                   FilterChain filterChain) throws ServletException, IOException {
@@ -49,16 +60,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             String token = extractTokenFromRequest(request);
             
-            if (token != null && jwtService.isTokenValid(token, extractUsernameFromToken(token))) {
-                // Redis 블랙리스트 확인
+            if (token != null) {
+                // 1. 블랙리스트 확인 (먼저 수행)
                 if (isTokenBlacklisted(token)) {
                     log.warn("Blacklisted token attempted: {}", token.substring(0, 20) + "...");
                     filterChain.doFilter(request, response);
                     return;
                 }
                 
-                // SecurityContext에 인증 정보 설정
-                setAuthenticationInContext(token);
+                // 2. 토큰 검증
+                String username = extractUsernameFromToken(token);
+                if (username != null && jwtService.isTokenValid(token, username)) {
+                    // SecurityContext에 인증 정보 설정
+                    setAuthenticationInContext(token);
+                }
             }
             
         } catch (Exception e) {

--- a/src/main/java/com/agenticcp/core/common/security/PendingUserAccessFilter.java
+++ b/src/main/java/com/agenticcp/core/common/security/PendingUserAccessFilter.java
@@ -1,0 +1,114 @@
+package com.agenticcp.core.common.security;
+
+import com.agenticcp.core.common.enums.AuthErrorCode;
+import com.agenticcp.core.common.enums.Status;
+import com.agenticcp.core.common.exception.BusinessException;
+import com.agenticcp.core.domain.user.entity.User;
+import com.agenticcp.core.domain.user.service.UserService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * PENDING 상태 사용자 접근 제한 필터
+ * PENDING 상태 사용자는 2FA 설정 API만 접근 가능하도록 제한
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ * @since 2025-11-20
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PendingUserAccessFilter extends OncePerRequestFilter {
+
+    private final UserService userService;
+
+    // 2FA 설정 관련 허용 경로
+    private static final String[] ALLOWED_PATHS = {
+        "/auth/2fa/setup",
+        "/auth/2fa/enable",
+        "/auth/2fa/status",
+        "/auth/logout",
+        "/auth/me"
+    };
+
+    /**
+     * 필터 내부 로직 처리
+     * PENDING 상태 사용자의 접근을 제한하고, 2FA 설정 API만 허용합니다.
+     * 
+     * @param request HTTP 요청
+     * @param response HTTP 응답
+     * @param filterChain 필터 체인
+     * @throws ServletException 서블릿 예외
+     * @throws IOException IO 예외
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, 
+                                  FilterChain filterChain) throws ServletException, IOException {
+        
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        
+        // 인증되지 않은 사용자는 통과 (다른 필터에서 처리)
+        if (authentication == null || !authentication.isAuthenticated()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String username = authentication.getName();
+        String requestPath = request.getRequestURI();
+
+        try {
+            // 사용자 조회
+            User user = userService.getUserByUsernameOrThrow(username);
+            
+            // PENDING 상태 사용자인 경우
+            if (user.getStatus() == Status.PENDING) {
+                // 허용된 경로인지 확인
+                if (!isAllowedPath(requestPath)) {
+                    log.warn("[PendingUserAccessFilter] PENDING user attempted to access restricted path: {} username={}", 
+                        requestPath, username);
+                    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                    response.setContentType("application/json;charset=UTF-8");
+                    response.getWriter().write(
+                        String.format("{\"success\":false,\"error\":{\"code\":\"%s\",\"message\":\"2FA 설정이 필요합니다. 먼저 2FA를 설정해주세요.\"}}",
+                            AuthErrorCode.ACCOUNT_INACTIVE.getCode())
+                    );
+                    return;
+                }
+            }
+            
+        } catch (Exception e) {
+            log.error("[PendingUserAccessFilter] Error checking user status", e);
+            // 에러 발생 시 통과 (다른 필터에서 처리)
+        }
+        
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * 요청 경로가 허용된 경로인지 확인
+     * 
+     * @param requestPath 확인할 요청 경로
+     * @return 허용된 경로이면 true, 아니면 false
+     */
+    private boolean isAllowedPath(String requestPath) {
+        for (String allowedPath : ALLOWED_PATHS) {
+            if (requestPath.startsWith(allowedPath)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+

--- a/src/main/java/com/agenticcp/core/common/service/AuthenticationService.java
+++ b/src/main/java/com/agenticcp/core/common/service/AuthenticationService.java
@@ -39,7 +39,7 @@ import static com.agenticcp.core.common.security.JwtConstants.TOKEN_TYPE_ACCESS;
  * 
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-10-24
  */
 @Slf4j
 @Service
@@ -94,13 +94,18 @@ public class AuthenticationService {
             String encodedPassword = passwordEncoder.encode(request.getPassword());
 
             // 5. 사용자 생성
+            // 2FA 정책에 따라 초기 상태 결정
+            // TODO: 설정에서 2FA 필수 여부 확인 (SecurityPolicyService 또는 PlatformConfig에서 가져오기)
+            boolean twoFactorRequired = true; // 기본값: 2FA 필수
+            Status initialStatus = twoFactorRequired ? Status.PENDING : Status.ACTIVE;
+            
             User newUser = User.builder()
                     .username(request.getUsername())
                     .email(request.getEmail())
                     .passwordHash(encodedPassword)
                     .name(request.getName())
                     .role(UserRole.VIEWER) // 기본 역할 부여
-                    .status(Status.ACTIVE) // 기본 상태 활성
+                    .status(initialStatus) // 2FA 정책에 따라 PENDING 또는 ACTIVE
                     .tenant(tenant)
                     .build();
 
@@ -142,6 +147,11 @@ public class AuthenticationService {
             if (user.isAccountLocked()) {
                 failureReason = "계정이 잠겨있습니다";
                 log.warn("[AuthenticationService] login - account locked username={}", loginRequest.getUsername());
+                // 계정 잠금 실패 이력 저장
+                if (httpRequest != null) {
+                    authHistoryService.recordAuthHistoryFromRequest(
+                            user, AuthType.LOGIN, false, httpRequest, failureReason);
+                }
                 throw new BusinessException(AuthErrorCode.ACCOUNT_LOCKED);
             }
             
@@ -153,6 +163,11 @@ public class AuthenticationService {
                 failureReason = "비활성 계정입니다";
                 log.warn("[AuthenticationService] login - inactive account status={} username={}", 
                     user.getStatus(), loginRequest.getUsername());
+                // 비활성 계정 실패 이력 저장
+                if (httpRequest != null) {
+                    authHistoryService.recordAuthHistoryFromRequest(
+                            user, AuthType.LOGIN, false, httpRequest, failureReason);
+                }
                 throw new BusinessException(AuthErrorCode.ACCOUNT_INACTIVE);
             }
             
@@ -223,6 +238,8 @@ public class AuthenticationService {
         } catch (ResourceNotFoundException e) {
             failureReason = "사용자를 찾을 수 없습니다";
             log.warn("[AuthenticationService] login - user not found username={}", loginRequest.getUsername());
+            // 사용자 없음 실패 이력 저장 불가 (UserAuthHistory 엔티티에서 user가 필수이므로)
+            // 보안상 사용자명을 노출하지 않기 위해 이력 저장 생략
             throw new BusinessException(AuthErrorCode.INVALID_CREDENTIALS);
         } catch (BusinessException e) {
             // 이미 이력이 저장된 경우는 스킵
@@ -232,6 +249,11 @@ public class AuthenticationService {
 
     /**
      * 토큰 갱신
+     * 리프레시 토큰을 검증하고 새로운 액세스 토큰과 리프레시 토큰을 발급합니다.
+     * 
+     * @param refreshTokenRequest 리프레시 토큰 요청 정보
+     * @return 새로운 액세스 토큰과 리프레시 토큰
+     * @throws BusinessException 리프레시 토큰이 유효하지 않거나, 사용자 상태가 ACTIVE가 아니거나, 계정이 잠긴 경우
      */
     public TokenResponse refreshToken(RefreshTokenRequest refreshTokenRequest) {
         log.info("[AuthenticationService] refreshToken");
@@ -263,6 +285,24 @@ public class AuthenticationService {
             
             // 사용자 조회
             User user = userService.getUserByUsernameOrThrow(username);
+            
+            // 사용자 상태 검증
+            if (user.getStatus() != Status.ACTIVE) {
+                if (user.getStatus() == Status.PENDING) {
+                    // 2FA 설정 중인 경우 제한적 허용 검토
+                    log.warn("[AuthenticationService] refreshToken - PENDING user attempted token refresh: {}", username);
+                } else {
+                    log.warn("[AuthenticationService] refreshToken - inactive user attempted token refresh: {} status={}", 
+                        username, user.getStatus());
+                }
+                throw new BusinessException(AuthErrorCode.ACCOUNT_INACTIVE);
+            }
+            
+            // 계정 잠금 확인
+            if (user.isAccountLocked()) {
+                log.warn("[AuthenticationService] refreshToken - locked account attempted token refresh: {}", username);
+                throw new BusinessException(AuthErrorCode.ACCOUNT_LOCKED);
+            }
             
             // 새 토큰 생성
             String newAccessToken = jwtService.generateAccessToken(user);
@@ -343,6 +383,21 @@ public class AuthenticationService {
 
     /**
      * 토큰을 블랙리스트에 추가
+     * 
+     * <p>로그아웃된 토큰을 블랙리스트에 추가하여 재사용을 방지합니다.
+     * 토큰의 만료 시간까지 블랙리스트에 유지됩니다.</p>
+     * 
+     * <p>Redis 비활성화 시 대안:</p>
+     * <ul>
+     *   <li>데이터베이스에 블랙리스트 테이블 생성하여 관리</li>
+     *   <li>인메모리 캐시(Caffeine, Guava Cache) 사용</li>
+     *   <li>JWT 토큰에 버전 번호 추가하여 강제 무효화</li>
+     * </ul>
+     * 
+     * <p>현재 구현: Redis가 없으면 블랙리스트 기능이 작동하지 않음
+     * (로그아웃한 토큰도 만료 전까지 유효하게 됨)</p>
+     * 
+     * @param token 블랙리스트에 추가할 JWT 토큰
      */
     public void blacklistToken(String token) {
         log.info("[AuthenticationService] blacklistToken");
@@ -353,12 +408,37 @@ public class AuthenticationService {
             long expirationTime = jwtService.extractExpiration(token).getTime() - System.currentTimeMillis();
             if (redisTemplate != null && expirationTime > 0) {
                 redisTemplate.opsForValue().set(blacklistKey, "blacklisted", expirationTime, TimeUnit.MILLISECONDS);
+                log.info("[AuthenticationService] blacklistToken - success");
+            } else {
+                log.warn("[AuthenticationService] blacklistToken - Redis not available, token blacklist not applied");
             }
-            
-            log.info("[AuthenticationService] blacklistToken - success");
             
         } catch (Exception e) {
             log.error("[AuthenticationService] blacklistToken - error", e);
+        }
+    }
+
+    /**
+     * 토큰이 블랙리스트에 있는지 확인
+     * 
+     * <p>Redis 비활성화 시:
+     * 블랙리스트 확인이 불가능하므로 false 반환합니다.
+     * 보안상 Redis 사용을 권장하거나 대안 구현이 필요합니다.</p>
+     * 
+     * @param token 확인할 JWT 토큰
+     * @return 블랙리스트에 있으면 true, 없거나 Redis가 비활성화된 경우 false
+     */
+    public boolean isTokenBlacklisted(String token) {
+        try {
+            if (redisTemplate == null) {
+                log.debug("[AuthenticationService] RedisTemplate is not available. Token blacklist check skipped.");
+                return false;
+            }
+            String blacklistKey = "blacklist:" + token;
+            return Boolean.TRUE.equals(redisTemplate.hasKey(blacklistKey));
+        } catch (Exception e) {
+            log.warn("[AuthenticationService] Failed to check token blacklist", e);
+            return false;
         }
     }
 

--- a/src/main/java/com/agenticcp/core/controller/AuthController.java
+++ b/src/main/java/com/agenticcp/core/controller/AuthController.java
@@ -157,6 +157,10 @@ public class AuthController {
 
     /**
      * 토큰 검증
+     * 현재 요청의 JWT 토큰 유효성을 검증하고 블랙리스트 여부를 확인합니다.
+     * 
+     * @param request HTTP 요청 (Authorization 헤더에서 토큰 추출)
+     * @return 토큰 유효성 검증 결과
      */
     @GetMapping("/validate")
     @Operation(summary = "토큰 검증", description = "현재 토큰의 유효성을 검증합니다.")
@@ -170,6 +174,12 @@ public class AuthController {
             }
             
             String token = authHeader.substring(7);
+            
+            // 블랙리스트 확인
+            if (authenticationService.isTokenBlacklisted(token)) {
+                return ResponseEntity.ok(ApiResponse.success(false, "토큰이 블랙리스트에 등록되어 있습니다."));
+            }
+            
             String username = jwtService.extractUsername(token);
             boolean isValid = jwtService.isTokenValid(token, username);
             

--- a/src/main/java/com/agenticcp/core/controller/AuthController.java
+++ b/src/main/java/com/agenticcp/core/controller/AuthController.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.*;
  * 
  * @author AgenticCP Team
  * @version 1.0.0
- * @since 2024-01-01
+ * @since 2025-10-24
  */
 @Slf4j
 @RestController


### PR DESCRIPTION
# [REFACTOR] 인증 프로세스 논리적 오점 개선

## :clipboard: 개요

이슈 #157의 요구사항에 따라 인증 프로세스에서 발견된 논리적 오점들을 개선합니다. 보안 강화, 로직 일관성 개선, 감사 로그 개선을 포함합니다.

## :wrench: 주요 변경사항

### 보안 관련 개선 (우선순위 높음)

#### 1. JWT 필터 블랙리스트 확인 순서 개선
- **파일**: `JwtAuthenticationFilter.java`
- **변경**: 블랙리스트 확인을 토큰 검증 전에 수행하도록 변경
- **효과**: 블랙리스트된 토큰을 즉시 차단하여 불필요한 검증 작업 방지 및 보안 강화

#### 2. 토큰 갱신 시 사용자 상태 재검증 추가
- **파일**: `AuthenticationService.java`
- **변경**: `refreshToken()` 메서드에 사용자 상태 검증 로직 추가
- **효과**: ACTIVE 상태가 아니거나 계정이 잠긴 사용자의 토큰 갱신 차단

#### 3. 토큰 검증 API에 블랙리스트 확인 추가
- **파일**: `AuthController.java`, `AuthenticationService.java`
- **변경**: `validateToken()` API에 블랙리스트 확인 로직 추가, `isTokenBlacklisted()` 메서드 추가
- **효과**: 블랙리스트된 토큰은 유효하지 않다고 반환

### 로직 일관성 개선 (우선순위 중간)

#### 4. 회원가입 시 초기 상태 설정 개선
- **파일**: `AuthenticationService.java`
- **변경**: 2FA 정책에 따라 초기 상태를 PENDING 또는 ACTIVE로 설정
- **효과**: 2FA 필수 정책인 경우 PENDING 상태로 생성하여 보안 정책과 일치
- **참고**: 현재는 기본값으로 2FA 필수(true)로 설정되어 있으며, 추후 설정 서비스 연동 필요

#### 5. PENDING 상태 사용자 접근 제한 로직 추가
- **파일**: `PendingUserAccessFilter.java` (신규), `SecurityConfig.java`
- **변경**: PENDING 상태 사용자는 2FA 설정 API만 접근 가능하도록 필터 추가
- **허용 경로**: `/auth/2fa/setup`, `/auth/2fa/enable`, `/auth/2fa/status`, `/auth/logout`, `/auth/me`
- **효과**: 2FA 설정이 완료되지 않은 사용자의 다른 API 접근 차단

#### 6. 2FA 활성화 시 상태 전이 로직 일관화 검토
- **검토 결과**: 현재 구현이 일관성 있게 동작함을 확인
- **플로우**: 회원가입(PENDING) → 2FA 활성화 → ACTIVE 상태 전환

### 감사 로그 개선 (우선순위 낮음)

#### 7. 모든 로그인 실패 시나리오에 이력 저장
- **파일**: `AuthenticationService.java`
- **변경**: 계정 잠금, 비활성 계정 등 모든 로그인 실패 케이스에 이력 저장
- **효과**: 보안 감사 추적성 향상

#### 8. Redis 비활성화 시 토큰 관리 대안 검토
- **파일**: `AuthenticationService.java`
- **변경**: Redis 비활성화 시 대안 방안을 JavaDoc에 문서화
- **대안**: DB 테이블, 인메모리 캐시, JWT 버전 관리 등

## 변경된 파일

```
src/main/java/com/agenticcp/core/common/security/
  ├── JwtAuthenticationFilter.java          (수정)
  └── PendingUserAccessFilter.java          (신규)

src/main/java/com/agenticcp/core/common/service/
  └── AuthenticationService.java             (수정)

src/main/java/com/agenticcp/core/controller/
  └── AuthController.java                    (수정)

src/main/java/com/agenticcp/core/common/config/
  └── SecurityConfig.java                    (수정)
```

## 관련 이슈

- #157: [REFACTOR] 로그인 관련
- #158: [FEATURE] 인증 프로세스 논리적 오점 점검 - 전체 프로세스 통합 분석
- #159: [REFACTOR] 로그인 관련 코드 검증 및 개선 방안 분석

## 체크리스트

### 코드 검토
- [x] 회원가입 프로세스 분석
- [x] 로그인 프로세스 분석
- [x] 토큰 관리 프로세스 분석
- [x] 2FA 프로세스 분석
- [x] JWT 인증 필터 분석
- [x] 상태 전이 및 데이터 일관성 검증

### 문제점 도출
- [x] 보안 관련 문제점 식별
- [x] 로직 일관성 문제점 식별
- [x] 감사 로그 문제점 식별

### 개선 작업
- [x] ISSUE-001: JWT 필터 블랙리스트 확인 순서 개선
- [x] ISSUE-002: 토큰 갱신 시 사용자 상태 재검증 추가
- [x] ISSUE-003: 토큰 검증 API에 블랙리스트 확인 추가
- [x] ISSUE-004: 회원가입 시 초기 상태 설정 개선
- [x] ISSUE-005: PENDING 상태 사용자 접근 제한 로직 추가
- [x] ISSUE-006: 2FA 활성화 시 상태 전이 로직 일관화 검토
- [x] ISSUE-007: 모든 로그인 실패 시나리오에 이력 저장
- [x] ISSUE-008: Redis 비활성화 시 토큰 관리 대안 검토

### 코드 품질
- [x] JavaDoc 주석 추가 (@param, @return, @throws)
- [x] 린터 오류 없음 확인
- [x] 코드 스타일 가이드 준수

## 참고사항

### TODO
- 2FA 필수 정책 설정을 SecurityPolicyService 또는 PlatformConfig에서 가져오도록 개선 필요
- 현재는 하드코딩된 값(`twoFactorRequired = true`) 사용

### 주의사항
- Redis가 비활성화된 경우 블랙리스트 기능이 작동하지 않음
- 로그아웃한 토큰도 만료 전까지 유효하게 될 수 있음
- 프로덕션 환경에서는 Redis 사용을 권장