### PR TITLE
Feature/#169: 클라우드 리소스 변경 내역 DB 저장 로직 구현 및 트러블슈팅

### DIFF
--- a/src/main/java/com/agenticcp/core/common/config/TagMapConverter.java
+++ b/src/main/java/com/agenticcp/core/common/config/TagMapConverter.java
@@ -1,0 +1,66 @@
+package com.agenticcp.core.common.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+
+/**
+ * Map<String, String> ↔ JSON String 변환을 위한 JPA AttributeConverter
+ * 
+ * 엔티티의 tags 필드를 Map 타입으로 선언하면서 DB에는 JSON 문자열로 저장합니다.
+ * 서비스 레이어에서 JSON 직렬화 로직을 제거하고 인프라 레이어로 이동시킵니다.
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Slf4j
+@Converter
+public class TagMapConverter implements AttributeConverter<Map<String, String>, String> {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final TypeReference<Map<String, String>> TYPE_REFERENCE = new TypeReference<>() {};
+
+    /**
+     * 엔티티 → DB: Map을 JSON 문자열로 변환
+     *
+     * @param attribute 엔티티의 Map<String, String> 필드
+     * @return JSON 문자열 (null이거나 비어있으면 null 반환)
+     */
+    @Override
+    public String convertToDatabaseColumn(Map<String, String> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            log.warn("[TagMapConverter] Map → JSON 직렬화 실패: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * DB → 엔티티: JSON 문자열을 Map으로 변환
+     *
+     * @param dbData DB에 저장된 JSON 문자열
+     * @return Map<String, String> (null이거나 비어있으면 null 반환)
+     */
+    @Override
+    public Map<String, String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(dbData, TYPE_REFERENCE);
+        } catch (JsonProcessingException e) {
+            log.warn("[TagMapConverter] JSON → Map 역직렬화 실패: {}", e.getMessage());
+            return null;
+        }
+    }
+}
+

--- a/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/s3/AwsS3BucketDiscoveryAdapter.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/s3/AwsS3BucketDiscoveryAdapter.java
@@ -14,8 +14,6 @@ import com.agenticcp.core.domain.cloud.dto.ObjectStorageContainerQueryRequest;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
 import com.agenticcp.core.domain.cloud.port.outbound.storage.ObjectStorageDiscoveryPort;
 import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -50,7 +48,6 @@ public class AwsS3BucketDiscoveryAdapter implements ObjectStorageDiscoveryPort, 
 
     private final AwsS3BucketMapper mapper;
     private final CloudProviderRepository cloudProviderRepository;
-    private final ObjectMapper objectMapper;
     private final AccountCredentialManagementPort accountCredentialManagementPort;
     private final AwsS3Config awsS3Config;
     private final AwsS3ErrorTranslator errorTranslator;
@@ -210,7 +207,7 @@ public class AwsS3BucketDiscoveryAdapter implements ObjectStorageDiscoveryPort, 
                         software.amazon.awssdk.services.resourcegroupstaggingapi.model.Tag::key,
                         software.amazon.awssdk.services.resourcegroupstaggingapi.model.Tag::value
                 ));
-        setTagsJson(resource, tagsMap);
+        setTags(resource, tagsMap);
         return resource;
     }
 
@@ -230,24 +227,19 @@ public class AwsS3BucketDiscoveryAdapter implements ObjectStorageDiscoveryPort, 
             GetBucketTaggingResponse tagsResponse = client.getBucketTagging(r -> r.bucket(bucketName));
             Map<String, String> tagsMap = tagsResponse.tagSet().stream()
                     .collect(Collectors.toMap(Tag::key, Tag::value));
-            setTagsJson(resource, tagsMap);
+            setTags(resource, tagsMap);
         } catch (S3Exception e) {
             if ("NoSuchTagSet".equals(e.awsErrorDetails().errorCode())) {
                 log.debug("Bucket {} has no tags.", bucketName);
             } else {
                 log.warn("Could not retrieve tags for bucket {}: {}", bucketName, e.getMessage());
             }
-            resource.setTags("{}");
+            resource.setTags(null);
         }
     }
 
-    private void setTagsJson(CloudResource resource, Map<String, String> tags) {
-        try {
-            resource.setTags(objectMapper.writeValueAsString(tags));
-        } catch (JsonProcessingException e) {
-            log.warn("Failed to serialize tags: {}", e.getMessage());
-            resource.setTags("{}");
-        }
+    private void setTags(CloudResource resource, Map<String, String> tags) {
+        resource.setTags(tags);
     }
 
     private Page<CloudResource> applyMemoryOperations(List<CloudResource> resources,

--- a/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/s3/AwsS3BucketManagementAdapter.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/s3/AwsS3BucketManagementAdapter.java
@@ -3,6 +3,7 @@ package com.agenticcp.core.domain.cloud.adapter.outbound.aws.s3;
 import com.agenticcp.core.common.exception.BusinessException;
 import com.agenticcp.core.common.exception.ResourceNotFoundException;
 import com.agenticcp.core.domain.cloud.adapter.outbound.aws.config.AwsS3Config;
+import com.agenticcp.core.domain.cloud.adapter.outbound.common.ProviderScoped;
 import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
 import com.agenticcp.core.domain.cloud.exception.ObjectStorageErrorCode;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider;
@@ -38,7 +39,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class AwsS3BucketManagementAdapter implements ObjectStorageManagementPort {
+public class AwsS3BucketManagementAdapter implements ObjectStorageManagementPort, ProviderScoped {
 
     private final AwsS3Config awsS3Config;
     private final AwsS3BucketMapper mapper;
@@ -350,6 +351,16 @@ public class AwsS3BucketManagementAdapter implements ObjectStorageManagementPort
             log.error("Failed to set tags for bucket {}", bucketName, e);
             throw new BusinessException(CloudErrorCode.CLOUD_TAG_OPERATION_FAILED);
         }
+    }
+
+    /**
+     * 이 어댑터가 지원하는 클라우드 프로바이더 타입을 반환합니다.
+     *
+     * @return AWS 프로바이더 타입
+     */
+    @Override
+    public CloudProvider.ProviderType getProviderType() {
+        return CloudProvider.ProviderType.AWS;
     }
 
     private CloudProvider findAwsProvider() {

--- a/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/s3/AwsS3BucketMapper.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/s3/AwsS3BucketMapper.java
@@ -73,7 +73,7 @@ public class AwsS3BucketMapper {
                     .instanceType("S3_BUCKET")
                     .instanceSize("STANDARD")
                     .storageGb(0L) // S3 버킷은 스토리지 용량이 동적이므로 0으로 설정
-                    .tags(buildTagsJson(tags))
+                    .tags(toTagMap(tags))
                     .configuration(buildConfigurationJson(bucket, versioningStatus, lifecycleConfig))
                     .createdInCloud(toLocalDateTime(bucket.creationDate()))
                     .lastModifiedInCloud(toLocalDateTime(bucket.creationDate()))
@@ -162,27 +162,6 @@ public class AwsS3BucketMapper {
             log.error("Failed to convert S3 bucket list to CloudResource list", e);
             throw new BusinessException(CloudErrorCode.MAPPING_FAILED, 
                     "S3 버킷 목록을 CloudResource로 변환하는 중 오류가 발생했습니다: " + e.getMessage());
-        }
-    }
-
-    /**
-     * 태그 리스트를 JSON 문자열로 변환
-     * 
-     * @param tags AWS S3 태그 리스트
-     * @return 태그 JSON 문자열
-     */
-    private String buildTagsJson(List<Tag> tags) {
-        if (tags == null || tags.isEmpty()) {
-            return "{}";
-        }
-        
-        try {
-            Map<String, String> tagMap = toTagMap(tags);
-            return objectMapper.writeValueAsString(tagMap);
-        } catch (Exception e) {
-            log.warn("Failed to serialize tags for bucket", e);
-            throw new BusinessException(CloudErrorCode.CLOUD_TAG_OPERATION_FAILED, 
-                    "S3 버킷 태그 직렬화에 실패했습니다: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/vm/AwsVmMapper.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/vm/AwsVmMapper.java
@@ -57,7 +57,7 @@ public class AwsVmMapper {
                 .memoryGb(getMemoryGb(awsInstance.instanceTypeAsString()))
                 .publicIpAddress(awsInstance.publicIpAddress())
                 .privateIpAddress(awsInstance.privateIpAddress())
-                .tags(toJson(mapTags(awsInstance.tags())))
+                .tags(mapTags(awsInstance.tags()))
                 .configuration(toJson(awsInstance))
                 .metadata(buildMetadata(awsInstance))
                 .build();

--- a/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/vpc/AwsVpcMapper.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/vpc/AwsVpcMapper.java
@@ -99,16 +99,6 @@ public class AwsVpcMapper {
             }
         }
         
-        // 태그를 JSON 문자열로 변환
-        String tagsJson = null;
-        if (tags != null && !tags.isEmpty()) {
-            try {
-                tagsJson = objectMapper.writeValueAsString(tags);
-            } catch (JsonProcessingException e) {
-                // 로깅은 생략 (필요시 추가)
-            }
-        }
-        
         // 메타데이터 구성
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("vpcId", vpc.vpcId());
@@ -151,7 +141,7 @@ public class AwsVpcMapper {
             .region(cloudRegion)
             .resourceType(CloudResource.ResourceType.NETWORK)
             .lifecycleState(mapStateToLifecycleState(vpc.stateAsString()))
-            .tags(tagsJson)
+            .tags(tags)
             .metadata(metadataJson)
             .createdInCloud(LocalDateTime.now()) // AWS VPC는 생성 시간 정보를 직접 제공하지 않으므로 현재 시간 사용
             .build();

--- a/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/vpc/AwsVpcMapper.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/vpc/AwsVpcMapper.java
@@ -50,9 +50,12 @@ public class AwsVpcMapper {
     
     /**
      * Vpc를 CloudResource로 변환 (CreateVpcCommand 사용)
+     * 
+     * 주의: VPC 생성 직후에는 태그가 아직 VPC 객체에 반영되지 않으므로,
+     * command.vpcName()을 직접 사용하여 resourceName을 설정합니다.
      */
     public CloudResource toCloudResource(Vpc vpc, CreateVpcCommand command) {
-        return buildCloudResource(vpc, command.providerType(), command.serviceKey(), command.region(), command.tenantKey(), command.tags());
+        return buildCloudResourceForCreate(vpc, command);
     }
     
     /**
@@ -77,6 +80,67 @@ public class AwsVpcMapper {
         return buildCloudResource(vpc, command.providerType(), "EC2", command.region(), command.tenantKey(), tags);
     }
     
+    /**
+     * VPC 생성 시 사용하는 CloudResource 빌더
+     * 
+     * VPC 생성 직후에는 태그가 VPC 응답 객체에 반영되지 않으므로,
+     * command.vpcName()을 직접 사용하여 resourceName을 설정합니다.
+     */
+    private CloudResource buildCloudResourceForCreate(Vpc vpc, CreateVpcCommand command) {
+        String resourceId = vpc.vpcId();
+        // command.vpcName()을 직접 사용 (VPC 생성 직후에는 태그가 반영되지 않음)
+        String resourceName = (command.vpcName() != null && !command.vpcName().isEmpty()) 
+                ? command.vpcName() 
+                : vpc.vpcId();
+        
+        // 메타데이터 구성
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("vpcId", vpc.vpcId());
+        metadata.put("cidrBlock", vpc.cidrBlock());
+        metadata.put("state", vpc.stateAsString());
+        metadata.put("isDefault", vpc.isDefault());
+        metadata.put("dhcpOptionsId", vpc.dhcpOptionsId());
+        metadata.put("instanceTenancy", vpc.instanceTenancyAsString());
+        
+        String metadataJson = null;
+        try {
+            metadataJson = objectMapper.writeValueAsString(metadata);
+        } catch (JsonProcessingException e) {
+            log.warn("[AwsVpcMapper] Failed to serialize metadata: {}", e.getMessage());
+        }
+        
+        // 엔티티 조회
+        CloudProvider provider = cloudProviderRepository.findFirstByProviderType(command.providerType())
+                .orElseThrow(() -> new IllegalStateException("CloudProvider not found for type: " + command.providerType()));
+        
+        CloudService service = cloudServiceRepository.findByProviderTypeAndServiceKey(command.providerType(), command.serviceKey())
+                .orElseThrow(() -> new IllegalStateException("CloudService not found for providerType: " + command.providerType() + ", serviceKey: " + command.serviceKey()));
+        
+        // region은 optional이므로 null일 수 있음
+        CloudRegion cloudRegion = null;
+        if (command.region() != null && !command.region().isEmpty()) {
+            cloudRegion = cloudRegionRepository.findByProviderTypeAndRegionKey(command.providerType(), command.region())
+                    .orElse(null);
+            if (cloudRegion == null) {
+                log.warn("[AwsVpcMapper] CloudRegion not found for providerType: {}, regionKey: {}", command.providerType(), command.region());
+            }
+        }
+        
+        return CloudResource.builder()
+            .resourceId(resourceId)
+            .resourceName(resourceName)
+            .displayName(resourceName)
+            .provider(provider)
+            .service(service)
+            .region(cloudRegion)
+            .resourceType(CloudResource.ResourceType.NETWORK)
+            .lifecycleState(mapStateToLifecycleState(vpc.stateAsString()))
+            .tags(command.tags())
+            .metadata(metadataJson)
+            .createdInCloud(LocalDateTime.now())
+            .build();
+    }
+
     private CloudResource buildCloudResource(
             Vpc vpc, 
             CloudProvider.ProviderType providerType, 

--- a/src/main/java/com/agenticcp/core/domain/cloud/config/NoOpCloudPortsConfig.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/config/NoOpCloudPortsConfig.java
@@ -1,7 +1,8 @@
 package com.agenticcp.core.domain.cloud.config;
 
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
-import com.agenticcp.core.domain.cloud.port.outbound.CredentialProviderPort;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
 import com.agenticcp.core.domain.cloud.port.outbound.AuditEventPort;
 import com.agenticcp.core.domain.cloud.port.outbound.TracingPort;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -17,11 +18,27 @@ import java.util.Map;
 public class NoOpCloudPortsConfig {
 
     @Bean
-    @ConditionalOnMissingBean(CredentialProviderPort.class)
-    public CredentialProviderPort credentialProviderPort() {
-        return new CredentialProviderPort() {
+    @ConditionalOnMissingBean(AccountCredentialManagementPort.class)
+    public AccountCredentialManagementPort accountCredentialManagementPort() {
+        return new AccountCredentialManagementPort() {
             @Override
             public Object resolveCredentials(String tenantKey, ProviderType providerType, String accountScope) {
+                return null; // 기본 No-Op 동작
+            }
+
+            @Override
+            public String storeCredentials(String tenantKey, ProviderType providerType, 
+                                          String accountScope, Map<String, String> credentials) {
+                return null; // 기본 No-Op 동작
+            }
+
+            @Override
+            public void deleteCredentials(ProviderType providerType, String credentialKey) {
+                // 기본 No-Op 동작
+            }
+
+            @Override
+            public CloudSessionCredential getSession(String tenantKey, String accountScope, ProviderType providerType) {
                 return null; // 기본 No-Op 동작
             }
         };

--- a/src/main/java/com/agenticcp/core/domain/cloud/controller/ObjectStorageController.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/controller/ObjectStorageController.java
@@ -40,7 +40,7 @@ public class ObjectStorageController {
     private final ObjectStorageUseCaseService objectStorageUseCaseService;
 
     @PostMapping
-    @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_CREATE') or hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_CREATE') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
             action = "CREATE_CONTAINER",
             resourceType = AuditResourceType.OBJECT_STORAGE_CONTAINER,
@@ -84,7 +84,7 @@ public class ObjectStorageController {
 
 
     @PutMapping("/{containerName}")
-    @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_UPDATE') or hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_UPDATE') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
             action = "UPDATE_CONTAINER",
             resourceType = AuditResourceType.OBJECT_STORAGE_CONTAINER,
@@ -131,7 +131,7 @@ public class ObjectStorageController {
 
 
     @GetMapping
-    @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_READ') or hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_READ') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
         action = "LIST_CONTAINERS",
         resourceType = AuditResourceType.OBJECT_STORAGE_CONTAINER,
@@ -180,7 +180,7 @@ public class ObjectStorageController {
 
 
     @GetMapping("/{containerName}")
-    @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_READ') or hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_READ') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
         action = "GET_CONTAINER",
         resourceType = AuditResourceType.OBJECT_STORAGE_CONTAINER,
@@ -219,7 +219,7 @@ public class ObjectStorageController {
 
 
     @RequestMapping(value = "/{containerName}", method = RequestMethod.HEAD)
-    @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_READ') or hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_READ') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
         action = "CHECK_CONTAINER_EXISTS",
         resourceType = AuditResourceType.OBJECT_STORAGE_CONTAINER,
@@ -262,7 +262,7 @@ public class ObjectStorageController {
 
 
     @DeleteMapping("/{containerName}")
-    @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_DELETE') or hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_DELETE') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
             action = "DELETE_CONTAINER",
             resourceType = AuditResourceType.OBJECT_STORAGE_CONTAINER,

--- a/src/main/java/com/agenticcp/core/domain/cloud/controller/VmController.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/controller/VmController.java
@@ -136,7 +136,7 @@ public class VmController {
      * @param provider 클라우드 프로바이더 타입
      * @param accountScope 계정 스코프
      * @param request 생성 요청 정보
-     * @return 생성된 인스턴스 ID
+     * @return 생성된 CloudResource 엔티티
      */
     @PostMapping
     @Operation(summary = "VM 인스턴스 생성", description = "새로운 VM 인스턴스를 생성합니다.")
@@ -145,7 +145,7 @@ public class VmController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
-    public ResponseEntity<ApiResponse<String>> createInstance(
+    public ResponseEntity<ApiResponse<CloudResource>> createInstance(
             @Parameter(description = "클라우드 프로바이더 타입", required = true, example = "AWS")
             @PathVariable CloudProvider.ProviderType provider,
             @Parameter(description = "계정 스코프", required = true, example = "123456789012")
@@ -160,10 +160,11 @@ public class VmController {
         log.info("[VmController] createInstance - provider={}, accountScope={}, image={}, instanceSize={}", 
                 provider, accountScope, request.getImage(), request.getInstanceSize());
         
-        String instanceId = vmUseCaseService.createInstance(request);
-        log.info("[VmController] createInstance - success provider={}, instanceId={}", provider, instanceId);
+        CloudResource cloudResource = vmUseCaseService.createInstance(request);
+        log.info("[VmController] createInstance - success provider={}, instanceId={}, resourceId={}", 
+                provider, cloudResource.getResourceId(), cloudResource.getId());
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success(instanceId, "VM 인스턴스 생성에 성공했습니다."));
+                .body(ApiResponse.success(cloudResource, "VM 인스턴스 생성에 성공했습니다."));
     }
 
     // ==================== 인스턴스 생명주기 관리 ====================

--- a/src/main/java/com/agenticcp/core/domain/cloud/controller/VpcController.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/controller/VpcController.java
@@ -45,7 +45,7 @@ public class VpcController {
      * @return 생성된 VPC 리소스
      */
     @PostMapping
-    @PreAuthorize("hasAuthority('VPC_CREATE') or hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('VPC_CREATE') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
         action = "CREATE_VPC",
         resourceType = AuditResourceType.CLOUD_PROVIDER,
@@ -72,7 +72,7 @@ public class VpcController {
      * @return VPC 리소스
      */
     @GetMapping("/{providerType}/{accountScope}/{region}/{resourceId}")
-    @PreAuthorize("hasAuthority('VPC_READ') or hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('VPC_READ') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
         action = "GET_VPC",
         resourceType = AuditResourceType.CLOUD_PROVIDER,
@@ -115,7 +115,7 @@ public class VpcController {
      * @return VPC 리소스 목록
      */
     @GetMapping
-    @PreAuthorize("hasAuthority('VPC_READ') or hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('VPC_READ') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
         action = "LIST_VPCS",
         resourceType = AuditResourceType.CLOUD_PROVIDER,
@@ -142,7 +142,7 @@ public class VpcController {
      * @return 수정된 VPC 리소스
      */
     @PutMapping("/{providerType}/{accountScope}/{region}/{resourceId}")
-    @PreAuthorize("hasAuthority('VPC_UPDATE') or hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('VPC_UPDATE') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
         action = "UPDATE_VPC",
         resourceType = AuditResourceType.CLOUD_PROVIDER,
@@ -183,7 +183,7 @@ public class VpcController {
      * @return 삭제 결과
      */
     @DeleteMapping("/{providerType}/{accountScope}/{region}/{resourceId}")
-    @PreAuthorize("hasAuthority('VPC_DELETE') or hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('VPC_DELETE') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
         action = "DELETE_VPC",
         resourceType = AuditResourceType.CLOUD_PROVIDER,

--- a/src/main/java/com/agenticcp/core/domain/cloud/controller/VpcController.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/controller/VpcController.java
@@ -1,17 +1,24 @@
 package com.agenticcp.core.domain.cloud.controller;
 
 import com.agenticcp.core.common.audit.AuditRequired;
+import com.agenticcp.core.common.dto.exception.ApiResponse;
 import com.agenticcp.core.common.enums.AuditResourceType;
 import com.agenticcp.core.common.enums.AuditSeverity;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
 import com.agenticcp.core.domain.cloud.dto.VpcCreateRequest;
 import com.agenticcp.core.domain.cloud.dto.VpcUpdateRequest;
+import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
 import com.agenticcp.core.domain.cloud.service.vpc.VpcUseCaseService;
 import com.agenticcp.core.domain.cloud.dto.VpcQueryRequest;
 import com.agenticcp.core.domain.cloud.port.model.ResourceIdentity;
 import com.agenticcp.core.domain.cloud.service.vpc.VpcConstants;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -23,24 +30,30 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * VPC 관리 컨트롤러
+ * VPC 관리 REST API 컨트롤러
  * 
- * VPC 관련 REST API 엔드포인트를 제공하는 컨트롤러
+ * 멀티 클라우드(AWS, GCP, Azure) VPC의 생성, 조회, 수정, 삭제 기능을 제공합니다.
+ * 헥사고날 아키텍처의 인터페이스 계층에 해당하며, 외부 클라이언트와의 통신을 담당합니다.
  * 
  * @author AgenticCP Team
- * @version 1.0.0
+ * @version 2.0.0
  */
 @Slf4j
 @RestController
-@RequestMapping("/api/v1/vpcs")
+@RequestMapping("/api/v1/cloud/providers/{provider}/accounts/{accountScope}/vpcs")
 @RequiredArgsConstructor
+@Tag(name = "VPC Management", description = "VPC 관리 API (멀티 클라우드 지원)")
 public class VpcController {
 
     private final VpcUseCaseService vpcUseCaseService;
 
+    // ==================== VPC 생성 ====================
+
     /**
-     * VPC 생성
+     * VPC를 생성합니다.
      * 
+     * @param provider 클라우드 프로바이더 타입 (AWS, GCP, AZURE)
+     * @param accountScope 계정 스코프
      * @param request VPC 생성 요청
      * @return 생성된 VPC 리소스
      */
@@ -54,64 +67,49 @@ public class VpcController {
         includeResponseData = true,
         severity = AuditSeverity.MEDIUM
     )
-    public ResponseEntity<CloudResource> createVpc(@RequestBody VpcCreateRequest request) {
-        log.info("[VpcController] createVpc - provider={}, vpcName={}", 
-                request.getProviderType(), request.getVpcName());
-        CloudResource vpc = vpcUseCaseService.createVpc(request);
-        log.info("[VpcController] createVpc - success resourceId={}", vpc.getResourceId());
-        return ResponseEntity.status(HttpStatus.CREATED).body(vpc);
-    }
-
-    /**
-     * VPC 조회 (단일)
-     * 
-     * @param providerType 프로바이더 타입
-     * @param accountScope 계정 스코프
-     * @param region 리전
-     * @param resourceId 리소스 ID
-     * @return VPC 리소스
-     */
-    @GetMapping("/{providerType}/{accountScope}/{region}/{resourceId}")
-    @PreAuthorize("hasAuthority('VPC_READ') or hasRole('SUPER_ADMIN')")
-    @AuditRequired(
-        action = "GET_VPC",
-        resourceType = AuditResourceType.CLOUD_PROVIDER,
-        description = "VPC 조회",
-        includeRequestData = false,
-        includeResponseData = true,
-        severity = AuditSeverity.LOW
+    @Operation(
+        summary = "VPC 생성",
+        description = "새로운 VPC를 생성합니다."
     )
-    public ResponseEntity<CloudResource> getVpc(
-            @PathVariable CloudProvider.ProviderType providerType,
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "VPC 생성 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<ApiResponse<CloudResource>> createVpc(
+            @Parameter(description = "클라우드 프로바이더 타입", required = true, example = "AWS")
+            @PathVariable CloudProvider.ProviderType provider,
+
+            @Parameter(description = "계정 식별자 (Account ID 등)", required = true, example = "123456789012")
             @PathVariable String accountScope,
-            @PathVariable String region,
-            @PathVariable String resourceId) {
+
+            @Parameter(description = "VPC 생성 요청", required = true)
+            @Valid @RequestBody VpcCreateRequest request) {
         
-        log.info("[VpcController] getVpc - provider={}, resourceId={}", providerType, resourceId);
-        ResourceIdentity vpcId = ResourceIdentity.builder()
-                .providerType(providerType)
-                .accountScope(accountScope)
-                .region(region)
-                .providerResourceId(resourceId)
-                .serviceKey(VpcConstants.SERVICE_KEY)
-                .resourceType(VpcConstants.RESOURCE_TYPE)
-                .build();
-
-        Optional<CloudResource> vpc = vpcUseCaseService.getVpc(vpcId);
-
-        if (vpc.isPresent()) {
-            log.info("[VpcController] getVpc - success resourceId={}", resourceId);
-            return ResponseEntity.ok(vpc.get());
-        } else {
-            log.warn("[VpcController] getVpc - not found resourceId={}", resourceId);
-            return ResponseEntity.notFound().build();
-        }
+        // PathVariable 값을 Request 객체에 주입
+        request.setProviderType(provider);
+        request.setAccountScope(accountScope);
+        
+        log.info("[VpcController] createVpc - provider={}, accountScope={}, vpcName={}", 
+                provider, accountScope, request.getVpcName());
+        
+        CloudResource vpc = vpcUseCaseService.createVpc(request);
+        
+        log.info("[VpcController] createVpc - success resourceId={}", vpc.getResourceId());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(vpc, "VPC 생성에 성공했습니다."));
     }
 
+    // ==================== VPC 조회 ====================
+
     /**
-     * VPC 목록 조회
+     * VPC 목록을 조회합니다.
      * 
-     * @param query VPC 조회 쿼리
+     * @param provider 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param region 리전 (선택)
+     * @param vpcName VPC 이름 필터 (선택)
+     * @param cidrBlock CIDR 블록 필터 (선택)
      * @return VPC 리소스 목록
      */
     @GetMapping
@@ -124,24 +122,126 @@ public class VpcController {
         includeResponseData = false,
         severity = AuditSeverity.LOW
     )
-    public ResponseEntity<List<CloudResource>> listVpcs(VpcQueryRequest query) {
-        log.info("[VpcController] listVpcs - provider={}", query.getProviderType());
+    @Operation(
+        summary = "VPC 목록 조회",
+        description = "지정된 클라우드 프로바이더의 VPC 목록을 조회합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "VPC 목록 조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<ApiResponse<List<CloudResource>>> listVpcs(
+            @Parameter(description = "클라우드 프로바이더 타입", required = true, example = "AWS")
+            @PathVariable CloudProvider.ProviderType provider,
+
+            @Parameter(description = "계정 식별자 (Account ID 등)", required = true, example = "123456789012")
+            @PathVariable String accountScope,
+
+            @Parameter(description = "리전", example = "us-east-1")
+            @RequestParam(required = false) String region,
+
+            @Parameter(description = "VPC 이름 필터", example = "my-vpc")
+            @RequestParam(required = false) String vpcName,
+
+            @Parameter(description = "CIDR 블록 필터", example = "10.0.0.0/16")
+            @RequestParam(required = false) String cidrBlock) {
+        
+        log.info("[VpcController] listVpcs - provider={}, accountScope={}, region={}", 
+                provider, accountScope, region);
+        
+        VpcQueryRequest query = VpcQueryRequest.builder()
+                .providerType(provider)
+                .accountScope(accountScope)
+                .region(region)
+                .vpcName(vpcName)
+                .cidrBlock(cidrBlock)
+                .build();
+        
         List<CloudResource> vpcs = vpcUseCaseService.listVpcs(query);
+        
         log.info("[VpcController] listVpcs - success count={}", vpcs.size());
-        return ResponseEntity.ok(vpcs);
+        return ResponseEntity.ok(ApiResponse.success(vpcs, "VPC 목록 조회에 성공했습니다."));
     }
 
     /**
-     * VPC 수정
+     * 특정 VPC를 조회합니다.
      * 
-     * @param providerType 프로바이더 타입
+     * @param provider 클라우드 프로바이더 타입
      * @param accountScope 계정 스코프
+     * @param vpcId VPC ID
      * @param region 리전
-     * @param resourceId 리소스 ID
+     * @return VPC 리소스
+     */
+    @GetMapping("/{vpcId}")
+    @PreAuthorize("hasAuthority('VPC_READ') or hasRole('SUPER_ADMIN')")
+    @AuditRequired(
+        action = "GET_VPC",
+        resourceType = AuditResourceType.CLOUD_PROVIDER,
+        description = "VPC 조회",
+        includeRequestData = false,
+        includeResponseData = true,
+        severity = AuditSeverity.LOW
+    )
+    @Operation(
+        summary = "VPC 상세 조회",
+        description = "특정 VPC의 상세 정보를 조회합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "VPC 조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "VPC를 찾을 수 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<ApiResponse<CloudResource>> getVpc(
+            @Parameter(description = "클라우드 프로바이더 타입", required = true, example = "AWS")
+            @PathVariable CloudProvider.ProviderType provider,
+
+            @Parameter(description = "계정 식별자 (Account ID 등)", required = true, example = "123456789012")
+            @PathVariable String accountScope,
+
+            @Parameter(description = "VPC ID", required = true, example = "vpc-12345678")
+            @PathVariable String vpcId,
+
+            @Parameter(description = "리전", required = true, example = "us-east-1")
+            @RequestParam String region) {
+        
+        log.info("[VpcController] getVpc - provider={}, accountScope={}, vpcId={}, region={}", 
+                provider, accountScope, vpcId, region);
+        
+        ResourceIdentity resourceIdentity = ResourceIdentity.builder()
+                .providerType(provider)
+                .accountScope(accountScope)
+                .region(region)
+                .providerResourceId(vpcId)
+                .serviceKey(VpcConstants.SERVICE_KEY)
+                .resourceType(VpcConstants.RESOURCE_TYPE)
+                .build();
+
+        Optional<CloudResource> vpc = vpcUseCaseService.getVpc(resourceIdentity);
+
+        if (vpc.isPresent()) {
+            log.info("[VpcController] getVpc - success vpcId={}", vpcId);
+            return ResponseEntity.ok(ApiResponse.success(vpc.get(), "VPC 조회에 성공했습니다."));
+        } else {
+            log.warn("[VpcController] getVpc - not found vpcId={}", vpcId);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(CloudErrorCode.CLOUD_RESOURCE_NOT_FOUND));
+        }
+    }
+
+    // ==================== VPC 수정 ====================
+
+    /**
+     * VPC를 수정합니다.
+     * 
+     * @param provider 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param vpcId VPC ID
+     * @param region 리전
      * @param request VPC 수정 요청
      * @return 수정된 VPC 리소스
      */
-    @PutMapping("/{providerType}/{accountScope}/{region}/{resourceId}")
+    @PutMapping("/{vpcId}")
     @PreAuthorize("hasAuthority('VPC_UPDATE') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
         action = "UPDATE_VPC",
@@ -151,38 +251,62 @@ public class VpcController {
         includeResponseData = true,
         severity = AuditSeverity.MEDIUM
     )
-    public ResponseEntity<CloudResource> updateVpc(
-            @PathVariable CloudProvider.ProviderType providerType,
+    @Operation(
+        summary = "VPC 수정",
+        description = "VPC의 정보를 수정합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "VPC 수정 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "VPC를 찾을 수 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<ApiResponse<CloudResource>> updateVpc(
+            @Parameter(description = "클라우드 프로바이더 타입", required = true, example = "AWS")
+            @PathVariable CloudProvider.ProviderType provider,
+
+            @Parameter(description = "계정 식별자 (Account ID 등)", required = true, example = "123456789012")
             @PathVariable String accountScope,
-            @PathVariable String region,
-            @PathVariable String resourceId,
-            @RequestBody VpcUpdateRequest request) {
+
+            @Parameter(description = "VPC ID", required = true, example = "vpc-12345678")
+            @PathVariable String vpcId,
+
+            @Parameter(description = "리전", required = true, example = "us-east-1")
+            @RequestParam String region,
+
+            @Parameter(description = "VPC 수정 요청", required = true)
+            @Valid @RequestBody VpcUpdateRequest request) {
         
-        log.info("[VpcController] updateVpc - provider={}, resourceId={}", providerType, resourceId);
-        ResourceIdentity vpcId = ResourceIdentity.builder()
-                .providerType(providerType)
+        log.info("[VpcController] updateVpc - provider={}, accountScope={}, vpcId={}, region={}", 
+                provider, accountScope, vpcId, region);
+        
+        ResourceIdentity resourceIdentity = ResourceIdentity.builder()
+                .providerType(provider)
                 .accountScope(accountScope)
                 .region(region)
-                .providerResourceId(resourceId)
+                .providerResourceId(vpcId)
                 .serviceKey(VpcConstants.SERVICE_KEY)
                 .resourceType(VpcConstants.RESOURCE_TYPE)
                 .build();
 
-        CloudResource vpc = vpcUseCaseService.updateVpc(vpcId, request);
-        log.info("[VpcController] updateVpc - success resourceId={}", resourceId);
-        return ResponseEntity.ok(vpc);
+        CloudResource vpc = vpcUseCaseService.updateVpc(resourceIdentity, request);
+        
+        log.info("[VpcController] updateVpc - success vpcId={}", vpcId);
+        return ResponseEntity.ok(ApiResponse.success(vpc, "VPC 수정에 성공했습니다."));
     }
 
+    // ==================== VPC 삭제 ====================
+
     /**
-     * VPC 삭제
+     * VPC를 삭제합니다.
      * 
-     * @param providerType 프로바이더 타입
+     * @param provider 클라우드 프로바이더 타입
      * @param accountScope 계정 스코프
+     * @param vpcId VPC ID
      * @param region 리전
-     * @param resourceId 리소스 ID
      * @return 삭제 결과
      */
-    @DeleteMapping("/{providerType}/{accountScope}/{region}/{resourceId}")
+    @DeleteMapping("/{vpcId}")
     @PreAuthorize("hasAuthority('VPC_DELETE') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
         action = "DELETE_VPC",
@@ -192,24 +316,43 @@ public class VpcController {
         includeResponseData = false,
         severity = AuditSeverity.HIGH
     )
+    @Operation(
+        summary = "VPC 삭제",
+        description = "VPC를 삭제합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "VPC 삭제 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "VPC를 찾을 수 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
     public ResponseEntity<Void> deleteVpc(
-            @PathVariable CloudProvider.ProviderType providerType,
+            @Parameter(description = "클라우드 프로바이더 타입", required = true, example = "AWS")
+            @PathVariable CloudProvider.ProviderType provider,
+
+            @Parameter(description = "계정 식별자 (Account ID 등)", required = true, example = "123456789012")
             @PathVariable String accountScope,
-            @PathVariable String region,
-            @PathVariable String resourceId) {
+
+            @Parameter(description = "VPC ID", required = true, example = "vpc-12345678")
+            @PathVariable String vpcId,
+
+            @Parameter(description = "리전", required = true, example = "us-east-1")
+            @RequestParam String region) {
         
-        log.info("[VpcController] deleteVpc - provider={}, resourceId={}", providerType, resourceId);
-        ResourceIdentity vpcId = ResourceIdentity.builder()
-                .providerType(providerType)
+        log.info("[VpcController] deleteVpc - provider={}, accountScope={}, vpcId={}, region={}", 
+                provider, accountScope, vpcId, region);
+        
+        ResourceIdentity resourceIdentity = ResourceIdentity.builder()
+                .providerType(provider)
                 .accountScope(accountScope)
                 .region(region)
-                .providerResourceId(resourceId)
+                .providerResourceId(vpcId)
                 .serviceKey(VpcConstants.SERVICE_KEY)
                 .resourceType(VpcConstants.RESOURCE_TYPE)
                 .build();
 
-        vpcUseCaseService.deleteVpc(vpcId);
-        log.info("[VpcController] deleteVpc - success resourceId={}", resourceId);
+        vpcUseCaseService.deleteVpc(resourceIdentity);
+        
+        log.info("[VpcController] deleteVpc - success vpcId={}", vpcId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/agenticcp/core/domain/cloud/dto/ResourceRegistrationRequest.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/dto/ResourceRegistrationRequest.java
@@ -1,0 +1,154 @@
+package com.agenticcp.core.domain.cloud.dto;
+
+import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.ResourceType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * CloudResource 등록 요청 DTO
+ * 
+ * 모든 클라우드 리소스(VM, Storage, VPC, RDS 등)를 통합적으로 등록하기 위한 요청 객체입니다.
+ * 도메인별 상세 속성(instanceSize, cidrBlock 등)은 attributes에 담아 전달합니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Getter
+@Builder
+public class ResourceRegistrationRequest {
+
+    /**
+     * 리소스 ID (CSP에서 부여한 고유 ID)
+     * 예: AWS EC2 인스턴스 ID, VPC ID, S3 버킷 이름 등
+     */
+    private final String resourceId;
+
+    /**
+     * 리소스 이름 (사용자 지정 또는 태그에서 추출)
+     */
+    private final String resourceName;
+
+    /**
+     * 리소스 타입
+     * @see ResourceType
+     */
+    private final ResourceType resourceType;
+
+    /**
+     * 리소스 태그 (CSP의 태그 정보)
+     */
+    @Builder.Default
+    private final Map<String, String> tags = new HashMap<>();
+
+    /**
+     * 도메인별 상세 속성
+     * 
+     * <p>리소스 타입에 따른 속성 예시:</p>
+     * <ul>
+     *   <li>VM: instanceSize, cpuCores, memoryGb</li>
+     *   <li>VPC: configuration (cidrBlock)</li>
+     *   <li>Storage: storageGb</li>
+     *   <li>RDS: engineVersion, storageType</li>
+     * </ul>
+     */
+    @Builder.Default
+    private final Map<String, Object> attributes = new HashMap<>();
+
+    /**
+     * 초기 생명주기 상태 (선택적)
+     * null인 경우 resourceType에 따라 기본값이 적용됩니다.
+     */
+    private final LifecycleState initialLifecycleState;
+
+    // ==================== 편의 메서드 ====================
+
+    /**
+     * 속성 값을 String으로 조회합니다.
+     * 
+     * @param key 속성 키
+     * @return 속성 값 또는 null
+     */
+    public String getAttributeAsString(String key) {
+        Object value = attributes.get(key);
+        return value != null ? value.toString() : null;
+    }
+
+    /**
+     * 속성 값을 Integer로 조회합니다.
+     * 
+     * @param key 속성 키
+     * @return 속성 값 또는 null
+     */
+    public Integer getAttributeAsInteger(String key) {
+        Object value = attributes.get(key);
+        if (value instanceof Integer) {
+            return (Integer) value;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        if (value instanceof String) {
+            try {
+                return Integer.parseInt((String) value);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 속성 값을 Long으로 조회합니다.
+     * 
+     * @param key 속성 키
+     * @return 속성 값 또는 null
+     */
+    public Long getAttributeAsLong(String key) {
+        Object value = attributes.get(key);
+        if (value instanceof Long) {
+            return (Long) value;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        if (value instanceof String) {
+            try {
+                return Long.parseLong((String) value);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    // ==================== 자주 사용되는 속성 키 상수 ====================
+
+    /**
+     * 자주 사용되는 속성 키 상수
+     */
+    public static final class AttributeKeys {
+        /** VM 인스턴스 크기 (예: t3.micro, Standard_B1s) */
+        public static final String INSTANCE_SIZE = "instanceSize";
+        
+        /** 리소스 설정 정보 (JSON 또는 CIDR 블록 등) */
+        public static final String CONFIGURATION = "configuration";
+        
+        /** CPU 코어 수 */
+        public static final String CPU_CORES = "cpuCores";
+        
+        /** 메모리 (GB) */
+        public static final String MEMORY_GB = "memoryGb";
+        
+        /** 스토리지 (GB) */
+        public static final String STORAGE_GB = "storageGb";
+        
+        /** 인스턴스 타입 */
+        public static final String INSTANCE_TYPE = "instanceType";
+        
+        private AttributeKeys() {}
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/dto/VpcCreateRequest.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/dto/VpcCreateRequest.java
@@ -3,6 +3,7 @@ package com.agenticcp.core.domain.cloud.dto;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import lombok.Builder;
 import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
 
 import java.util.Map;
 
@@ -16,6 +17,7 @@ import java.util.Map;
  */
 @Value
 @Builder
+@Jacksonized
 public class VpcCreateRequest {
     ProviderType providerType;
     String accountScope;

--- a/src/main/java/com/agenticcp/core/domain/cloud/dto/VpcCreateRequest.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/dto/VpcCreateRequest.java
@@ -1,9 +1,12 @@
 package com.agenticcp.core.domain.cloud.dto;
 
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Value;
-import lombok.extern.jackson.Jacksonized;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.Map;
 
@@ -13,19 +16,64 @@ import java.util.Map;
  * 모든 클라우드 프로바이더에서 VPC 생성을 위한 표준화된 요청 모델
  * 
  * @author AgenticCP Team
- * @version 1.0.0
+ * @version 2.0.0
  */
-@Value
+@Data
 @Builder
-@Jacksonized
+@NoArgsConstructor
+@AllArgsConstructor
 public class VpcCreateRequest {
-    ProviderType providerType;
-    String accountScope;
-    String region;
-    String vpcName;
-    String cidrBlock;
-    String description;
-    Map<String, String> tags;
-    String tenantKey;
-    Map<String, Object> providerSpecificConfig;
+
+    /**
+     * 클라우드 프로바이더 타입 (AWS, GCP, AZURE)
+     * Controller에서 PathVariable로 주입됩니다.
+     */
+    private ProviderType providerType;
+
+    /**
+     * 계정 스코프 (Account ID 등)
+     * Controller에서 PathVariable로 주입됩니다.
+     */
+    private String accountScope;
+
+    /**
+     * 리전 (필수)
+     * 예: us-east-1, ap-northeast-2
+     */
+    @NotBlank(message = "리전은 필수입니다")
+    private String region;
+
+    /**
+     * VPC 이름
+     */
+    private String vpcName;
+
+    /**
+     * CIDR 블록 (필수)
+     * 예: 10.0.0.0/16
+     */
+    @NotBlank(message = "CIDR 블록은 필수입니다")
+    @Pattern(regexp = "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/\\d{1,2}$",
+            message = "올바른 CIDR 형식이어야 합니다 (예: 10.0.0.0/16)")
+    private String cidrBlock;
+
+    /**
+     * VPC 설명
+     */
+    private String description;
+
+    /**
+     * 태그
+     */
+    private Map<String, String> tags;
+
+    /**
+     * 테넌트 키
+     */
+    private String tenantKey;
+
+    /**
+     * 프로바이더별 추가 설정
+     */
+    private Map<String, Object> providerSpecificConfig;
 }

--- a/src/main/java/com/agenticcp/core/domain/cloud/dto/VpcQueryRequest.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/dto/VpcQueryRequest.java
@@ -1,8 +1,10 @@
 package com.agenticcp.core.domain.cloud.dto;
 
 import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Value;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.Map;
 
@@ -12,20 +14,67 @@ import java.util.Map;
  * VPC 목록 조회를 위한 표준화된 쿼리 모델
  * 
  * @author AgenticCP Team
- * @version 1.0.0
+ * @version 2.0.0
  */
-@Value
+@Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class VpcQueryRequest {
-    CloudProvider.ProviderType providerType;
-    String accountScope;
-    String region;
-    String vpcName;
-    String cidrBlock;
-    Map<String, String> tags;
-    String tenantKey;
-    Integer page;
-    Integer size;
-    String sortBy;
-    String sortDirection;
+
+    /**
+     * 클라우드 프로바이더 타입 (AWS, GCP, AZURE)
+     */
+    private CloudProvider.ProviderType providerType;
+
+    /**
+     * 계정 스코프 (Account ID 등)
+     */
+    private String accountScope;
+
+    /**
+     * 리전
+     * 예: us-east-1, ap-northeast-2
+     */
+    private String region;
+
+    /**
+     * VPC 이름 필터
+     */
+    private String vpcName;
+
+    /**
+     * CIDR 블록 필터
+     */
+    private String cidrBlock;
+
+    /**
+     * 태그 필터
+     */
+    private Map<String, String> tags;
+
+    /**
+     * 테넌트 키
+     */
+    private String tenantKey;
+
+    /**
+     * 페이지 번호 (0부터 시작)
+     */
+    private Integer page;
+
+    /**
+     * 페이지 크기
+     */
+    private Integer size;
+
+    /**
+     * 정렬 기준 필드
+     */
+    private String sortBy;
+
+    /**
+     * 정렬 방향 (ASC, DESC)
+     */
+    private String sortDirection;
 }

--- a/src/main/java/com/agenticcp/core/domain/cloud/entity/CloudResource.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/entity/CloudResource.java
@@ -1,5 +1,6 @@
 package com.agenticcp.core.domain.cloud.entity;
 
+import com.agenticcp.core.common.config.TagMapConverter;
 import com.agenticcp.core.common.entity.BaseEntity;
 import com.agenticcp.core.common.enums.Status;
 import com.agenticcp.core.domain.tenant.entity.Tenant;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Entity
 @Table(name = "cloud_resources")
@@ -84,8 +86,9 @@ public class CloudResource extends BaseEntity {
     @Column(name = "public_ip_address")
     private String publicIpAddress;
 
+    @Convert(converter = TagMapConverter.class)
     @Column(name = "tags", columnDefinition = "TEXT")
-    private String tags; // JSON for resource tags
+    private Map<String, String> tags;
 
     @Column(name = "configuration", columnDefinition = "TEXT")
     private String configuration; // JSON for resource configuration
@@ -120,7 +123,7 @@ public class CloudResource extends BaseEntity {
      * @param service      클라우드 서비스 (EC2, Compute Engine 등)
      * @param tenant       테넌트
      * @param instanceSize 인스턴스 크기
-     * @param tagsJson     태그 (JSON 형식)
+     * @param tags         태그 맵
      * @return CloudResource 엔티티
      */
     public static CloudResource createVmInstance(
@@ -130,7 +133,7 @@ public class CloudResource extends BaseEntity {
             CloudService service,
             Tenant tenant,
             String instanceSize,
-            String tagsJson
+            Map<String, String> tags
     ) {
         LocalDateTime now = LocalDateTime.now();
         return CloudResource.builder()
@@ -144,7 +147,7 @@ public class CloudResource extends BaseEntity {
                 .resourceType(ResourceType.INSTANCE)
                 .lifecycleState(LifecycleState.PENDING)
                 .instanceSize(instanceSize)
-                .tags(tagsJson)
+                .tags(tags)
                 .createdInCloud(now)
                 .lastModifiedInCloud(now)
                 .lastSync(now)
@@ -159,7 +162,7 @@ public class CloudResource extends BaseEntity {
      * @param provider      클라우드 프로바이더
      * @param service       클라우드 서비스 (S3, BlobStorage 등)
      * @param tenant        테넌트
-     * @param tagsJson      태그 (JSON 형식)
+     * @param tags          태그 맵
      * @return CloudResource 엔티티
      */
     public static CloudResource createStorageBucket(
@@ -167,7 +170,7 @@ public class CloudResource extends BaseEntity {
             CloudProvider provider,
             CloudService service,
             Tenant tenant,
-            String tagsJson
+            Map<String, String> tags
     ) {
         LocalDateTime now = LocalDateTime.now();
         return CloudResource.builder()
@@ -180,7 +183,7 @@ public class CloudResource extends BaseEntity {
                 .status(Status.ACTIVE)
                 .resourceType(ResourceType.BUCKET)
                 .lifecycleState(LifecycleState.RUNNING)
-                .tags(tagsJson)
+                .tags(tags)
                 .createdInCloud(now)
                 .lastModifiedInCloud(now)
                 .lastSync(now)
@@ -197,7 +200,7 @@ public class CloudResource extends BaseEntity {
      * @param service      클라우드 서비스 (EC2, VirtualNetwork 등)
      * @param tenant       테넌트
      * @param cidrBlock    CIDR 블록 (configuration에 저장)
-     * @param tagsJson     태그 (JSON 형식)
+     * @param tags         태그 맵
      * @return CloudResource 엔티티
      */
     public static CloudResource createVpc(
@@ -207,7 +210,7 @@ public class CloudResource extends BaseEntity {
             CloudService service,
             Tenant tenant,
             String cidrBlock,
-            String tagsJson
+            Map<String, String> tags
     ) {
         LocalDateTime now = LocalDateTime.now();
         return CloudResource.builder()
@@ -220,7 +223,7 @@ public class CloudResource extends BaseEntity {
                 .status(Status.ACTIVE)
                 .resourceType(ResourceType.NETWORK)
                 .lifecycleState(LifecycleState.RUNNING)
-                .tags(tagsJson)
+                .tags(tags)
                 .configuration(cidrBlock)
                 .createdInCloud(now)
                 .lastModifiedInCloud(now)

--- a/src/main/java/com/agenticcp/core/domain/cloud/entity/CloudResource.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/entity/CloudResource.java
@@ -108,6 +108,126 @@ public class CloudResource extends BaseEntity {
     @Column(name = "metadata", columnDefinition = "TEXT")
     private String metadata; // JSON for additional resource metadata
 
+    // ==================== Factory Methods ====================
+
+    /**
+     * VM 인스턴스용 CloudResource 생성
+     * CSP에서 생성된 VM 인스턴스 정보를 CloudResource 엔티티로 변환합니다.
+     *
+     * @param resourceId   인스턴스 ID (CSP에서 부여한 ID)
+     * @param resourceName 리소스 이름 (태그에서 추출 또는 resourceId)
+     * @param provider     클라우드 프로바이더
+     * @param service      클라우드 서비스 (EC2, Compute Engine 등)
+     * @param tenant       테넌트
+     * @param instanceSize 인스턴스 크기
+     * @param tagsJson     태그 (JSON 형식)
+     * @return CloudResource 엔티티
+     */
+    public static CloudResource createVmInstance(
+            String resourceId,
+            String resourceName,
+            CloudProvider provider,
+            CloudService service,
+            Tenant tenant,
+            String instanceSize,
+            String tagsJson
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+        return CloudResource.builder()
+                .resourceId(resourceId)
+                .resourceName(resourceName)
+                .displayName(resourceName)
+                .provider(provider)
+                .service(service)
+                .tenant(tenant)
+                .status(Status.ACTIVE)
+                .resourceType(ResourceType.INSTANCE)
+                .lifecycleState(LifecycleState.PENDING)
+                .instanceSize(instanceSize)
+                .tags(tagsJson)
+                .createdInCloud(now)
+                .lastModifiedInCloud(now)
+                .lastSync(now)
+                .build();
+    }
+
+    /**
+     * Object Storage (버킷/컨테이너)용 CloudResource 생성
+     * CSP에서 생성된 스토리지 컨테이너 정보를 CloudResource 엔티티로 변환합니다.
+     *
+     * @param containerName 컨테이너 이름 (S3 버킷명, Azure Blob 컨테이너명 등)
+     * @param provider      클라우드 프로바이더
+     * @param service       클라우드 서비스 (S3, BlobStorage 등)
+     * @param tenant        테넌트
+     * @param tagsJson      태그 (JSON 형식)
+     * @return CloudResource 엔티티
+     */
+    public static CloudResource createStorageBucket(
+            String containerName,
+            CloudProvider provider,
+            CloudService service,
+            Tenant tenant,
+            String tagsJson
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+        return CloudResource.builder()
+                .resourceId(containerName)
+                .resourceName(containerName)
+                .displayName(containerName)
+                .provider(provider)
+                .service(service)
+                .tenant(tenant)
+                .status(Status.ACTIVE)
+                .resourceType(ResourceType.BUCKET)
+                .lifecycleState(LifecycleState.RUNNING)
+                .tags(tagsJson)
+                .createdInCloud(now)
+                .lastModifiedInCloud(now)
+                .lastSync(now)
+                .build();
+    }
+
+    /**
+     * VPC 네트워크용 CloudResource 생성
+     * CSP에서 생성된 VPC 정보를 CloudResource 엔티티로 변환합니다.
+     *
+     * @param vpcId        VPC ID (CSP에서 부여한 ID)
+     * @param resourceName 리소스 이름 (VPC 이름 또는 vpcId)
+     * @param provider     클라우드 프로바이더
+     * @param service      클라우드 서비스 (EC2, VirtualNetwork 등)
+     * @param tenant       테넌트
+     * @param cidrBlock    CIDR 블록 (configuration에 저장)
+     * @param tagsJson     태그 (JSON 형식)
+     * @return CloudResource 엔티티
+     */
+    public static CloudResource createVpc(
+            String vpcId,
+            String resourceName,
+            CloudProvider provider,
+            CloudService service,
+            Tenant tenant,
+            String cidrBlock,
+            String tagsJson
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+        return CloudResource.builder()
+                .resourceId(vpcId)
+                .resourceName(resourceName)
+                .displayName(resourceName)
+                .provider(provider)
+                .service(service)
+                .tenant(tenant)
+                .status(Status.ACTIVE)
+                .resourceType(ResourceType.NETWORK)
+                .lifecycleState(LifecycleState.RUNNING)
+                .tags(tagsJson)
+                .configuration(cidrBlock)
+                .createdInCloud(now)
+                .lastModifiedInCloud(now)
+                .lastSync(now)
+                .build();
+    }
+
     public enum ResourceType {
         INSTANCE,
         VOLUME,

--- a/src/main/java/com/agenticcp/core/domain/cloud/entity/CloudResource.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/entity/CloudResource.java
@@ -10,6 +10,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import com.agenticcp.core.domain.cloud.dto.ResourceRegistrationRequest;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Map;
@@ -112,6 +114,111 @@ public class CloudResource extends BaseEntity {
     private String metadata; // JSON for additional resource metadata
 
     // ==================== Factory Methods ====================
+
+    /**
+     * 통합 CloudResource 생성 팩토리 메서드
+     * 
+     * 모든 리소스 타입(VM, Storage, VPC, RDS 등)을 하나의 메서드로 생성합니다.
+     * 도메인별 상세 속성은 ResourceRegistrationRequest의 attributes에서 추출합니다.
+     *
+     * @param request  리소스 등록 요청 DTO
+     * @param provider 클라우드 프로바이더
+     * @param service  클라우드 서비스
+     * @param tenant   테넌트
+     * @return CloudResource 엔티티
+     */
+    public static CloudResource create(
+            ResourceRegistrationRequest request,
+            CloudProvider provider,
+            CloudService service,
+            Tenant tenant
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+        
+        CloudResource resource = CloudResource.builder()
+                .resourceId(request.getResourceId())
+                .resourceName(request.getResourceName())
+                .displayName(request.getResourceName())
+                .provider(provider)
+                .service(service)
+                .tenant(tenant)
+                .status(Status.ACTIVE)
+                .resourceType(request.getResourceType())
+                .lifecycleState(determineInitialLifecycleState(request))
+                .tags(request.getTags())
+                .createdInCloud(now)
+                .lastModifiedInCloud(now)
+                .lastSync(now)
+                .build();
+        
+        // 도메인별 속성 적용
+        applyAttributes(resource, request);
+        
+        return resource;
+    }
+
+    /**
+     * 초기 생명주기 상태 결정
+     * 요청에 명시된 상태가 있으면 사용, 없으면 리소스 타입에 따라 기본값 적용
+     */
+    private static LifecycleState determineInitialLifecycleState(ResourceRegistrationRequest request) {
+        if (request.getInitialLifecycleState() != null) {
+            return request.getInitialLifecycleState();
+        }
+        
+        // 리소스 타입별 기본 생명주기 상태
+        return switch (request.getResourceType()) {
+            case INSTANCE -> LifecycleState.PENDING;
+            default -> LifecycleState.RUNNING;
+        };
+    }
+
+    /**
+     * 도메인별 속성을 CloudResource에 적용
+     */
+    private static void applyAttributes(CloudResource resource, ResourceRegistrationRequest request) {
+        // instanceSize
+        String instanceSize = request.getAttributeAsString(
+                ResourceRegistrationRequest.AttributeKeys.INSTANCE_SIZE);
+        if (instanceSize != null) {
+            resource.setInstanceSize(instanceSize);
+        }
+        
+        // configuration (cidrBlock, JSON 설정 등)
+        String configuration = request.getAttributeAsString(
+                ResourceRegistrationRequest.AttributeKeys.CONFIGURATION);
+        if (configuration != null) {
+            resource.setConfiguration(configuration);
+        }
+        
+        // cpuCores
+        Integer cpuCores = request.getAttributeAsInteger(
+                ResourceRegistrationRequest.AttributeKeys.CPU_CORES);
+        if (cpuCores != null) {
+            resource.setCpuCores(cpuCores);
+        }
+        
+        // memoryGb
+        Integer memoryGb = request.getAttributeAsInteger(
+                ResourceRegistrationRequest.AttributeKeys.MEMORY_GB);
+        if (memoryGb != null) {
+            resource.setMemoryGb(memoryGb);
+        }
+        
+        // storageGb
+        Long storageGb = request.getAttributeAsLong(
+                ResourceRegistrationRequest.AttributeKeys.STORAGE_GB);
+        if (storageGb != null) {
+            resource.setStorageGb(storageGb);
+        }
+        
+        // instanceType
+        String instanceType = request.getAttributeAsString(
+                ResourceRegistrationRequest.AttributeKeys.INSTANCE_TYPE);
+        if (instanceType != null) {
+            resource.setInstanceType(instanceType);
+        }
+    }
 
     /**
      * VM 인스턴스용 CloudResource 생성

--- a/src/main/java/com/agenticcp/core/domain/cloud/exception/CloudErrorCode.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/exception/CloudErrorCode.java
@@ -44,7 +44,11 @@ public enum CloudErrorCode implements BaseErrorCode {
     INVALID_REGION(HttpStatus.BAD_REQUEST, 4036, "유효하지 않은 클라우드 리전입니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, 4037, "유효하지 않은 클라우드 API 요청입니다."),
     CLOUD_NETWORK_ERROR(HttpStatus.SERVICE_UNAVAILABLE, 4038, "클라우드 네트워크 통신에 실패했습니다."),
-    CLOUD_CONFIGURATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 4039, "클라우드 설정이 잘못되었습니다.");
+    CLOUD_CONFIGURATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 4039, "클라우드 설정이 잘못되었습니다."),
+    
+    // 리소스 생성/동기화 관련 (4040-4049)
+    RESOURCE_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4040, "클라우드 리소스 생성 후 DB 저장에 실패하여 롤백되었습니다."),
+    RESOURCE_SYNC_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4041, "클라우드 리소스 동기화에 실패했습니다.");
     
     private final HttpStatus httpStatus;
     private final int codeNumber;

--- a/src/main/java/com/agenticcp/core/domain/cloud/repository/CloudResourceRepository.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/repository/CloudResourceRepository.java
@@ -1,22 +1,34 @@
 package com.agenticcp.core.domain.cloud.repository;
 
+import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.ResourceType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 클라우드 리소스 Repository
+ * <p>
+ * 멀티 클라우드(AWS, Azure, GCP 등) 자원의 생명주기 관리를 위한 Repository입니다.
+ * CSP 독립적인 자원 조회, 상태 업데이트, 소프트 삭제 기능을 제공합니다.
+ * </p>
  * 
  * @author AgenticCP Team
- * @version 1.0.0
+ * @version 2.0.0
  * @since 2025-10-06
  */
 @Repository
 public interface CloudResourceRepository extends JpaRepository<CloudResource, Long> {
+    
+    // ==================== 기본 조회 ====================
     
     /**
      * 테넌트 키로 클라우드 리소스 목록 조회
@@ -28,17 +40,227 @@ public interface CloudResourceRepository extends JpaRepository<CloudResource, Lo
            "JOIN FETCH cr.provider " +
            "WHERE cr.tenant.tenantKey = :tenantKey " +
            "AND cr.isDeleted = false")
-    List<CloudResource> findByTenantId(@Param("tenantKey") String tenantKey);
+    List<CloudResource> findByTenantKey(@Param("tenantKey") String tenantKey);
     
     /**
      * 리소스 ID로 조회
      * 
-     * @param resourceId 리소스 ID
+     * @param resourceId 리소스 ID (AWS instanceId, Azure vmId 등)
      * @return 클라우드 리소스
      */
     @Query("SELECT cr FROM CloudResource cr " +
            "WHERE cr.resourceId = :resourceId " +
            "AND cr.isDeleted = false")
     CloudResource findByResourceId(@Param("resourceId") String resourceId);
+    
+    /**
+     * 리소스 ID로 조회 (Optional 반환)
+     * 
+     * @param resourceId 리소스 ID (AWS instanceId, Azure vmId 등)
+     * @return 클라우드 리소스 (Optional)
+     */
+    @Query("SELECT cr FROM CloudResource cr " +
+           "JOIN FETCH cr.provider " +
+           "WHERE cr.resourceId = :resourceId " +
+           "AND cr.isDeleted = false")
+    Optional<CloudResource> findOptionalByResourceId(@Param("resourceId") String resourceId);
+    
+    /**
+     * 리소스 ID 존재 여부 확인
+     * 
+     * @param resourceId 리소스 ID
+     * @return 존재 여부
+     */
+    @Query("SELECT CASE WHEN COUNT(cr) > 0 THEN true ELSE false END " +
+           "FROM CloudResource cr " +
+           "WHERE cr.resourceId = :resourceId " +
+           "AND cr.isDeleted = false")
+    boolean existsByResourceId(@Param("resourceId") String resourceId);
+    
+    // ==================== 리소스 타입별 조회 ====================
+    
+    /**
+     * 리소스 타입별 조회 (INSTANCE, BUCKET, NETWORK 등)
+     * 
+     * @param resourceType 리소스 타입
+     * @return 클라우드 리소스 목록
+     */
+    @Query("SELECT cr FROM CloudResource cr " +
+           "JOIN FETCH cr.provider " +
+           "WHERE cr.resourceType = :resourceType " +
+           "AND cr.isDeleted = false")
+    List<CloudResource> findByResourceType(@Param("resourceType") ResourceType resourceType);
+    
+    /**
+     * 테넌트 키 + 리소스 타입별 조회
+     * 
+     * @param tenantKey 테넌트 키
+     * @param resourceType 리소스 타입
+     * @return 클라우드 리소스 목록
+     */
+    @Query("SELECT cr FROM CloudResource cr " +
+           "JOIN FETCH cr.provider " +
+           "WHERE cr.tenant.tenantKey = :tenantKey " +
+           "AND cr.resourceType = :resourceType " +
+           "AND cr.isDeleted = false")
+    List<CloudResource> findByTenantKeyAndResourceType(
+            @Param("tenantKey") String tenantKey,
+            @Param("resourceType") ResourceType resourceType);
+    
+    // ==================== 프로바이더(CSP)별 조회 ====================
+    
+    /**
+     * 프로바이더 타입별 조회 (AWS, Azure, GCP 등)
+     * 
+     * @param providerType 프로바이더 타입
+     * @return 클라우드 리소스 목록
+     */
+    @Query("SELECT cr FROM CloudResource cr " +
+           "JOIN FETCH cr.provider p " +
+           "WHERE p.providerType = :providerType " +
+           "AND cr.isDeleted = false")
+    List<CloudResource> findByProviderType(@Param("providerType") ProviderType providerType);
+    
+    /**
+     * 테넌트 키 + 프로바이더 타입별 조회
+     * 
+     * @param tenantKey 테넌트 키
+     * @param providerType 프로바이더 타입
+     * @return 클라우드 리소스 목록
+     */
+    @Query("SELECT cr FROM CloudResource cr " +
+           "JOIN FETCH cr.provider p " +
+           "WHERE cr.tenant.tenantKey = :tenantKey " +
+           "AND p.providerType = :providerType " +
+           "AND cr.isDeleted = false")
+    List<CloudResource> findByTenantKeyAndProviderType(
+            @Param("tenantKey") String tenantKey,
+            @Param("providerType") ProviderType providerType);
+    
+    // ==================== 생명주기 상태별 조회 ====================
+    
+    /**
+     * 생명주기 상태별 조회
+     * 
+     * @param lifecycleState 생명주기 상태 (RUNNING, STOPPED 등)
+     * @return 클라우드 리소스 목록
+     */
+    @Query("SELECT cr FROM CloudResource cr " +
+           "JOIN FETCH cr.provider " +
+           "WHERE cr.lifecycleState = :lifecycleState " +
+           "AND cr.isDeleted = false")
+    List<CloudResource> findByLifecycleState(@Param("lifecycleState") LifecycleState lifecycleState);
+    
+    /**
+     * 특정 생명주기 상태를 제외한 조회 (동기화용)
+     * TERMINATED 상태를 제외한 활성 리소스 조회 등에 활용
+     * 
+     * @param excludeStates 제외할 상태 목록
+     * @return 클라우드 리소스 목록
+     */
+    @Query("SELECT cr FROM CloudResource cr " +
+           "JOIN FETCH cr.provider " +
+           "WHERE cr.lifecycleState NOT IN :excludeStates " +
+           "AND cr.isDeleted = false")
+    List<CloudResource> findByLifecycleStateNotIn(@Param("excludeStates") List<LifecycleState> excludeStates);
+    
+    /**
+     * 테넌트 키 + 프로바이더 타입 + 리소스 타입별 조회
+     * 
+     * @param tenantKey 테넌트 키
+     * @param providerType 프로바이더 타입
+     * @param resourceType 리소스 타입
+     * @return 클라우드 리소스 목록
+     */
+    @Query("SELECT cr FROM CloudResource cr " +
+           "JOIN FETCH cr.provider p " +
+           "WHERE cr.tenant.tenantKey = :tenantKey " +
+           "AND p.providerType = :providerType " +
+           "AND cr.resourceType = :resourceType " +
+           "AND cr.isDeleted = false")
+    List<CloudResource> findByTenantKeyAndProviderTypeAndResourceType(
+            @Param("tenantKey") String tenantKey,
+            @Param("providerType") ProviderType providerType,
+            @Param("resourceType") ResourceType resourceType);
+    
+    // ==================== 상태 업데이트 (Modifying) ====================
+    
+    /**
+     * 생명주기 상태 업데이트
+     * CSP에서 자원 시작/중지/종료 후 DB 상태 동기화에 사용
+     * 
+     * @param resourceId 리소스 ID
+     * @param lifecycleState 새로운 생명주기 상태
+     * @param lastModifiedInCloud 클라우드에서 수정된 시간
+     * @return 업데이트된 행 수
+     */
+    @Modifying
+    @Query("UPDATE CloudResource cr SET " +
+           "cr.lifecycleState = :lifecycleState, " +
+           "cr.lastModifiedInCloud = :lastModifiedInCloud, " +
+           "cr.updatedAt = CURRENT_TIMESTAMP " +
+           "WHERE cr.resourceId = :resourceId " +
+           "AND cr.isDeleted = false")
+    int updateLifecycleState(
+            @Param("resourceId") String resourceId,
+            @Param("lifecycleState") LifecycleState lifecycleState,
+            @Param("lastModifiedInCloud") LocalDateTime lastModifiedInCloud);
+    
+    /**
+     * 소프트 삭제 처리
+     * CSP에서 자원 삭제 후 DB에서 논리적 삭제 처리에 사용
+     * 
+     * @param resourceId 리소스 ID
+     * @return 업데이트된 행 수
+     */
+    @Modifying
+    @Query("UPDATE CloudResource cr SET " +
+           "cr.isDeleted = true, " +
+           "cr.lifecycleState = 'TERMINATED', " +
+           "cr.updatedAt = CURRENT_TIMESTAMP " +
+           "WHERE cr.resourceId = :resourceId")
+    int softDeleteByResourceId(@Param("resourceId") String resourceId);
+    
+    /**
+     * 마지막 동기화 시간 업데이트
+     * 
+     * @param resourceId 리소스 ID
+     * @param lastSync 마지막 동기화 시간
+     * @return 업데이트된 행 수
+     */
+    @Modifying
+    @Query("UPDATE CloudResource cr SET " +
+           "cr.lastSync = :lastSync, " +
+           "cr.updatedAt = CURRENT_TIMESTAMP " +
+           "WHERE cr.resourceId = :resourceId " +
+           "AND cr.isDeleted = false")
+    int updateLastSync(
+            @Param("resourceId") String resourceId,
+            @Param("lastSync") LocalDateTime lastSync);
+    
+    // ==================== 통계 조회 ====================
+    
+    /**
+     * 테넌트별 리소스 수 조회
+     * 
+     * @param tenantKey 테넌트 키
+     * @return 리소스 수
+     */
+    @Query("SELECT COUNT(cr) FROM CloudResource cr " +
+           "WHERE cr.tenant.tenantKey = :tenantKey " +
+           "AND cr.isDeleted = false")
+    long countByTenantKey(@Param("tenantKey") String tenantKey);
+    
+    /**
+     * 프로바이더 타입별 리소스 수 조회
+     * 
+     * @param providerType 프로바이더 타입
+     * @return 리소스 수
+     */
+    @Query("SELECT COUNT(cr) FROM CloudResource cr " +
+           "JOIN cr.provider p " +
+           "WHERE p.providerType = :providerType " +
+           "AND cr.isDeleted = false")
+    long countByProviderType(@Param("providerType") ProviderType providerType);
 }
 

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/CloudResourceService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/CloudResourceService.java
@@ -35,7 +35,7 @@ public class CloudResourceService {
         log.info("[CloudResourceService] getResourcesByTenant - tenantKey={}", 
                 LogMaskingUtils.mask(tenantKey, 2, 2));
         
-        List<CloudResource> resources = cloudResourceRepository.findByTenantId(tenantKey);
+        List<CloudResource> resources = cloudResourceRepository.findByTenantKey(tenantKey);
         
         log.info("[CloudResourceService] getResourcesByTenant - success count={} tenantId={}", 
                 resources.size(), LogMaskingUtils.mask(tenantKey, 2, 2));

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/helper/CloudResourceManagementHelper.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/helper/CloudResourceManagementHelper.java
@@ -55,10 +55,11 @@ public class CloudResourceManagementHelper {
      * @param resourceName 리소스 이름
      * @param instanceSize 인스턴스 크기
      * @param tags         태그 맵
+     * @return 저장된 CloudResource 엔티티
      * @throws CloudResourceRegistrationException DB 저장 실패 시
      */
     @Transactional
-    public void registerVmInstance(
+    public CloudResource registerVmInstance(
             ProviderType providerType,
             String serviceKey,
             String instanceId,
@@ -80,8 +81,10 @@ public class CloudResourceManagementHelper {
                 tags
         );
 
-        cloudResourceRepository.save(cloudResource);
-        log.debug("[CloudResourceManagementHelper] VM 인스턴스 등록 완료: instanceId={}", instanceId);
+        CloudResource savedResource = cloudResourceRepository.save(cloudResource);
+        log.debug("[CloudResourceManagementHelper] VM 인스턴스 등록 완료: instanceId={}, resourceId={}", 
+                instanceId, savedResource.getResourceId());
+        return savedResource;
     }
 
     // ==================== Storage Bucket ====================

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/helper/CloudResourceManagementHelper.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/helper/CloudResourceManagementHelper.java
@@ -1,10 +1,13 @@
 package com.agenticcp.core.domain.cloud.service.helper;
 
 import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.cloud.dto.ResourceRegistrationRequest;
+import com.agenticcp.core.domain.cloud.dto.ResourceRegistrationRequest.AttributeKeys;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
 import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.ResourceType;
 import com.agenticcp.core.domain.cloud.entity.CloudService;
 import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
 import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
@@ -41,13 +44,47 @@ public class CloudResourceManagementHelper {
     private final CloudServiceRepository cloudServiceRepository;
     private final TenantRepository tenantRepository;
 
+    // ==================== 통합 리소스 등록 ====================
+
+    /**
+     * CloudResource를 통합적으로 등록합니다.
+     * 
+     * 모든 리소스 타입(VM, Storage, VPC, RDS 등)을 하나의 메서드로 등록할 수 있습니다.
+     * 도메인별 상세 속성은 ResourceRegistrationRequest의 attributes에 담아 전달합니다.
+     * 
+     * <p><b>주의:</b> 실패 시 예외를 던집니다. 
+     * 호출하는 서비스에서 보상 트랜잭션을 처리해야 합니다.</p>
+     *
+     * @param providerType 프로바이더 타입
+     * @param serviceKey   서비스 키 (EC2, S3, VirtualMachines 등)
+     * @param request      리소스 등록 요청 DTO
+     * @return 저장된 CloudResource 엔티티
+     */
+    @Transactional
+    public CloudResource registerResource(
+            ProviderType providerType,
+            String serviceKey,
+            ResourceRegistrationRequest request
+    ) {
+        CloudProvider provider = findProvider(providerType);
+        CloudService service = findServiceOrNull(providerType, serviceKey);
+        Tenant tenant = findCurrentTenant();
+
+        CloudResource cloudResource = CloudResource.create(request, provider, service, tenant);
+
+        CloudResource savedResource = cloudResourceRepository.save(cloudResource);
+        log.debug("[CloudResourceManagementHelper] 리소스 등록 완료: resourceType={}, resourceId={}", 
+                request.getResourceType(), savedResource.getResourceId());
+        return savedResource;
+    }
+
     // ==================== VM Instance ====================
 
     /**
      * VM 인스턴스를 CloudResource로 등록합니다.
      * 
-     * 주의: 실패 시 CloudResourceRegistrationException을 던집니다. 
-     * 호출하는 서비스에서 보상 트랜잭션을 처리해야 합니다.
+     * @deprecated registerResource() 메서드 사용을 권장합니다.
+     * @see #registerResource(ProviderType, String, ResourceRegistrationRequest)
      *
      * @param providerType 프로바이더 타입
      * @param serviceKey   서비스 키 (EC2, VirtualMachines 등)
@@ -56,8 +93,8 @@ public class CloudResourceManagementHelper {
      * @param instanceSize 인스턴스 크기
      * @param tags         태그 맵
      * @return 저장된 CloudResource 엔티티
-     * @throws CloudResourceRegistrationException DB 저장 실패 시
      */
+    @Deprecated
     @Transactional
     public CloudResource registerVmInstance(
             ProviderType providerType,
@@ -67,24 +104,15 @@ public class CloudResourceManagementHelper {
             String instanceSize,
             Map<String, String> tags
     ) {
-        CloudProvider provider = findProvider(providerType);
-        CloudService service = findServiceOrNull(providerType, serviceKey);
-        Tenant tenant = findCurrentTenant();
+        ResourceRegistrationRequest request = ResourceRegistrationRequest.builder()
+                .resourceId(instanceId)
+                .resourceName(resourceName)
+                .resourceType(ResourceType.INSTANCE)
+                .tags(tags)
+                .attributes(Map.of(AttributeKeys.INSTANCE_SIZE, instanceSize))
+                .build();
 
-        CloudResource cloudResource = CloudResource.createVmInstance(
-                instanceId,
-                resourceName,
-                provider,
-                service,
-                tenant,
-                instanceSize,
-                tags
-        );
-
-        CloudResource savedResource = cloudResourceRepository.save(cloudResource);
-        log.debug("[CloudResourceManagementHelper] VM 인스턴스 등록 완료: instanceId={}, resourceId={}", 
-                instanceId, savedResource.getResourceId());
-        return savedResource;
+        return registerResource(providerType, serviceKey, request);
     }
 
     // ==================== Storage Bucket ====================
@@ -92,15 +120,15 @@ public class CloudResourceManagementHelper {
     /**
      * Object Storage 버킷을 CloudResource로 등록합니다.
      * 
-     * <p><b>주의:</b> 실패 시 RuntimeException을 던집니다. 
-     * 호출하는 서비스에서 보상 트랜잭션을 처리해야 합니다.</p>
+     * @deprecated registerResource() 메서드 사용을 권장합니다.
+     * @see #registerResource(ProviderType, String, ResourceRegistrationRequest)
      *
      * @param providerType  프로바이더 타입
      * @param serviceKey    서비스 키 (S3, BlobStorage 등)
      * @param containerName 컨테이너/버킷 이름
      * @param tags          태그 맵
-     * @throws CloudResourceRegistrationException DB 저장 실패 시
      */
+    @Deprecated
     @Transactional
     public void registerStorageBucket(
             ProviderType providerType,
@@ -108,20 +136,14 @@ public class CloudResourceManagementHelper {
             String containerName,
             Map<String, String> tags
     ) {
-        CloudProvider provider = findProvider(providerType);
-        CloudService service = findServiceOrNull(providerType, serviceKey);
-        Tenant tenant = findCurrentTenant();
+        ResourceRegistrationRequest request = ResourceRegistrationRequest.builder()
+                .resourceId(containerName)
+                .resourceName(containerName)
+                .resourceType(ResourceType.BUCKET)
+                .tags(tags)
+                .build();
 
-        CloudResource cloudResource = CloudResource.createStorageBucket(
-                containerName,
-                provider,
-                service,
-                tenant,
-                tags
-        );
-
-        cloudResourceRepository.save(cloudResource);
-        log.debug("[CloudResourceManagementHelper] 스토리지 버킷 등록 완료: containerName={}", containerName);
+        registerResource(providerType, serviceKey, request);
     }
 
     // ==================== VPC ====================
@@ -129,8 +151,8 @@ public class CloudResourceManagementHelper {
     /**
      * VPC를 CloudResource로 등록합니다.
      * 
-     * 주의: 실패 시 CloudResourceRegistrationException을 던집니다. 
-     * 호출하는 서비스에서 보상 트랜잭션을 처리해야 합니다.
+     * @deprecated registerResource() 메서드 사용을 권장합니다.
+     * @see #registerResource(ProviderType, String, ResourceRegistrationRequest)
      *
      * @param providerType 프로바이더 타입
      * @param serviceKey   서비스 키 (EC2, VirtualNetwork 등)
@@ -138,8 +160,9 @@ public class CloudResourceManagementHelper {
      * @param resourceName 리소스 이름 (VPC 이름 또는 vpcId)
      * @param cidrBlock    CIDR 블록
      * @param tags         태그 맵
-     * @throws CloudResourceRegistrationException DB 저장 실패 시
+     * @throws IllegalStateException CloudService가 존재하지 않을 경우
      */
+    @Deprecated
     @Transactional
     public void registerVpc(
             ProviderType providerType,
@@ -149,22 +172,18 @@ public class CloudResourceManagementHelper {
             String cidrBlock,
             Map<String, String> tags
     ) {
-        CloudProvider provider = findProvider(providerType);
-        CloudService service = findServiceOrThrow(providerType, serviceKey);
-        Tenant tenant = findCurrentTenant();
+        // VPC는 CloudService가 필수 (기존 동작 유지)
+        findServiceOrThrow(providerType, serviceKey);
 
-        CloudResource cloudResource = CloudResource.createVpc(
-                vpcId,
-                resourceName,
-                provider,
-                service,
-                tenant,
-                cidrBlock,
-                tags
-        );
+        ResourceRegistrationRequest request = ResourceRegistrationRequest.builder()
+                .resourceId(vpcId)
+                .resourceName(resourceName)
+                .resourceType(ResourceType.NETWORK)
+                .tags(tags)
+                .attributes(Map.of(AttributeKeys.CONFIGURATION, cidrBlock))
+                .build();
 
-        cloudResourceRepository.save(cloudResource);
-        log.debug("[CloudResourceManagementHelper] VPC 등록 완료: vpcId={}", vpcId);
+        registerResource(providerType, serviceKey, request);
     }
 
     // ==================== 공통 작업 ====================

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/helper/CloudResourceManagementHelper.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/helper/CloudResourceManagementHelper.java
@@ -1,0 +1,259 @@
+package com.agenticcp.core.domain.cloud.service.helper;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
+import com.agenticcp.core.domain.cloud.entity.CloudService;
+import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import com.agenticcp.core.domain.tenant.repository.TenantRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+/**
+ * CloudResource 관리를 위한 Helper 컴포넌트
+ * 
+ * 서비스 레이어의 Repository 의존성을 줄이고, 연관 엔티티 조회 및 
+ * CloudResource 등록/삭제/상태변경 로직을 중앙화합니다.
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CloudResourceManagementHelper {
+
+    private final CloudResourceRepository cloudResourceRepository;
+    private final CloudProviderRepository cloudProviderRepository;
+    private final CloudServiceRepository cloudServiceRepository;
+    private final TenantRepository tenantRepository;
+
+    // ==================== VM Instance ====================
+
+    /**
+     * VM 인스턴스를 CloudResource로 등록합니다.
+     *
+     * @param providerType 프로바이더 타입
+     * @param serviceKey   서비스 키 (EC2, VirtualMachines 등)
+     * @param instanceId   인스턴스 ID
+     * @param resourceName 리소스 이름
+     * @param instanceSize 인스턴스 크기
+     * @param tags         태그 맵
+     */
+    @Transactional
+    public void registerVmInstance(
+            ProviderType providerType,
+            String serviceKey,
+            String instanceId,
+            String resourceName,
+            String instanceSize,
+            Map<String, String> tags
+    ) {
+        try {
+            CloudProvider provider = findProvider(providerType);
+            CloudService service = findServiceOrNull(providerType, serviceKey);
+            Tenant tenant = findCurrentTenant();
+
+            CloudResource cloudResource = CloudResource.createVmInstance(
+                    instanceId,
+                    resourceName,
+                    provider,
+                    service,
+                    tenant,
+                    instanceSize,
+                    tags
+            );
+
+            cloudResourceRepository.save(cloudResource);
+            log.debug("[CloudResourceManagementHelper] VM 인스턴스 등록 완료: instanceId={}", instanceId);
+
+        } catch (Exception e) {
+            log.warn("[CloudResourceManagementHelper] VM 인스턴스 등록 실패: instanceId={}, error={}",
+                    instanceId, e.getMessage());
+        }
+    }
+
+    // ==================== Storage Bucket ====================
+
+    /**
+     * Object Storage 버킷을 CloudResource로 등록합니다.
+     *
+     * @param providerType  프로바이더 타입
+     * @param serviceKey    서비스 키 (S3, BlobStorage 등)
+     * @param containerName 컨테이너/버킷 이름
+     * @param tags          태그 맵
+     */
+    @Transactional
+    public void registerStorageBucket(
+            ProviderType providerType,
+            String serviceKey,
+            String containerName,
+            Map<String, String> tags
+    ) {
+        try {
+            CloudProvider provider = findProvider(providerType);
+            CloudService service = findServiceOrNull(providerType, serviceKey);
+            Tenant tenant = findCurrentTenant();
+
+            CloudResource cloudResource = CloudResource.createStorageBucket(
+                    containerName,
+                    provider,
+                    service,
+                    tenant,
+                    tags
+            );
+
+            cloudResourceRepository.save(cloudResource);
+            log.debug("[CloudResourceManagementHelper] 스토리지 버킷 등록 완료: containerName={}", containerName);
+
+        } catch (Exception e) {
+            log.warn("[CloudResourceManagementHelper] 스토리지 버킷 등록 실패: containerName={}, error={}",
+                    containerName, e.getMessage());
+        }
+    }
+
+    // ==================== VPC ====================
+
+    /**
+     * VPC를 CloudResource로 등록합니다.
+     *
+     * @param providerType 프로바이더 타입
+     * @param serviceKey   서비스 키 (EC2, VirtualNetwork 등)
+     * @param vpcId        VPC ID
+     * @param resourceName 리소스 이름 (VPC 이름 또는 vpcId)
+     * @param cidrBlock    CIDR 블록
+     * @param tags         태그 맵
+     */
+    @Transactional
+    public void registerVpc(
+            ProviderType providerType,
+            String serviceKey,
+            String vpcId,
+            String resourceName,
+            String cidrBlock,
+            Map<String, String> tags
+    ) {
+        try {
+            CloudProvider provider = findProvider(providerType);
+            CloudService service = findServiceOrThrow(providerType, serviceKey);
+            Tenant tenant = findCurrentTenant();
+
+            CloudResource cloudResource = CloudResource.createVpc(
+                    vpcId,
+                    resourceName,
+                    provider,
+                    service,
+                    tenant,
+                    cidrBlock,
+                    tags
+            );
+
+            cloudResourceRepository.save(cloudResource);
+            log.debug("[CloudResourceManagementHelper] VPC 등록 완료: vpcId={}", vpcId);
+
+        } catch (Exception e) {
+            log.warn("[CloudResourceManagementHelper] VPC 등록 실패: vpcId={}, error={}",
+                    vpcId, e.getMessage());
+        }
+    }
+
+    // ==================== 공통 작업 ====================
+
+    /**
+     * 리소스의 생명주기 상태를 업데이트합니다.
+     *
+     * @param resourceId     리소스 ID
+     * @param lifecycleState 새로운 생명주기 상태
+     */
+    public void updateLifecycleState(String resourceId, LifecycleState lifecycleState) {
+        try {
+            int updatedCount = cloudResourceRepository.updateLifecycleState(
+                    resourceId, lifecycleState, LocalDateTime.now());
+
+            if (updatedCount > 0) {
+                log.debug("[CloudResourceManagementHelper] 생명주기 상태 업데이트 완료: resourceId={}, state={}",
+                        resourceId, lifecycleState);
+            } else {
+                log.debug("[CloudResourceManagementHelper] DB에 리소스가 없어 상태 업데이트 스킵: resourceId={}", resourceId);
+            }
+        } catch (Exception e) {
+            log.warn("[CloudResourceManagementHelper] 생명주기 상태 업데이트 실패: resourceId={}, error={}",
+                    resourceId, e.getMessage());
+        }
+    }
+
+    /**
+     * 리소스를 소프트 삭제합니다.
+     *
+     * @param resourceId 리소스 ID
+     */
+    public void softDeleteResource(String resourceId) {
+        try {
+            int deletedCount = cloudResourceRepository.softDeleteByResourceId(resourceId);
+
+            if (deletedCount > 0) {
+                log.debug("[CloudResourceManagementHelper] 리소스 소프트 삭제 완료: resourceId={}", resourceId);
+            } else {
+                log.debug("[CloudResourceManagementHelper] DB에 리소스가 없어 삭제 스킵: resourceId={}", resourceId);
+            }
+        } catch (Exception e) {
+            log.warn("[CloudResourceManagementHelper] 리소스 소프트 삭제 실패: resourceId={}, error={}",
+                    resourceId, e.getMessage());
+        }
+    }
+
+    // ==================== Private Helper Methods ====================
+
+    private CloudProvider findProvider(ProviderType providerType) {
+        return cloudProviderRepository.findFirstByProviderType(providerType)
+                .orElseThrow(() -> new IllegalStateException(
+                        "CloudProvider not found for type: " + providerType));
+    }
+
+    private CloudService findServiceOrNull(ProviderType providerType, String serviceKey) {
+        return cloudServiceRepository
+                .findByProviderTypeAndServiceKey(providerType, serviceKey)
+                .orElse(null);
+    }
+
+    private CloudService findServiceOrThrow(ProviderType providerType, String serviceKey) {
+        return cloudServiceRepository
+                .findByProviderTypeAndServiceKey(providerType, serviceKey)
+                .orElseThrow(() -> new IllegalStateException(
+                        "CloudService not found for provider: " + providerType + ", serviceKey: " + serviceKey));
+    }
+
+    private Tenant findCurrentTenant() {
+        String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
+        return tenantRepository.findByTenantKey(tenantKey)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Tenant not found for key: " + tenantKey));
+    }
+
+    // ==================== 유틸리티 메서드 ====================
+
+    /**
+     * 태그에서 리소스 이름 추출 (Name 태그 또는 기본값 사용)
+     *
+     * @param tags       태그 맵
+     * @param defaultName 기본 이름 (Name 태그가 없을 경우)
+     * @return 리소스 이름
+     */
+    public String extractResourceName(Map<String, String> tags, String defaultName) {
+        if (tags != null && tags.containsKey("Name")) {
+            return tags.get("Name");
+        }
+        return defaultName;
+    }
+}
+

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/helper/CloudResourceManagementHelper.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/helper/CloudResourceManagementHelper.java
@@ -2,12 +2,10 @@ package com.agenticcp.core.domain.cloud.service.helper;
 
 import com.agenticcp.core.common.context.TenantContextHolder;
 import com.agenticcp.core.domain.cloud.dto.ResourceRegistrationRequest;
-import com.agenticcp.core.domain.cloud.dto.ResourceRegistrationRequest.AttributeKeys;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
 import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
-import com.agenticcp.core.domain.cloud.entity.CloudResource.ResourceType;
 import com.agenticcp.core.domain.cloud.entity.CloudService;
 import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
 import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
@@ -78,114 +76,6 @@ public class CloudResourceManagementHelper {
         return savedResource;
     }
 
-    // ==================== VM Instance ====================
-
-    /**
-     * VM 인스턴스를 CloudResource로 등록합니다.
-     * 
-     * @deprecated registerResource() 메서드 사용을 권장합니다.
-     * @see #registerResource(ProviderType, String, ResourceRegistrationRequest)
-     *
-     * @param providerType 프로바이더 타입
-     * @param serviceKey   서비스 키 (EC2, VirtualMachines 등)
-     * @param instanceId   인스턴스 ID
-     * @param resourceName 리소스 이름
-     * @param instanceSize 인스턴스 크기
-     * @param tags         태그 맵
-     * @return 저장된 CloudResource 엔티티
-     */
-    @Deprecated
-    @Transactional
-    public CloudResource registerVmInstance(
-            ProviderType providerType,
-            String serviceKey,
-            String instanceId,
-            String resourceName,
-            String instanceSize,
-            Map<String, String> tags
-    ) {
-        ResourceRegistrationRequest request = ResourceRegistrationRequest.builder()
-                .resourceId(instanceId)
-                .resourceName(resourceName)
-                .resourceType(ResourceType.INSTANCE)
-                .tags(tags)
-                .attributes(Map.of(AttributeKeys.INSTANCE_SIZE, instanceSize))
-                .build();
-
-        return registerResource(providerType, serviceKey, request);
-    }
-
-    // ==================== Storage Bucket ====================
-
-    /**
-     * Object Storage 버킷을 CloudResource로 등록합니다.
-     * 
-     * @deprecated registerResource() 메서드 사용을 권장합니다.
-     * @see #registerResource(ProviderType, String, ResourceRegistrationRequest)
-     *
-     * @param providerType  프로바이더 타입
-     * @param serviceKey    서비스 키 (S3, BlobStorage 등)
-     * @param containerName 컨테이너/버킷 이름
-     * @param tags          태그 맵
-     */
-    @Deprecated
-    @Transactional
-    public void registerStorageBucket(
-            ProviderType providerType,
-            String serviceKey,
-            String containerName,
-            Map<String, String> tags
-    ) {
-        ResourceRegistrationRequest request = ResourceRegistrationRequest.builder()
-                .resourceId(containerName)
-                .resourceName(containerName)
-                .resourceType(ResourceType.BUCKET)
-                .tags(tags)
-                .build();
-
-        registerResource(providerType, serviceKey, request);
-    }
-
-    // ==================== VPC ====================
-
-    /**
-     * VPC를 CloudResource로 등록합니다.
-     * 
-     * @deprecated registerResource() 메서드 사용을 권장합니다.
-     * @see #registerResource(ProviderType, String, ResourceRegistrationRequest)
-     *
-     * @param providerType 프로바이더 타입
-     * @param serviceKey   서비스 키 (EC2, VirtualNetwork 등)
-     * @param vpcId        VPC ID
-     * @param resourceName 리소스 이름 (VPC 이름 또는 vpcId)
-     * @param cidrBlock    CIDR 블록
-     * @param tags         태그 맵
-     * @throws IllegalStateException CloudService가 존재하지 않을 경우
-     */
-    @Deprecated
-    @Transactional
-    public void registerVpc(
-            ProviderType providerType,
-            String serviceKey,
-            String vpcId,
-            String resourceName,
-            String cidrBlock,
-            Map<String, String> tags
-    ) {
-        // VPC는 CloudService가 필수 (기존 동작 유지)
-        findServiceOrThrow(providerType, serviceKey);
-
-        ResourceRegistrationRequest request = ResourceRegistrationRequest.builder()
-                .resourceId(vpcId)
-                .resourceName(resourceName)
-                .resourceType(ResourceType.NETWORK)
-                .tags(tags)
-                .attributes(Map.of(AttributeKeys.CONFIGURATION, cidrBlock))
-                .build();
-
-        registerResource(providerType, serviceKey, request);
-    }
-
     // ==================== 공통 작업 ====================
 
     /**
@@ -243,13 +133,6 @@ public class CloudResourceManagementHelper {
         return cloudServiceRepository
                 .findByProviderTypeAndServiceKey(providerType, serviceKey)
                 .orElse(null);
-    }
-
-    private CloudService findServiceOrThrow(ProviderType providerType, String serviceKey) {
-        return cloudServiceRepository
-                .findByProviderTypeAndServiceKey(providerType, serviceKey)
-                .orElseThrow(() -> new IllegalStateException(
-                        "CloudService not found for provider: " + providerType + ", serviceKey: " + serviceKey));
     }
 
     private Tenant findCurrentTenant() {

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/helper/CloudResourceManagementHelper.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/helper/CloudResourceManagementHelper.java
@@ -24,9 +24,12 @@ import java.util.Map;
  * 
  * 서비스 레이어의 Repository 의존성을 줄이고, 연관 엔티티 조회 및 
  * CloudResource 등록/삭제/상태변경 로직을 중앙화합니다.
+ * 
+ * 주의: 등록 메서드(registerXxx)는 실패 시 예외를 던집니다.
+ * 호출하는 서비스에서 적절한 예외 처리(보상 트랜잭션 등)를 해야 합니다.
  *
  * @author AgenticCP Team
- * @version 1.0.0
+ * @version 1.1.0
  */
 @Slf4j
 @Component
@@ -42,6 +45,9 @@ public class CloudResourceManagementHelper {
 
     /**
      * VM 인스턴스를 CloudResource로 등록합니다.
+     * 
+     * 주의: 실패 시 CloudResourceRegistrationException을 던집니다. 
+     * 호출하는 서비스에서 보상 트랜잭션을 처리해야 합니다.
      *
      * @param providerType 프로바이더 타입
      * @param serviceKey   서비스 키 (EC2, VirtualMachines 등)
@@ -49,6 +55,7 @@ public class CloudResourceManagementHelper {
      * @param resourceName 리소스 이름
      * @param instanceSize 인스턴스 크기
      * @param tags         태그 맵
+     * @throws CloudResourceRegistrationException DB 저장 실패 시
      */
     @Transactional
     public void registerVmInstance(
@@ -59,39 +66,37 @@ public class CloudResourceManagementHelper {
             String instanceSize,
             Map<String, String> tags
     ) {
-        try {
-            CloudProvider provider = findProvider(providerType);
-            CloudService service = findServiceOrNull(providerType, serviceKey);
-            Tenant tenant = findCurrentTenant();
+        CloudProvider provider = findProvider(providerType);
+        CloudService service = findServiceOrNull(providerType, serviceKey);
+        Tenant tenant = findCurrentTenant();
 
-            CloudResource cloudResource = CloudResource.createVmInstance(
-                    instanceId,
-                    resourceName,
-                    provider,
-                    service,
-                    tenant,
-                    instanceSize,
-                    tags
-            );
+        CloudResource cloudResource = CloudResource.createVmInstance(
+                instanceId,
+                resourceName,
+                provider,
+                service,
+                tenant,
+                instanceSize,
+                tags
+        );
 
-            cloudResourceRepository.save(cloudResource);
-            log.debug("[CloudResourceManagementHelper] VM 인스턴스 등록 완료: instanceId={}", instanceId);
-
-        } catch (Exception e) {
-            log.warn("[CloudResourceManagementHelper] VM 인스턴스 등록 실패: instanceId={}, error={}",
-                    instanceId, e.getMessage());
-        }
+        cloudResourceRepository.save(cloudResource);
+        log.debug("[CloudResourceManagementHelper] VM 인스턴스 등록 완료: instanceId={}", instanceId);
     }
 
     // ==================== Storage Bucket ====================
 
     /**
      * Object Storage 버킷을 CloudResource로 등록합니다.
+     * 
+     * <p><b>주의:</b> 실패 시 RuntimeException을 던집니다. 
+     * 호출하는 서비스에서 보상 트랜잭션을 처리해야 합니다.</p>
      *
      * @param providerType  프로바이더 타입
      * @param serviceKey    서비스 키 (S3, BlobStorage 등)
      * @param containerName 컨테이너/버킷 이름
      * @param tags          태그 맵
+     * @throws CloudResourceRegistrationException DB 저장 실패 시
      */
     @Transactional
     public void registerStorageBucket(
@@ -100,32 +105,29 @@ public class CloudResourceManagementHelper {
             String containerName,
             Map<String, String> tags
     ) {
-        try {
-            CloudProvider provider = findProvider(providerType);
-            CloudService service = findServiceOrNull(providerType, serviceKey);
-            Tenant tenant = findCurrentTenant();
+        CloudProvider provider = findProvider(providerType);
+        CloudService service = findServiceOrNull(providerType, serviceKey);
+        Tenant tenant = findCurrentTenant();
 
-            CloudResource cloudResource = CloudResource.createStorageBucket(
-                    containerName,
-                    provider,
-                    service,
-                    tenant,
-                    tags
-            );
+        CloudResource cloudResource = CloudResource.createStorageBucket(
+                containerName,
+                provider,
+                service,
+                tenant,
+                tags
+        );
 
-            cloudResourceRepository.save(cloudResource);
-            log.debug("[CloudResourceManagementHelper] 스토리지 버킷 등록 완료: containerName={}", containerName);
-
-        } catch (Exception e) {
-            log.warn("[CloudResourceManagementHelper] 스토리지 버킷 등록 실패: containerName={}, error={}",
-                    containerName, e.getMessage());
-        }
+        cloudResourceRepository.save(cloudResource);
+        log.debug("[CloudResourceManagementHelper] 스토리지 버킷 등록 완료: containerName={}", containerName);
     }
 
     // ==================== VPC ====================
 
     /**
      * VPC를 CloudResource로 등록합니다.
+     * 
+     * 주의: 실패 시 CloudResourceRegistrationException을 던집니다. 
+     * 호출하는 서비스에서 보상 트랜잭션을 처리해야 합니다.
      *
      * @param providerType 프로바이더 타입
      * @param serviceKey   서비스 키 (EC2, VirtualNetwork 등)
@@ -133,6 +135,7 @@ public class CloudResourceManagementHelper {
      * @param resourceName 리소스 이름 (VPC 이름 또는 vpcId)
      * @param cidrBlock    CIDR 블록
      * @param tags         태그 맵
+     * @throws CloudResourceRegistrationException DB 저장 실패 시
      */
     @Transactional
     public void registerVpc(
@@ -143,28 +146,22 @@ public class CloudResourceManagementHelper {
             String cidrBlock,
             Map<String, String> tags
     ) {
-        try {
-            CloudProvider provider = findProvider(providerType);
-            CloudService service = findServiceOrThrow(providerType, serviceKey);
-            Tenant tenant = findCurrentTenant();
+        CloudProvider provider = findProvider(providerType);
+        CloudService service = findServiceOrThrow(providerType, serviceKey);
+        Tenant tenant = findCurrentTenant();
 
-            CloudResource cloudResource = CloudResource.createVpc(
-                    vpcId,
-                    resourceName,
-                    provider,
-                    service,
-                    tenant,
-                    cidrBlock,
-                    tags
-            );
+        CloudResource cloudResource = CloudResource.createVpc(
+                vpcId,
+                resourceName,
+                provider,
+                service,
+                tenant,
+                cidrBlock,
+                tags
+        );
 
-            cloudResourceRepository.save(cloudResource);
-            log.debug("[CloudResourceManagementHelper] VPC 등록 완료: vpcId={}", vpcId);
-
-        } catch (Exception e) {
-            log.warn("[CloudResourceManagementHelper] VPC 등록 실패: vpcId={}, error={}",
-                    vpcId, e.getMessage());
-        }
+        cloudResourceRepository.save(cloudResource);
+        log.debug("[CloudResourceManagementHelper] VPC 등록 완료: vpcId={}", vpcId);
     }
 
     // ==================== 공통 작업 ====================

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseService.java
@@ -9,17 +9,12 @@ import com.agenticcp.core.domain.cloud.dto.UpdateObjectStorageContainerRequest;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
-import com.agenticcp.core.domain.cloud.entity.CloudService;
 import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
 import com.agenticcp.core.domain.cloud.port.model.storage.CreateObjectStorageContainerCommand;
 import com.agenticcp.core.domain.cloud.port.model.storage.UpdateObjectStorageContainerCommand;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
-import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
-import com.agenticcp.core.domain.tenant.entity.Tenant;
-import com.agenticcp.core.domain.tenant.repository.TenantRepository;
+import com.agenticcp.core.domain.cloud.service.helper.CloudResourceManagementHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -45,12 +40,7 @@ public class ObjectStorageUseCaseService {
     private final ObjectStoragePortRouter router;
     private final CapabilityGuard capabilityGuard;
     private final AccountCredentialManagementPort accountCredentialManagementPort;
-    
-    // DB 저장을 위한 Repository
-    private final CloudResourceRepository cloudResourceRepository;
-    private final CloudProviderRepository cloudProviderRepository;
-    private final CloudServiceRepository cloudServiceRepository;
-    private final TenantRepository tenantRepository;
+    private final CloudResourceManagementHelper resourceHelper;
 
     private static final String RESOURCE_TYPE = "BUCKET";
 
@@ -96,7 +86,12 @@ public class ObjectStorageUseCaseService {
         CloudResource container = router.management(providerType).createContainer(command);
 
         // DB에 CloudResource 저장
-        saveCloudResource(request.getContainerName(), request, providerType);
+        resourceHelper.registerStorageBucket(
+                providerType,
+                getServiceKeyForProvider(providerType),
+                request.getContainerName(),
+                request.getTags()
+        );
 
         log.info("[ObjectStorageUseCaseService] createContainer - success provider={}, containerName={}",
                 providerType, request.getContainerName());
@@ -177,7 +172,7 @@ public class ObjectStorageUseCaseService {
         router.management(providerType).deleteContainer(session, containerName);
 
         // DB 소프트 삭제
-        softDeleteResourceIfExists(containerName);
+        resourceHelper.softDeleteResource(containerName);
 
         log.info("[ObjectStorageUseCaseService] deleteContainer - success provider={}, containerName={}",
                 providerType, containerName);
@@ -213,7 +208,7 @@ public class ObjectStorageUseCaseService {
         router.management(providerType).forceDeleteContainer(containerName, session);
 
         // DB 소프트 삭제
-        softDeleteResourceIfExists(containerName);
+        resourceHelper.softDeleteResource(containerName);
 
         log.info("[ObjectStorageUseCaseService] forceDeleteContainer - success provider={}, containerName={}",
                 providerType, containerName);
@@ -296,73 +291,7 @@ public class ObjectStorageUseCaseService {
         }
     }
 
-    // ==================== DB 저장 헬퍼 메서드 ====================
-
-    /**
-     * CSP에서 생성된 Object Storage Container 정보를 CloudResource 엔티티로 저장합니다.
-     *
-     * @param containerName 생성된 컨테이너 이름 (S3 버킷명, Azure Blob 컨테이너명 등)
-     * @param request 생성 요청 정보
-     * @param providerType 프로바이더 타입
-     */
-    private void saveCloudResource(String containerName, CreateObjectStorageContainerRequest request, 
-                                   ProviderType providerType) {
-        try {
-            String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
-            
-            // Provider 조회
-            CloudProvider provider = cloudProviderRepository.findFirstByProviderType(providerType)
-                    .orElseThrow(() -> new IllegalStateException(
-                            "CloudProvider not found for type: " + providerType));
-            
-            // Service 조회 (Storage용 서비스 - S3, BlobStorage, CloudStorage 등)
-            CloudService cloudService = cloudServiceRepository
-                    .findByProviderTypeAndServiceKey(providerType, getServiceKeyForProvider(providerType))
-                    .orElse(null);
-            
-            // Tenant 조회
-            Tenant tenant = tenantRepository.findByTenantKey(tenantKey)
-                    .orElseThrow(() -> new IllegalStateException(
-                            "Tenant not found for key: " + tenantKey));
-            
-            // Factory Method를 사용한 CloudResource 엔티티 생성
-            CloudResource cloudResource = CloudResource.createStorageBucket(
-                    containerName,
-                    provider,
-                    cloudService,
-                    tenant,
-                    request.getTags()
-            );
-            
-            cloudResourceRepository.save(cloudResource);
-            log.debug("[ObjectStorageUseCaseService] CloudResource 저장 완료: containerName={}", containerName);
-            
-        } catch (Exception e) {
-            // DB 저장 실패해도 CSP 생성은 완료되었으므로 경고 로그만 출력
-            log.warn("[ObjectStorageUseCaseService] CloudResource 저장 실패 (CSP 생성은 완료됨): containerName={}, error={}", 
-                    containerName, e.getMessage());
-        }
-    }
-
-    /**
-     * 리소스가 존재하면 소프트 삭제 처리합니다.
-     *
-     * @param resourceId 리소스 ID (containerName)
-     */
-    private void softDeleteResourceIfExists(String resourceId) {
-        try {
-            int deletedCount = cloudResourceRepository.softDeleteByResourceId(resourceId);
-            
-            if (deletedCount > 0) {
-                log.debug("[ObjectStorageUseCaseService] 리소스 소프트 삭제 완료: resourceId={}", resourceId);
-            } else {
-                log.debug("[ObjectStorageUseCaseService] DB에 리소스가 없어 삭제 스킵: resourceId={}", resourceId);
-            }
-        } catch (Exception e) {
-            log.warn("[ObjectStorageUseCaseService] 리소스 소프트 삭제 실패: resourceId={}, error={}", 
-                    resourceId, e.getMessage());
-        }
-    }
+    // ==================== Private Helper Methods ====================
 
     /**
      * 프로바이더 타입에 따른 서비스 키 반환

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseService.java
@@ -47,9 +47,13 @@ public class ObjectStorageUseCaseService {
     /**
      * Object Storage Container를 생성합니다.
      * CSP에서 컨테이너 생성 후 CloudResource 엔티티를 DB에 저장합니다.
+     * 
+     * 보상 트랜잭션: DB 저장 실패 시 CSP에 생성된 컨테이너를 삭제하여
+     * 데이터 정합성(Ghost Resource 방지)을 보장합니다.
      *
      * @param request 생성 요청 정보
      * @return 생성된 Object Storage Container 정보
+     * @throws BusinessException DB 저장 실패 및 보상 트랜잭션 실행 시
      */
     @Transactional
     public CloudResource createContainer(CreateObjectStorageContainerRequest request) {
@@ -85,18 +89,58 @@ public class ObjectStorageUseCaseService {
         // CSP에서 Container 생성
         CloudResource container = router.management(providerType).createContainer(command);
 
-        // DB에 CloudResource 저장
-        resourceHelper.registerStorageBucket(
-                providerType,
-                getServiceKeyForProvider(providerType),
-                request.getContainerName(),
-                request.getTags()
-        );
+        // DB에 CloudResource 저장 (실패 시 보상 트랜잭션 실행)
+        try {
+            resourceHelper.registerStorageBucket(
+                    providerType,
+                    serviceKey,
+                    request.getContainerName(),
+                    request.getTags()
+            );
+        } catch (Exception e) {
+            log.error("[ObjectStorageUseCaseService] DB 저장 실패, 보상 트랜잭션 실행: containerName={}, error={}",
+                    request.getContainerName(), e.getMessage());
+            
+            // 보상 트랜잭션: CSP에 생성된 컨테이너 삭제
+            executeCompensatingTransaction(providerType, session, request.getContainerName());
+            
+            throw new BusinessException(
+                    CloudErrorCode.RESOURCE_CREATION_FAILED,
+                    "컨테이너 생성 후 DB 저장 실패로 인해 롤백되었습니다: " + request.getContainerName()
+            );
+        }
 
         log.info("[ObjectStorageUseCaseService] createContainer - success provider={}, containerName={}",
                 providerType, request.getContainerName());
 
         return container;
+    }
+
+    /**
+     * 보상 트랜잭션: CSP에 생성된 컨테이너를 삭제합니다.
+     * Ghost Resource 방지를 위해 DB 저장 실패 시 호출됩니다.
+     *
+     * @param providerType  프로바이더 타입
+     * @param session       세션 자격증명
+     * @param containerName 삭제할 컨테이너 이름
+     */
+    private void executeCompensatingTransaction(
+            ProviderType providerType,
+            CloudSessionCredential session,
+            String containerName
+    ) {
+        try {
+            log.warn("[ObjectStorageUseCaseService] 보상 트랜잭션 실행: CSP 컨테이너 삭제 시도 - containerName={}", 
+                    containerName);
+            router.management(providerType).deleteContainer(session, containerName);
+            log.info("[ObjectStorageUseCaseService] 보상 트랜잭션 완료: CSP 컨테이너 삭제 성공 - containerName={}", 
+                    containerName);
+        } catch (Exception compensationError) {
+            // 보상 트랜잭션도 실패한 경우 - Ghost Resource 발생
+            // 이 경우 별도의 모니터링/알림 시스템이나 배치 동기화로 처리 필요
+            log.error("[ObjectStorageUseCaseService] 보상 트랜잭션 실패: Ghost Resource 발생 가능 - containerName={}, error={}",
+                    containerName, compensationError.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseService.java
@@ -5,6 +5,7 @@ import com.agenticcp.core.common.exception.BusinessException;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.CreateObjectStorageContainerRequest;
 import com.agenticcp.core.domain.cloud.dto.ObjectStorageContainerQueryRequest;
+import com.agenticcp.core.domain.cloud.dto.ResourceRegistrationRequest;
 import com.agenticcp.core.domain.cloud.dto.UpdateObjectStorageContainerRequest;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
@@ -21,6 +22,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -91,11 +93,17 @@ public class ObjectStorageUseCaseService {
 
         // DB에 CloudResource 저장 (실패 시 보상 트랜잭션 실행)
         try {
-            resourceHelper.registerStorageBucket(
+            ResourceRegistrationRequest registrationRequest = ResourceRegistrationRequest.builder()
+                    .resourceId(request.getContainerName())
+                    .resourceName(request.getContainerName())
+                    .resourceType(CloudResource.ResourceType.BUCKET)
+                    .tags(request.getTags())
+                    .build();
+            
+            resourceHelper.registerResource(
                     providerType,
                     serviceKey,
-                    request.getContainerName(),
-                    request.getTags()
+                    registrationRequest
             );
         } catch (Exception e) {
             log.error("[ObjectStorageUseCaseService] DB 저장 실패, 보상 트랜잭션 실행: containerName={}, error={}",

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseService.java
@@ -1,23 +1,38 @@
 package com.agenticcp.core.domain.cloud.service.storage;
 
 import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.common.enums.Status;
 import com.agenticcp.core.common.exception.BusinessException;
+import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.CreateObjectStorageContainerRequest;
 import com.agenticcp.core.domain.cloud.dto.ObjectStorageContainerQueryRequest;
 import com.agenticcp.core.domain.cloud.dto.UpdateObjectStorageContainerRequest;
-import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
-import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
-import com.agenticcp.core.domain.cloud.port.model.storage.*;
-import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.ResourceType;
+import com.agenticcp.core.domain.cloud.entity.CloudService;
 import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import com.agenticcp.core.domain.cloud.port.model.storage.CreateObjectStorageContainerCommand;
+import com.agenticcp.core.domain.cloud.port.model.storage.UpdateObjectStorageContainerCommand;
+import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
+import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import com.agenticcp.core.domain.tenant.repository.TenantRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -37,9 +52,17 @@ public class ObjectStorageUseCaseService {
     private final ObjectStoragePortRouter router;
     private final CapabilityGuard capabilityGuard;
     private final AccountCredentialManagementPort accountCredentialManagementPort;
+    
+    // DB 저장을 위한 Repository
+    private final CloudResourceRepository cloudResourceRepository;
+    private final CloudProviderRepository cloudProviderRepository;
+    private final CloudServiceRepository cloudServiceRepository;
+    private final TenantRepository tenantRepository;
+    private final ObjectMapper objectMapper;
 
     /**
      * Object Storage Container를 생성합니다.
+     * CSP에서 컨테이너 생성 후 CloudResource 엔티티를 DB에 저장합니다.
      *
      * @param request 생성 요청 정보
      * @return 생성된 Object Storage Container 정보
@@ -73,7 +96,11 @@ public class ObjectStorageUseCaseService {
                 .session(session)
                 .build();
 
+        // CSP에서 Container 생성
         CloudResource container = router.management(providerType).createContainer(command);
+
+        // DB에 CloudResource 저장
+        saveCloudResource(request.getContainerName(), request, providerType);
 
         log.info("[ObjectStorageUseCaseService] createContainer - success provider={}, containerName={}",
                 providerType, request.getContainerName());
@@ -124,8 +151,10 @@ public class ObjectStorageUseCaseService {
 
     /**
      * Object Storage Container를 삭제합니다.
+     * CSP에서 컨테이너 삭제 후 DB에서 소프트 삭제 처리합니다.
      *
      * @param providerType 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
      * @param containerName Container 이름
      */
     @Transactional
@@ -144,7 +173,11 @@ public class ObjectStorageUseCaseService {
         log.debug("[ObjectStorageUseCaseService] deleteContainer - session acquired, expiresAt={}",
                 session.getExpiresAt());
 
+        // CSP에서 Container 삭제
         router.management(providerType).deleteContainer(session, containerName);
+
+        // DB 소프트 삭제
+        softDeleteResourceIfExists(containerName);
 
         log.info("[ObjectStorageUseCaseService] deleteContainer - success provider={}, containerName={}",
                 providerType, containerName);
@@ -152,8 +185,10 @@ public class ObjectStorageUseCaseService {
 
     /**
      * Object Storage Container를 강제 삭제합니다 (내용물 포함).
+     * CSP에서 컨테이너 강제 삭제 후 DB에서 소프트 삭제 처리합니다.
      *
      * @param providerType 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
      * @param containerName Container 이름
      */
     @Transactional
@@ -172,7 +207,11 @@ public class ObjectStorageUseCaseService {
         log.debug("[ObjectStorageUseCaseService] forceDeleteContainer - session acquired, expiresAt={}",
                 session.getExpiresAt());
 
+        // CSP에서 Container 강제 삭제
         router.management(providerType).forceDeleteContainer(containerName, session);
+
+        // DB 소프트 삭제
+        softDeleteResourceIfExists(containerName);
 
         log.info("[ObjectStorageUseCaseService] forceDeleteContainer - success provider={}, containerName={}",
                 providerType, containerName);
@@ -252,6 +291,110 @@ public class ObjectStorageUseCaseService {
                     CloudErrorCode.ACCOUNT_SCOPE_REQUIRED,
                     "AccountScope가 필요합니다."
             );
+        }
+    }
+
+    // ==================== DB 저장 헬퍼 메서드 ====================
+
+    /**
+     * CSP에서 생성된 Object Storage Container 정보를 CloudResource 엔티티로 저장합니다.
+     *
+     * @param containerName 생성된 컨테이너 이름 (S3 버킷명, Azure Blob 컨테이너명 등)
+     * @param request 생성 요청 정보
+     * @param providerType 프로바이더 타입
+     */
+    private void saveCloudResource(String containerName, CreateObjectStorageContainerRequest request, 
+                                   ProviderType providerType) {
+        try {
+            String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
+            
+            // Provider 조회
+            CloudProvider provider = cloudProviderRepository.findFirstByProviderType(providerType)
+                    .orElseThrow(() -> new IllegalStateException(
+                            "CloudProvider not found for type: " + providerType));
+            
+            // Service 조회 (Storage용 서비스 - S3, BlobStorage, CloudStorage 등)
+            CloudService cloudService = cloudServiceRepository
+                    .findByProviderTypeAndServiceKey(providerType, getServiceKeyForProvider(providerType))
+                    .orElse(null);
+            
+            // Tenant 조회
+            Tenant tenant = tenantRepository.findByTenantKey(tenantKey)
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Tenant not found for key: " + tenantKey));
+            
+            // CloudResource 엔티티 생성
+            CloudResource cloudResource = CloudResource.builder()
+                    .resourceId(containerName)
+                    .resourceName(containerName)
+                    .displayName(containerName)
+                    .provider(provider)
+                    .service(cloudService)
+                    .tenant(tenant)
+                    .status(Status.ACTIVE)
+                    .resourceType(ResourceType.BUCKET)
+                    .lifecycleState(LifecycleState.RUNNING)
+                    .tags(serializeTagsToJson(request.getTags()))
+                    .createdInCloud(LocalDateTime.now())
+                    .lastModifiedInCloud(LocalDateTime.now())
+                    .lastSync(LocalDateTime.now())
+                    .build();
+            
+            cloudResourceRepository.save(cloudResource);
+            log.debug("[ObjectStorageUseCaseService] CloudResource 저장 완료: containerName={}", containerName);
+            
+        } catch (Exception e) {
+            // DB 저장 실패해도 CSP 생성은 완료되었으므로 경고 로그만 출력
+            log.warn("[ObjectStorageUseCaseService] CloudResource 저장 실패 (CSP 생성은 완료됨): containerName={}, error={}", 
+                    containerName, e.getMessage());
+        }
+    }
+
+    /**
+     * 리소스가 존재하면 소프트 삭제 처리합니다.
+     *
+     * @param resourceId 리소스 ID (containerName)
+     */
+    private void softDeleteResourceIfExists(String resourceId) {
+        try {
+            int deletedCount = cloudResourceRepository.softDeleteByResourceId(resourceId);
+            
+            if (deletedCount > 0) {
+                log.debug("[ObjectStorageUseCaseService] 리소스 소프트 삭제 완료: resourceId={}", resourceId);
+            } else {
+                log.debug("[ObjectStorageUseCaseService] DB에 리소스가 없어 삭제 스킵: resourceId={}", resourceId);
+            }
+        } catch (Exception e) {
+            log.warn("[ObjectStorageUseCaseService] 리소스 소프트 삭제 실패: resourceId={}, error={}", 
+                    resourceId, e.getMessage());
+        }
+    }
+
+    /**
+     * 프로바이더 타입에 따른 서비스 키 반환
+     * AWS: S3, Azure: BlobStorage, GCP: CloudStorage 등
+     */
+    private String getServiceKeyForProvider(ProviderType providerType) {
+        return switch (providerType) {
+            case AWS -> "S3";
+            case AZURE -> "BlobStorage";
+            case GCP -> "CloudStorage";
+            default -> "ObjectStorage";
+        };
+    }
+
+    /**
+     * 태그 맵을 JSON 문자열로 직렬화
+     */
+    private String serializeTagsToJson(Map<String, String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(tags);
+        } catch (JsonProcessingException e) {
+            log.warn("[ObjectStorageUseCaseService] 태그 JSON 직렬화 실패: {}", e.getMessage());
+            return null;
         }
     }
 }

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseService.java
@@ -20,15 +20,12 @@ import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
 import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
 import com.agenticcp.core.domain.tenant.entity.Tenant;
 import com.agenticcp.core.domain.tenant.repository.TenantRepository;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -54,7 +51,6 @@ public class ObjectStorageUseCaseService {
     private final CloudProviderRepository cloudProviderRepository;
     private final CloudServiceRepository cloudServiceRepository;
     private final TenantRepository tenantRepository;
-    private final ObjectMapper objectMapper;
 
     private static final String RESOURCE_TYPE = "BUCKET";
 
@@ -335,7 +331,7 @@ public class ObjectStorageUseCaseService {
                     provider,
                     cloudService,
                     tenant,
-                    serializeTagsToJson(request.getTags())
+                    request.getTags()
             );
             
             cloudResourceRepository.save(cloudResource);
@@ -379,20 +375,5 @@ public class ObjectStorageUseCaseService {
             case GCP -> "CloudStorage";
             default -> "ObjectStorage";
         };
-    }
-
-    /**
-     * 태그 맵을 JSON 문자열로 직렬화
-     */
-    private String serializeTagsToJson(Map<String, String> tags) {
-        if (tags == null || tags.isEmpty()) {
-            return null;
-        }
-        try {
-            return objectMapper.writeValueAsString(tags);
-        } catch (JsonProcessingException e) {
-            log.warn("[ObjectStorageUseCaseService] 태그 JSON 직렬화 실패: {}", e.getMessage());
-            return null;
-        }
     }
 }

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseService.java
@@ -1,7 +1,6 @@
 package com.agenticcp.core.domain.cloud.service.storage;
 
 import com.agenticcp.core.common.context.TenantContextHolder;
-import com.agenticcp.core.common.enums.Status;
 import com.agenticcp.core.common.exception.BusinessException;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.CreateObjectStorageContainerRequest;
@@ -10,8 +9,6 @@ import com.agenticcp.core.domain.cloud.dto.UpdateObjectStorageContainerRequest;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
-import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
-import com.agenticcp.core.domain.cloud.entity.CloudResource.ResourceType;
 import com.agenticcp.core.domain.cloud.entity.CloudService;
 import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
@@ -31,7 +28,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Objects;
 
@@ -333,22 +329,14 @@ public class ObjectStorageUseCaseService {
                     .orElseThrow(() -> new IllegalStateException(
                             "Tenant not found for key: " + tenantKey));
             
-            // CloudResource 엔티티 생성
-            CloudResource cloudResource = CloudResource.builder()
-                    .resourceId(containerName)
-                    .resourceName(containerName)
-                    .displayName(containerName)
-                    .provider(provider)
-                    .service(cloudService)
-                    .tenant(tenant)
-                    .status(Status.ACTIVE)
-                    .resourceType(ResourceType.BUCKET)
-                    .lifecycleState(LifecycleState.RUNNING)
-                    .tags(serializeTagsToJson(request.getTags()))
-                    .createdInCloud(LocalDateTime.now())
-                    .lastModifiedInCloud(LocalDateTime.now())
-                    .lastSync(LocalDateTime.now())
-                    .build();
+            // Factory Method를 사용한 CloudResource 엔티티 생성
+            CloudResource cloudResource = CloudResource.createStorageBucket(
+                    containerName,
+                    provider,
+                    cloudService,
+                    tenant,
+                    serializeTagsToJson(request.getTags())
+            );
             
             cloudResourceRepository.save(cloudResource);
             log.debug("[ObjectStorageUseCaseService] CloudResource 저장 완료: containerName={}", containerName);

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseService.java
@@ -60,6 +60,8 @@ public class ObjectStorageUseCaseService {
     private final TenantRepository tenantRepository;
     private final ObjectMapper objectMapper;
 
+    private static final String RESOURCE_TYPE = "BUCKET";
+
     /**
      * Object Storage Container를 생성합니다.
      * CSP에서 컨테이너 생성 후 CloudResource 엔티티를 DB에 저장합니다.
@@ -76,7 +78,9 @@ public class ObjectStorageUseCaseService {
         log.info("[ObjectStorageUseCaseService] createContainer - provider={}, accountScope={}, region={}, containerName={}",
                 providerType, accountScope, request.getRegion(), request.getContainerName());
 
-        capabilityGuard.ensureSupported(providerType, "OBJECT_STORAGE", "CONTAINER", CapabilityGuard.Operation.TAGGING);
+        // getServiceKeyForProvider를 사용하여 일관성 유지
+        String serviceKey = getServiceKeyForProvider(providerType);
+        capabilityGuard.ensureSupported(providerType, serviceKey, RESOURCE_TYPE, CapabilityGuard.Operation.TAGGING);
 
         String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
         CloudSessionCredential session = accountCredentialManagementPort.getSession(
@@ -123,7 +127,9 @@ public class ObjectStorageUseCaseService {
         log.info("[ObjectStorageUseCaseService] updateContainer - provider={}, accountScope={}, containerName={}",
                 providerType, accountScope, request.getContainerName());
 
-        capabilityGuard.ensureSupported(providerType, "OBJECT_STORAGE", "CONTAINER", CapabilityGuard.Operation.TAGGING);
+        // getServiceKeyForProvider를 사용하여 일관성 유지
+        String serviceKey = getServiceKeyForProvider(providerType);
+        capabilityGuard.ensureSupported(providerType, serviceKey, RESOURCE_TYPE, CapabilityGuard.Operation.TAGGING);
 
         String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
         CloudSessionCredential session = accountCredentialManagementPort.getSession(
@@ -164,7 +170,9 @@ public class ObjectStorageUseCaseService {
         log.info("[ObjectStorageUseCaseService] deleteContainer - provider={}, accountScope={}, containerName={}",
                 providerType, accountScope, containerName);
 
-        capabilityGuard.ensureSupported(providerType, "OBJECT_STORAGE", "CONTAINER", CapabilityGuard.Operation.TERMINATE);
+        // getServiceKeyForProvider를 사용하여 일관성 유지
+        String serviceKey = getServiceKeyForProvider(providerType);
+        capabilityGuard.ensureSupported(providerType, serviceKey, RESOURCE_TYPE, CapabilityGuard.Operation.TERMINATE);
 
         String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
         CloudSessionCredential session = accountCredentialManagementPort.getSession(
@@ -198,7 +206,9 @@ public class ObjectStorageUseCaseService {
         log.info("[ObjectStorageUseCaseService] forceDeleteContainer - provider={}, accountScope={}, containerName={}",
                 providerType, accountScope, containerName);
 
-        capabilityGuard.ensureSupported(providerType, "OBJECT_STORAGE", "CONTAINER", CapabilityGuard.Operation.TERMINATE);
+        // getServiceKeyForProvider를 사용하여 일관성 유지
+        String serviceKey = getServiceKeyForProvider(providerType);
+        capabilityGuard.ensureSupported(providerType, serviceKey, RESOURCE_TYPE, CapabilityGuard.Operation.TERMINATE);
 
         String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
         CloudSessionCredential session = accountCredentialManagementPort.getSession(

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseService.java
@@ -5,9 +5,11 @@ import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.VmCreateRequest;
 import com.agenticcp.core.domain.cloud.dto.VmDeleteRequest;
 import com.agenticcp.core.domain.cloud.dto.VmUpdateRequest;
+import com.agenticcp.core.common.exception.BusinessException;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
 import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
+import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
 import com.agenticcp.core.domain.cloud.port.model.VmQuery;
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
 import com.agenticcp.core.domain.cloud.port.model.vm.VmCreateCommand;
@@ -111,9 +113,13 @@ public class VmUseCaseService {
     /**
      * 새로운 VM 인스턴스를 생성합니다.
      * CSP에서 인스턴스 생성 후 CloudResource 엔티티를 DB에 저장합니다.
+     * 
+     * 보상 트랜잭션: DB 저장 실패 시 CSP에 생성된 인스턴스를 종료(terminate)하여
+     * 데이터 정합성(Ghost Resource 방지)을 보장합니다.
      *
      * @param request 생성 요청 정보 (providerType, accountScope 포함)
      * @return 생성된 인스턴스 ID
+     * @throws BusinessException DB 저장 실패 및 보상 트랜잭션 실행 시
      */
     @Transactional
     public String createInstance(VmCreateRequest request) {
@@ -132,19 +138,57 @@ public class VmUseCaseService {
         String instanceId = vmPortRouter.lifecycle(providerType)
             .createInstance(toCreateCommand(request, session));
 
-        // DB에 CloudResource 저장
-        String resourceName = resourceHelper.extractResourceName(request.getTags(), instanceId);
-        resourceHelper.registerVmInstance(
-                providerType,
-                getServiceKeyForProvider(providerType),
-                instanceId,
-                resourceName,
-                request.getInstanceSize(),
-                request.getTags()
-        );
+        // DB에 CloudResource 저장 (실패 시 보상 트랜잭션 실행)
+        try {
+            String resourceName = resourceHelper.extractResourceName(request.getTags(), instanceId);
+            resourceHelper.registerVmInstance(
+                    providerType,
+                    getServiceKeyForProvider(providerType),
+                    instanceId,
+                    resourceName,
+                    request.getInstanceSize(),
+                    request.getTags()
+            );
+        } catch (Exception e) {
+            log.error("[VmUseCaseService] DB 저장 실패, 보상 트랜잭션 실행: instanceId={}, error={}",
+                    instanceId, e.getMessage());
+            
+            // 보상 트랜잭션: CSP에 생성된 인스턴스 종료
+            executeCompensatingTransaction(providerType, session, instanceId);
+            
+            throw new BusinessException(
+                    CloudErrorCode.RESOURCE_CREATION_FAILED,
+                    "VM 인스턴스 생성 후 DB 저장 실패로 인해 롤백되었습니다: " + instanceId
+            );
+        }
 
         log.info("VM 인스턴스 생성 완료: provider={}, instanceId={}", providerType, instanceId);
         return instanceId;
+    }
+
+    /**
+     * 보상 트랜잭션: CSP에 생성된 VM 인스턴스를 종료합니다.
+     * Ghost Resource 방지를 위해 DB 저장 실패 시 호출됩니다.
+     *
+     * @param providerType 프로바이더 타입
+     * @param session      세션 자격증명
+     * @param instanceId   종료할 인스턴스 ID
+     */
+    private void executeCompensatingTransaction(
+            ProviderType providerType,
+            CloudSessionCredential session,
+            String instanceId
+    ) {
+        try {
+            log.warn("[VmUseCaseService] 보상 트랜잭션 실행: CSP 인스턴스 종료 시도 - instanceId={}", instanceId);
+            vmPortRouter.lifecycle(providerType).terminateInstance(instanceId, session);
+            log.info("[VmUseCaseService] 보상 트랜잭션 완료: CSP 인스턴스 종료 성공 - instanceId={}", instanceId);
+        } catch (Exception compensationError) {
+            // 보상 트랜잭션도 실패한 경우 - Ghost Resource 발생
+            // 이 경우 별도의 모니터링/알림 시스템이나 배치 동기화로 처리 필요
+            log.error("[VmUseCaseService] 보상 트랜잭션 실패: Ghost Resource 발생 가능 - instanceId={}, error={}",
+                    instanceId, compensationError.getMessage());
+        }
     }
 
     // ==================== 인스턴스 생명주기 관리 ====================

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseService.java
@@ -5,29 +5,22 @@ import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.VmCreateRequest;
 import com.agenticcp.core.domain.cloud.dto.VmDeleteRequest;
 import com.agenticcp.core.domain.cloud.dto.VmUpdateRequest;
-import com.agenticcp.core.domain.cloud.entity.CloudProvider;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
 import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
-import com.agenticcp.core.domain.cloud.entity.CloudService;
 import com.agenticcp.core.domain.cloud.port.model.VmQuery;
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
 import com.agenticcp.core.domain.cloud.port.model.vm.VmCreateCommand;
 import com.agenticcp.core.domain.cloud.port.model.vm.VmDeleteCommand;
 import com.agenticcp.core.domain.cloud.port.model.vm.VmUpdateCommand;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
-import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
-import com.agenticcp.core.domain.tenant.entity.Tenant;
-import com.agenticcp.core.domain.tenant.repository.TenantRepository;
+import com.agenticcp.core.domain.cloud.service.helper.CloudResourceManagementHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
 
@@ -55,12 +48,7 @@ public class VmUseCaseService {
     private final VmPortRouter vmPortRouter;
     private final CapabilityGuard capabilityGuard;
     private final AccountCredentialManagementPort credentialProviderPort;
-    
-    // DB 저장을 위한 Repository
-    private final CloudResourceRepository cloudResourceRepository;
-    private final CloudProviderRepository cloudProviderRepository;
-    private final CloudServiceRepository cloudServiceRepository;
-    private final TenantRepository tenantRepository;
+    private final CloudResourceManagementHelper resourceHelper;
 
     /**
      * 세션 자격증명을 획득합니다.
@@ -145,7 +133,15 @@ public class VmUseCaseService {
             .createInstance(toCreateCommand(request, session));
 
         // DB에 CloudResource 저장
-        saveCloudResource(instanceId, request, providerType);
+        String resourceName = resourceHelper.extractResourceName(request.getTags(), instanceId);
+        resourceHelper.registerVmInstance(
+                providerType,
+                getServiceKeyForProvider(providerType),
+                instanceId,
+                resourceName,
+                request.getInstanceSize(),
+                request.getTags()
+        );
 
         log.info("VM 인스턴스 생성 완료: provider={}, instanceId={}", providerType, instanceId);
         return instanceId;
@@ -175,7 +171,7 @@ public class VmUseCaseService {
         vmPortRouter.lifecycle(providerType).startInstance(instanceId, session);
 
         // DB 상태 업데이트: RUNNING
-        updateLifecycleStateIfExists(instanceId, LifecycleState.RUNNING);
+        resourceHelper.updateLifecycleState(instanceId, LifecycleState.RUNNING);
 
         log.info("VM 인스턴스 시작 완료: provider={}, instanceId={}", providerType, instanceId);
     }
@@ -202,7 +198,7 @@ public class VmUseCaseService {
         vmPortRouter.lifecycle(providerType).stopInstance(instanceId, session);
 
         // DB 상태 업데이트: STOPPED
-        updateLifecycleStateIfExists(instanceId, LifecycleState.STOPPED);
+        resourceHelper.updateLifecycleState(instanceId, LifecycleState.STOPPED);
 
         log.info("VM 인스턴스 중지 완료: provider={}, instanceId={}", providerType, instanceId);
     }
@@ -230,7 +226,7 @@ public class VmUseCaseService {
         vmPortRouter.lifecycle(providerType).rebootInstance(instanceId, session);
 
         // DB 상태 업데이트: 재부팅 후 RUNNING 상태 유지 (lastModifiedInCloud만 업데이트)
-        updateLifecycleStateIfExists(instanceId, LifecycleState.RUNNING);
+        resourceHelper.updateLifecycleState(instanceId, LifecycleState.RUNNING);
 
         log.info("VM 인스턴스 재부팅 완료: provider={}, instanceId={}", providerType, instanceId);
     }
@@ -257,7 +253,7 @@ public class VmUseCaseService {
         vmPortRouter.lifecycle(providerType).terminateInstance(instanceId, session);
 
         // DB 상태 업데이트: TERMINATED
-        updateLifecycleStateIfExists(instanceId, LifecycleState.TERMINATED);
+        resourceHelper.updateLifecycleState(instanceId, LifecycleState.TERMINATED);
 
         log.info("VM 인스턴스 종료 완료: provider={}, instanceId={}", providerType, instanceId);
     }
@@ -286,7 +282,7 @@ public class VmUseCaseService {
         vmPortRouter.lifecycle(providerType).deleteInstance(toDeleteCommand(request, session));
 
         // DB 소프트 삭제
-        softDeleteResourceIfExists(instanceId);
+        resourceHelper.softDeleteResource(instanceId);
 
         log.info("VM 인스턴스 삭제 완료: provider={}, instanceId={}", providerType, instanceId);
     }
@@ -476,100 +472,7 @@ public class VmUseCaseService {
                 .build();
     }
 
-    // ==================== DB 저장 헬퍼 메서드 ====================
-
-    /**
-     * CSP에서 생성된 VM 인스턴스 정보를 CloudResource 엔티티로 저장합니다.
-     *
-     * @param instanceId 생성된 인스턴스 ID
-     * @param request 생성 요청 정보
-     * @param providerType 프로바이더 타입
-     */
-    private void saveCloudResource(String instanceId, VmCreateRequest request, ProviderType providerType) {
-        try {
-            String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
-            
-            // Provider 조회
-            CloudProvider provider = cloudProviderRepository.findFirstByProviderType(providerType)
-                    .orElseThrow(() -> new IllegalStateException(
-                            "CloudProvider not found for type: " + providerType));
-            
-            // Service 조회 (VM용 서비스 - EC2, Compute Engine 등)
-            CloudService cloudService = cloudServiceRepository
-                    .findByProviderTypeAndServiceKey(providerType, getServiceKeyForProvider(providerType))
-                    .orElse(null);
-            
-            // Tenant 조회
-            Tenant tenant = tenantRepository.findByTenantKey(tenantKey)
-                    .orElseThrow(() -> new IllegalStateException(
-                            "Tenant not found for key: " + tenantKey));
-            
-            // 리소스 이름 생성 (태그에서 Name 추출 또는 instanceId 사용)
-            String resourceName = extractResourceName(request.getTags(), instanceId);
-            
-            // Factory Method를 사용한 CloudResource 엔티티 생성
-            CloudResource cloudResource = CloudResource.createVmInstance(
-                    instanceId,
-                    resourceName,
-                    provider,
-                    cloudService,
-                    tenant,
-                    request.getInstanceSize(),
-                    request.getTags()
-            );
-            
-            cloudResourceRepository.save(cloudResource);
-            log.debug("[VmUseCaseService] CloudResource 저장 완료: instanceId={}", instanceId);
-            
-        } catch (Exception e) {
-            // DB 저장 실패해도 CSP 생성은 완료되었으므로 경고 로그만 출력
-            log.warn("[VmUseCaseService] CloudResource 저장 실패 (CSP 생성은 완료됨): instanceId={}, error={}", 
-                    instanceId, e.getMessage());
-        }
-    }
-
-    /**
-     * 리소스가 존재하면 생명주기 상태를 업데이트합니다.
-     *
-     * @param resourceId 리소스 ID
-     * @param lifecycleState 새로운 생명주기 상태
-     */
-    private void updateLifecycleStateIfExists(String resourceId, LifecycleState lifecycleState) {
-        try {
-            int updatedCount = cloudResourceRepository.updateLifecycleState(
-                    resourceId, lifecycleState, LocalDateTime.now());
-            
-            if (updatedCount > 0) {
-                log.debug("[VmUseCaseService] 생명주기 상태 업데이트 완료: resourceId={}, state={}", 
-                        resourceId, lifecycleState);
-            } else {
-                log.debug("[VmUseCaseService] DB에 리소스가 없어 상태 업데이트 스킵: resourceId={}", resourceId);
-            }
-        } catch (Exception e) {
-            log.warn("[VmUseCaseService] 생명주기 상태 업데이트 실패: resourceId={}, error={}", 
-                    resourceId, e.getMessage());
-        }
-    }
-
-    /**
-     * 리소스가 존재하면 소프트 삭제 처리합니다.
-     *
-     * @param resourceId 리소스 ID
-     */
-    private void softDeleteResourceIfExists(String resourceId) {
-        try {
-            int deletedCount = cloudResourceRepository.softDeleteByResourceId(resourceId);
-            
-            if (deletedCount > 0) {
-                log.debug("[VmUseCaseService] 리소스 소프트 삭제 완료: resourceId={}", resourceId);
-            } else {
-                log.debug("[VmUseCaseService] DB에 리소스가 없어 삭제 스킵: resourceId={}", resourceId);
-            }
-        } catch (Exception e) {
-            log.warn("[VmUseCaseService] 리소스 소프트 삭제 실패: resourceId={}, error={}", 
-                    resourceId, e.getMessage());
-        }
-    }
+    // ==================== Private Helper Methods ====================
 
     /**
      * 프로바이더 타입에 따른 서비스 키 반환
@@ -582,15 +485,5 @@ public class VmUseCaseService {
             case GCP -> "ComputeEngine";
             default -> "VM";
         };
-    }
-
-    /**
-     * 태그에서 리소스 이름 추출 (Name 태그 또는 instanceId 사용)
-     */
-    private String extractResourceName(Map<String, String> tags, String instanceId) {
-        if (tags != null && tags.containsKey("Name")) {
-            return tags.get("Name");
-        }
-        return instanceId;
     }
 }

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseService.java
@@ -1,7 +1,6 @@
 package com.agenticcp.core.domain.cloud.service.vm;
 
 import com.agenticcp.core.common.context.TenantContextHolder;
-import com.agenticcp.core.common.enums.Status;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.VmCreateRequest;
 import com.agenticcp.core.domain.cloud.dto.VmDeleteRequest;
@@ -10,7 +9,6 @@ import com.agenticcp.core.domain.cloud.entity.CloudProvider;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
 import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
-import com.agenticcp.core.domain.cloud.entity.CloudResource.ResourceType;
 import com.agenticcp.core.domain.cloud.entity.CloudService;
 import com.agenticcp.core.domain.cloud.port.model.VmQuery;
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
@@ -512,23 +510,16 @@ public class VmUseCaseService {
             // 리소스 이름 생성 (태그에서 Name 추출 또는 instanceId 사용)
             String resourceName = extractResourceName(request.getTags(), instanceId);
             
-            // CloudResource 엔티티 생성
-            CloudResource cloudResource = CloudResource.builder()
-                    .resourceId(instanceId)
-                    .resourceName(resourceName)
-                    .displayName(resourceName)
-                    .provider(provider)
-                    .service(cloudService)
-                    .tenant(tenant)
-                    .status(Status.ACTIVE)
-                    .resourceType(ResourceType.INSTANCE)
-                    .lifecycleState(LifecycleState.PENDING)
-                    .instanceSize(request.getInstanceSize())
-                    .tags(serializeTagsToJson(request.getTags()))
-                    .createdInCloud(LocalDateTime.now())
-                    .lastModifiedInCloud(LocalDateTime.now())
-                    .lastSync(LocalDateTime.now())
-                    .build();
+            // Factory Method를 사용한 CloudResource 엔티티 생성
+            CloudResource cloudResource = CloudResource.createVmInstance(
+                    instanceId,
+                    resourceName,
+                    provider,
+                    cloudService,
+                    tenant,
+                    request.getInstanceSize(),
+                    serializeTagsToJson(request.getTags())
+            );
             
             cloudResourceRepository.save(cloudResource);
             log.debug("[VmUseCaseService] CloudResource 저장 완료: instanceId={}", instanceId);

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseService.java
@@ -118,11 +118,11 @@ public class VmUseCaseService {
      * 데이터 정합성(Ghost Resource 방지)을 보장합니다.
      *
      * @param request 생성 요청 정보 (providerType, accountScope 포함)
-     * @return 생성된 인스턴스 ID
+     * @return 생성된 CloudResource 엔티티
      * @throws BusinessException DB 저장 실패 및 보상 트랜잭션 실행 시
      */
     @Transactional
-    public String createInstance(VmCreateRequest request) {
+    public CloudResource createInstance(VmCreateRequest request) {
         ProviderType providerType = request.getProviderType();
         String accountScope = request.getAccountScope();
         
@@ -139,9 +139,10 @@ public class VmUseCaseService {
             .createInstance(toCreateCommand(request, session));
 
         // DB에 CloudResource 저장 (실패 시 보상 트랜잭션 실행)
+        CloudResource cloudResource;
         try {
             String resourceName = resourceHelper.extractResourceName(request.getTags(), instanceId);
-            resourceHelper.registerVmInstance(
+            cloudResource = resourceHelper.registerVmInstance(
                     providerType,
                     getServiceKeyForProvider(providerType),
                     instanceId,
@@ -162,8 +163,9 @@ public class VmUseCaseService {
             );
         }
 
-        log.info("VM 인스턴스 생성 완료: provider={}, instanceId={}", providerType, instanceId);
-        return instanceId;
+        log.info("VM 인스턴스 생성 완료: provider={}, instanceId={}, resourceId={}", 
+                providerType, instanceId, cloudResource.getResourceId());
+        return cloudResource;
     }
 
     /**

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseService.java
@@ -1,25 +1,39 @@
 package com.agenticcp.core.domain.cloud.service.vm;
 
 import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.common.enums.Status;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
-import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
-import com.agenticcp.core.domain.cloud.entity.CloudResource;
 import com.agenticcp.core.domain.cloud.dto.VmCreateRequest;
 import com.agenticcp.core.domain.cloud.dto.VmDeleteRequest;
-import com.agenticcp.core.domain.cloud.port.model.VmQuery;
 import com.agenticcp.core.domain.cloud.dto.VmUpdateRequest;
-import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.ResourceType;
+import com.agenticcp.core.domain.cloud.entity.CloudService;
+import com.agenticcp.core.domain.cloud.port.model.VmQuery;
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
 import com.agenticcp.core.domain.cloud.port.model.vm.VmCreateCommand;
 import com.agenticcp.core.domain.cloud.port.model.vm.VmDeleteCommand;
 import com.agenticcp.core.domain.cloud.port.model.vm.VmUpdateCommand;
-import java.util.Map;
-import java.util.Optional;
+import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
+import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import com.agenticcp.core.domain.tenant.repository.TenantRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * 가상머신(VM) 유스케이스 서비스
@@ -45,6 +59,13 @@ public class VmUseCaseService {
     private final VmPortRouter vmPortRouter;
     private final CapabilityGuard capabilityGuard;
     private final AccountCredentialManagementPort credentialProviderPort;
+    
+    // DB 저장을 위한 Repository
+    private final CloudResourceRepository cloudResourceRepository;
+    private final CloudProviderRepository cloudProviderRepository;
+    private final CloudServiceRepository cloudServiceRepository;
+    private final TenantRepository tenantRepository;
+    private final ObjectMapper objectMapper;
 
     /**
      * 세션 자격증명을 획득합니다.
@@ -106,6 +127,7 @@ public class VmUseCaseService {
 
     /**
      * 새로운 VM 인스턴스를 생성합니다.
+     * CSP에서 인스턴스 생성 후 CloudResource 엔티티를 DB에 저장합니다.
      *
      * @param request 생성 요청 정보 (providerType, accountScope 포함)
      * @return 생성된 인스턴스 ID
@@ -123,9 +145,12 @@ public class VmUseCaseService {
         // 세션 획득
         CloudSessionCredential session = getSession(providerType, accountScope);
 
-        // VM 인스턴스 생성
+        // CSP에서 VM 인스턴스 생성
         String instanceId = vmPortRouter.lifecycle(providerType)
             .createInstance(toCreateCommand(request, session));
+
+        // DB에 CloudResource 저장
+        saveCloudResource(instanceId, request, providerType);
 
         log.info("VM 인스턴스 생성 완료: provider={}, instanceId={}", providerType, instanceId);
         return instanceId;
@@ -135,6 +160,7 @@ public class VmUseCaseService {
 
     /**
      * VM 인스턴스를 시작합니다.
+     * CSP에서 인스턴스 시작 후 DB의 lifecycleState를 RUNNING으로 업데이트합니다.
      *
      * @param providerType 클라우드 프로바이더 타입
      * @param accountScope 계정 스코프
@@ -150,14 +176,18 @@ public class VmUseCaseService {
         // 세션 획득
         CloudSessionCredential session = getSession(providerType, accountScope);
 
-        // VM 인스턴스 시작
+        // CSP에서 VM 인스턴스 시작
         vmPortRouter.lifecycle(providerType).startInstance(instanceId, session);
+
+        // DB 상태 업데이트: RUNNING
+        updateLifecycleStateIfExists(instanceId, LifecycleState.RUNNING);
 
         log.info("VM 인스턴스 시작 완료: provider={}, instanceId={}", providerType, instanceId);
     }
 
     /**
      * VM 인스턴스를 중지합니다.
+     * CSP에서 인스턴스 중지 후 DB의 lifecycleState를 STOPPED로 업데이트합니다.
      *
      * @param providerType 클라우드 프로바이더 타입
      * @param accountScope 계정 스코프
@@ -173,14 +203,18 @@ public class VmUseCaseService {
         // 세션 획득
         CloudSessionCredential session = getSession(providerType, accountScope);
 
-        // VM 인스턴스 중지
+        // CSP에서 VM 인스턴스 중지
         vmPortRouter.lifecycle(providerType).stopInstance(instanceId, session);
+
+        // DB 상태 업데이트: STOPPED
+        updateLifecycleStateIfExists(instanceId, LifecycleState.STOPPED);
 
         log.info("VM 인스턴스 중지 완료: provider={}, instanceId={}", providerType, instanceId);
     }
 
     /**
      * VM 인스턴스를 재부팅합니다.
+     * CSP에서 인스턴스 재부팅 후 DB의 lifecycleState를 RUNNING으로 유지합니다.
      *
      * @param providerType 클라우드 프로바이더 타입
      * @param accountScope 계정 스코프
@@ -197,14 +231,18 @@ public class VmUseCaseService {
         // 세션 획득
         CloudSessionCredential session = getSession(providerType, accountScope);
 
-        // VM 인스턴스 재부팅
+        // CSP에서 VM 인스턴스 재부팅
         vmPortRouter.lifecycle(providerType).rebootInstance(instanceId, session);
+
+        // DB 상태 업데이트: 재부팅 후 RUNNING 상태 유지 (lastModifiedInCloud만 업데이트)
+        updateLifecycleStateIfExists(instanceId, LifecycleState.RUNNING);
 
         log.info("VM 인스턴스 재부팅 완료: provider={}, instanceId={}", providerType, instanceId);
     }
 
     /**
      * VM 인스턴스를 종료합니다.
+     * CSP에서 인스턴스 종료 후 DB의 lifecycleState를 TERMINATED로 업데이트합니다.
      *
      * @param providerType 클라우드 프로바이더 타입
      * @param accountScope 계정 스코프
@@ -220,14 +258,18 @@ public class VmUseCaseService {
         // 세션 획득
         CloudSessionCredential session = getSession(providerType, accountScope);
 
-        // VM 인스턴스 종료
+        // CSP에서 VM 인스턴스 종료
         vmPortRouter.lifecycle(providerType).terminateInstance(instanceId, session);
+
+        // DB 상태 업데이트: TERMINATED
+        updateLifecycleStateIfExists(instanceId, LifecycleState.TERMINATED);
 
         log.info("VM 인스턴스 종료 완료: provider={}, instanceId={}", providerType, instanceId);
     }
 
     /**
      * VM 인스턴스를 삭제합니다.
+     * CSP에서 인스턴스 삭제 후 DB에서 소프트 삭제 처리합니다.
      *
      * @param request 삭제 요청 정보 (providerType, accountScope 포함)
      */
@@ -235,6 +277,7 @@ public class VmUseCaseService {
     public void deleteInstance(VmDeleteRequest request) {
         ProviderType providerType = request.getProviderType();
         String accountScope = request.getAccountScope();
+        String instanceId = request.getInstanceId();
         
         log.debug("VM 인스턴스 삭제: provider={}, accountScope={}, request={}", providerType, accountScope, request);
 
@@ -244,10 +287,13 @@ public class VmUseCaseService {
         // 세션 획득
         CloudSessionCredential session = getSession(providerType, accountScope);
 
-        // VM 인스턴스 삭제
+        // CSP에서 VM 인스턴스 삭제
         vmPortRouter.lifecycle(providerType).deleteInstance(toDeleteCommand(request, session));
 
-        log.info("VM 인스턴스 삭제 완료: provider={}, instanceId={}", providerType, request.getInstanceId());
+        // DB 소프트 삭제
+        softDeleteResourceIfExists(instanceId);
+
+        log.info("VM 인스턴스 삭제 완료: provider={}, instanceId={}", providerType, instanceId);
     }
 
     // ==================== 인스턴스 수정 ====================
@@ -433,5 +479,145 @@ public class VmUseCaseService {
                 .createSnapshot(request.isCreateSnapshot())
                 .session(session)
                 .build();
+    }
+
+    // ==================== DB 저장 헬퍼 메서드 ====================
+
+    /**
+     * CSP에서 생성된 VM 인스턴스 정보를 CloudResource 엔티티로 저장합니다.
+     *
+     * @param instanceId 생성된 인스턴스 ID
+     * @param request 생성 요청 정보
+     * @param providerType 프로바이더 타입
+     */
+    private void saveCloudResource(String instanceId, VmCreateRequest request, ProviderType providerType) {
+        try {
+            String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
+            
+            // Provider 조회
+            CloudProvider provider = cloudProviderRepository.findFirstByProviderType(providerType)
+                    .orElseThrow(() -> new IllegalStateException(
+                            "CloudProvider not found for type: " + providerType));
+            
+            // Service 조회 (VM용 서비스 - EC2, Compute Engine 등)
+            CloudService cloudService = cloudServiceRepository
+                    .findByProviderTypeAndServiceKey(providerType, getServiceKeyForProvider(providerType))
+                    .orElse(null);
+            
+            // Tenant 조회
+            Tenant tenant = tenantRepository.findByTenantKey(tenantKey)
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Tenant not found for key: " + tenantKey));
+            
+            // 리소스 이름 생성 (태그에서 Name 추출 또는 instanceId 사용)
+            String resourceName = extractResourceName(request.getTags(), instanceId);
+            
+            // CloudResource 엔티티 생성
+            CloudResource cloudResource = CloudResource.builder()
+                    .resourceId(instanceId)
+                    .resourceName(resourceName)
+                    .displayName(resourceName)
+                    .provider(provider)
+                    .service(cloudService)
+                    .tenant(tenant)
+                    .status(Status.ACTIVE)
+                    .resourceType(ResourceType.INSTANCE)
+                    .lifecycleState(LifecycleState.PENDING)
+                    .instanceSize(request.getInstanceSize())
+                    .tags(serializeTagsToJson(request.getTags()))
+                    .createdInCloud(LocalDateTime.now())
+                    .lastModifiedInCloud(LocalDateTime.now())
+                    .lastSync(LocalDateTime.now())
+                    .build();
+            
+            cloudResourceRepository.save(cloudResource);
+            log.debug("[VmUseCaseService] CloudResource 저장 완료: instanceId={}", instanceId);
+            
+        } catch (Exception e) {
+            // DB 저장 실패해도 CSP 생성은 완료되었으므로 경고 로그만 출력
+            log.warn("[VmUseCaseService] CloudResource 저장 실패 (CSP 생성은 완료됨): instanceId={}, error={}", 
+                    instanceId, e.getMessage());
+        }
+    }
+
+    /**
+     * 리소스가 존재하면 생명주기 상태를 업데이트합니다.
+     *
+     * @param resourceId 리소스 ID
+     * @param lifecycleState 새로운 생명주기 상태
+     */
+    private void updateLifecycleStateIfExists(String resourceId, LifecycleState lifecycleState) {
+        try {
+            int updatedCount = cloudResourceRepository.updateLifecycleState(
+                    resourceId, lifecycleState, LocalDateTime.now());
+            
+            if (updatedCount > 0) {
+                log.debug("[VmUseCaseService] 생명주기 상태 업데이트 완료: resourceId={}, state={}", 
+                        resourceId, lifecycleState);
+            } else {
+                log.debug("[VmUseCaseService] DB에 리소스가 없어 상태 업데이트 스킵: resourceId={}", resourceId);
+            }
+        } catch (Exception e) {
+            log.warn("[VmUseCaseService] 생명주기 상태 업데이트 실패: resourceId={}, error={}", 
+                    resourceId, e.getMessage());
+        }
+    }
+
+    /**
+     * 리소스가 존재하면 소프트 삭제 처리합니다.
+     *
+     * @param resourceId 리소스 ID
+     */
+    private void softDeleteResourceIfExists(String resourceId) {
+        try {
+            int deletedCount = cloudResourceRepository.softDeleteByResourceId(resourceId);
+            
+            if (deletedCount > 0) {
+                log.debug("[VmUseCaseService] 리소스 소프트 삭제 완료: resourceId={}", resourceId);
+            } else {
+                log.debug("[VmUseCaseService] DB에 리소스가 없어 삭제 스킵: resourceId={}", resourceId);
+            }
+        } catch (Exception e) {
+            log.warn("[VmUseCaseService] 리소스 소프트 삭제 실패: resourceId={}, error={}", 
+                    resourceId, e.getMessage());
+        }
+    }
+
+    /**
+     * 프로바이더 타입에 따른 서비스 키 반환
+     * AWS: EC2, Azure: VirtualMachines, GCP: ComputeEngine 등
+     */
+    private String getServiceKeyForProvider(ProviderType providerType) {
+        return switch (providerType) {
+            case AWS -> "EC2";
+            case AZURE -> "VirtualMachines";
+            case GCP -> "ComputeEngine";
+            default -> "VM";
+        };
+    }
+
+    /**
+     * 태그에서 리소스 이름 추출 (Name 태그 또는 instanceId 사용)
+     */
+    private String extractResourceName(Map<String, String> tags, String instanceId) {
+        if (tags != null && tags.containsKey("Name")) {
+            return tags.get("Name");
+        }
+        return instanceId;
+    }
+
+    /**
+     * 태그 맵을 JSON 문자열로 직렬화
+     */
+    private String serializeTagsToJson(Map<String, String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(tags);
+        } catch (JsonProcessingException e) {
+            log.warn("[VmUseCaseService] 태그 JSON 직렬화 실패: {}", e.getMessage());
+            return null;
+        }
     }
 }

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseService.java
@@ -21,8 +21,6 @@ import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
 import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
 import com.agenticcp.core.domain.tenant.entity.Tenant;
 import com.agenticcp.core.domain.tenant.repository.TenantRepository;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -63,7 +61,6 @@ public class VmUseCaseService {
     private final CloudProviderRepository cloudProviderRepository;
     private final CloudServiceRepository cloudServiceRepository;
     private final TenantRepository tenantRepository;
-    private final ObjectMapper objectMapper;
 
     /**
      * 세션 자격증명을 획득합니다.
@@ -518,7 +515,7 @@ public class VmUseCaseService {
                     cloudService,
                     tenant,
                     request.getInstanceSize(),
-                    serializeTagsToJson(request.getTags())
+                    request.getTags()
             );
             
             cloudResourceRepository.save(cloudResource);
@@ -595,20 +592,5 @@ public class VmUseCaseService {
             return tags.get("Name");
         }
         return instanceId;
-    }
-
-    /**
-     * 태그 맵을 JSON 문자열로 직렬화
-     */
-    private String serializeTagsToJson(Map<String, String> tags) {
-        if (tags == null || tags.isEmpty()) {
-            return null;
-        }
-        try {
-            return objectMapper.writeValueAsString(tags);
-        } catch (JsonProcessingException e) {
-            log.warn("[VmUseCaseService] 태그 JSON 직렬화 실패: {}", e.getMessage());
-            return null;
-        }
     }
 }

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseService.java
@@ -2,6 +2,8 @@ package com.agenticcp.core.domain.cloud.service.vm;
 
 import com.agenticcp.core.common.context.TenantContextHolder;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
+import com.agenticcp.core.domain.cloud.dto.ResourceRegistrationRequest;
+import com.agenticcp.core.domain.cloud.dto.ResourceRegistrationRequest.AttributeKeys;
 import com.agenticcp.core.domain.cloud.dto.VmCreateRequest;
 import com.agenticcp.core.domain.cloud.dto.VmDeleteRequest;
 import com.agenticcp.core.domain.cloud.dto.VmUpdateRequest;
@@ -142,13 +144,18 @@ public class VmUseCaseService {
         CloudResource cloudResource;
         try {
             String resourceName = resourceHelper.extractResourceName(request.getTags(), instanceId);
-            cloudResource = resourceHelper.registerVmInstance(
+            ResourceRegistrationRequest registrationRequest = ResourceRegistrationRequest.builder()
+                    .resourceId(instanceId)
+                    .resourceName(resourceName)
+                    .resourceType(CloudResource.ResourceType.INSTANCE)
+                    .tags(request.getTags())
+                    .attributes(Map.of(AttributeKeys.INSTANCE_SIZE, request.getInstanceSize()))
+                    .build();
+            
+            cloudResource = resourceHelper.registerResource(
                     providerType,
                     getServiceKeyForProvider(providerType),
-                    instanceId,
-                    resourceName,
-                    request.getInstanceSize(),
-                    request.getTags()
+                    registrationRequest
             );
         } catch (Exception e) {
             log.error("[VmUseCaseService] DB 저장 실패, 보상 트랜잭션 실행: instanceId={}, error={}",

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseService.java
@@ -1,31 +1,44 @@
 package com.agenticcp.core.domain.cloud.service.vpc;
 
-import com.agenticcp.core.domain.cloud.port.outbound.vpc.VpcManagementPort;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.common.enums.Status;
 import com.agenticcp.core.common.exception.BusinessException;
-import com.agenticcp.core.domain.cloud.entity.CloudResource;
-import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
-import com.agenticcp.core.domain.cloud.exception.CredentialErrorCode;
-import com.agenticcp.core.domain.cloud.port.model.vpc.CreateVpcCommand;
-import com.agenticcp.core.domain.cloud.port.model.vpc.DeleteVpcCommand;
-import com.agenticcp.core.domain.cloud.port.model.vpc.GetVpcCommand;
+import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.ListVpcsQueryRequest;
-import com.agenticcp.core.domain.cloud.port.model.vpc.UpdateVpcCommand;
-import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
-import com.agenticcp.core.domain.cloud.port.model.ResourceIdentity;
 import com.agenticcp.core.domain.cloud.dto.VpcCreateRequest;
 import com.agenticcp.core.domain.cloud.dto.VpcQueryRequest;
 import com.agenticcp.core.domain.cloud.dto.VpcUpdateRequest;
-import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.ResourceType;
+import com.agenticcp.core.domain.cloud.entity.CloudService;
+import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
+import com.agenticcp.core.domain.cloud.exception.CredentialErrorCode;
+import com.agenticcp.core.domain.cloud.port.model.ResourceIdentity;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import com.agenticcp.core.domain.cloud.port.model.vpc.CreateVpcCommand;
+import com.agenticcp.core.domain.cloud.port.model.vpc.DeleteVpcCommand;
+import com.agenticcp.core.domain.cloud.port.model.vpc.GetVpcCommand;
+import com.agenticcp.core.domain.cloud.port.model.vpc.UpdateVpcCommand;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
-
+import com.agenticcp.core.domain.cloud.port.outbound.vpc.VpcManagementPort;
+import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import com.agenticcp.core.domain.tenant.repository.TenantRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -36,6 +49,13 @@ public class VpcUseCaseService {
     private final VpcPortRouter vpcPortRouter;
     private final CapabilityGuard capabilityGuard;
     private final AccountCredentialManagementPort accountCredentialManagementPort;
+    
+    // DB 저장을 위한 Repository
+    private final CloudResourceRepository cloudResourceRepository;
+    private final CloudProviderRepository cloudProviderRepository;
+    private final CloudServiceRepository cloudServiceRepository;
+    private final TenantRepository tenantRepository;
+    private final ObjectMapper objectMapper;
 
     @Transactional
     public CloudResource createVpc(VpcCreateRequest request) {
@@ -89,7 +109,14 @@ public class VpcUseCaseService {
             .providerSpecificConfig(request.getProviderSpecificConfig())
             .session(session)
             .build();
-        return vpcPort.createVpc(command);
+        
+        // CSP에서 VPC 생성
+        CloudResource vpc = vpcPort.createVpc(command);
+        
+        // DB에 CloudResource 저장
+        saveCloudResource(vpc.getResourceId(), request);
+        
+        return vpc;
     }
 
     @Transactional(readOnly = true)
@@ -280,7 +307,12 @@ public class VpcUseCaseService {
             .tenantKey(tenantKey)
             .session(session)
             .build();
+        
+        // CSP에서 VPC 삭제
         vpcPort.deleteVpc(command);
+        
+        // DB 소프트 삭제
+        softDeleteResourceIfExists(vpcId.getProviderResourceId());
     }
     
     /**
@@ -295,6 +327,113 @@ public class VpcUseCaseService {
                 CloudErrorCode.ACCOUNT_SCOPE_REQUIRED,
                 "AccountScope가 필요합니다"
             );
+        }
+    }
+
+    // ==================== DB 저장 헬퍼 메서드 ====================
+
+    /**
+     * CSP에서 생성된 VPC 정보를 CloudResource 엔티티로 저장합니다.
+     *
+     * @param vpcId 생성된 VPC ID
+     * @param request 생성 요청 정보
+     */
+    private void saveCloudResource(String vpcId, VpcCreateRequest request) {
+        try {
+            String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
+            ProviderType providerType = request.getProviderType();
+            
+            // Provider 조회
+            CloudProvider provider = cloudProviderRepository.findFirstByProviderType(providerType)
+                    .orElseThrow(() -> new IllegalStateException(
+                            "CloudProvider not found for type: " + providerType));
+            
+            // Service 조회 (VPC용 서비스)
+            CloudService cloudService = cloudServiceRepository
+                    .findByProviderTypeAndServiceKey(providerType, getServiceKeyForProvider(providerType))
+                    .orElse(null);
+            
+            // Tenant 조회
+            Tenant tenant = tenantRepository.findByTenantKey(tenantKey)
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Tenant not found for key: " + tenantKey));
+            
+            // 리소스 이름 결정
+            String resourceName = request.getVpcName() != null ? request.getVpcName() : vpcId;
+            
+            // CloudResource 엔티티 생성
+            CloudResource cloudResource = CloudResource.builder()
+                    .resourceId(vpcId)
+                    .resourceName(resourceName)
+                    .displayName(resourceName)
+                    .provider(provider)
+                    .service(cloudService)
+                    .tenant(tenant)
+                    .status(Status.ACTIVE)
+                    .resourceType(ResourceType.NETWORK)
+                    .lifecycleState(LifecycleState.RUNNING)
+                    .tags(serializeTagsToJson(request.getTags()))
+                    .configuration(request.getCidrBlock()) // CIDR 정보 저장
+                    .createdInCloud(LocalDateTime.now())
+                    .lastModifiedInCloud(LocalDateTime.now())
+                    .lastSync(LocalDateTime.now())
+                    .build();
+            
+            cloudResourceRepository.save(cloudResource);
+            log.debug("[VpcUseCaseService] CloudResource 저장 완료: vpcId={}", vpcId);
+            
+        } catch (Exception e) {
+            // DB 저장 실패해도 CSP 생성은 완료되었으므로 경고 로그만 출력
+            log.warn("[VpcUseCaseService] CloudResource 저장 실패 (CSP 생성은 완료됨): vpcId={}, error={}", 
+                    vpcId, e.getMessage());
+        }
+    }
+
+    /**
+     * 리소스가 존재하면 소프트 삭제 처리합니다.
+     *
+     * @param resourceId 리소스 ID (VPC ID)
+     */
+    private void softDeleteResourceIfExists(String resourceId) {
+        try {
+            int deletedCount = cloudResourceRepository.softDeleteByResourceId(resourceId);
+            
+            if (deletedCount > 0) {
+                log.debug("[VpcUseCaseService] 리소스 소프트 삭제 완료: resourceId={}", resourceId);
+            } else {
+                log.debug("[VpcUseCaseService] DB에 리소스가 없어 삭제 스킵: resourceId={}", resourceId);
+            }
+        } catch (Exception e) {
+            log.warn("[VpcUseCaseService] 리소스 소프트 삭제 실패: resourceId={}, error={}", 
+                    resourceId, e.getMessage());
+        }
+    }
+
+    /**
+     * 프로바이더 타입에 따른 서비스 키 반환
+     * AWS: VPC, Azure: VirtualNetwork, GCP: VPCNetwork 등
+     */
+    private String getServiceKeyForProvider(ProviderType providerType) {
+        return switch (providerType) {
+            case AWS -> "VPC";
+            case AZURE -> "VirtualNetwork";
+            case GCP -> "VPCNetwork";
+            default -> "Network";
+        };
+    }
+
+    /**
+     * 태그 맵을 JSON 문자열로 직렬화
+     */
+    private String serializeTagsToJson(Map<String, String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(tags);
+        } catch (JsonProcessingException e) {
+            log.warn("[VpcUseCaseService] 태그 JSON 직렬화 실패: {}", e.getMessage());
+            return null;
         }
     }
 }

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseService.java
@@ -38,6 +38,17 @@ public class VpcUseCaseService {
     private final AccountCredentialManagementPort accountCredentialManagementPort;
     private final CloudResourceManagementHelper resourceHelper;
 
+    /**
+     * VPC를 생성합니다.
+     * CSP에서 VPC 생성 후 CloudResource 엔티티를 DB에 저장합니다.
+     * 
+     * 보상 트랜잭션: DB 저장 실패 시 CSP에 생성된 VPC를 삭제하여
+     * 데이터 정합성(Ghost Resource 방지)을 보장합니다.
+     *
+     * @param request 생성 요청 정보
+     * @return 생성된 VPC CloudResource
+     * @throws BusinessException DB 저장 실패 및 보상 트랜잭션 실행 시
+     */
     @Transactional
     public CloudResource createVpc(VpcCreateRequest request) {
         capabilityGuard.ensureSupported(
@@ -94,18 +105,69 @@ public class VpcUseCaseService {
         // CSP에서 VPC 생성
         CloudResource vpc = vpcPort.createVpc(command);
         
-        // DB에 CloudResource 저장
-        String resourceName = request.getVpcName() != null ? request.getVpcName() : vpc.getResourceId();
-        resourceHelper.registerVpc(
-                request.getProviderType(),
-                getServiceKeyForProvider(request.getProviderType()),
-                vpc.getResourceId(),
-                resourceName,
-                request.getCidrBlock(),
-                request.getTags()
-        );
+        // DB에 CloudResource 저장 (실패 시 보상 트랜잭션 실행)
+        try {
+            String resourceName = request.getVpcName() != null ? request.getVpcName() : vpc.getResourceId();
+            resourceHelper.registerVpc(
+                    request.getProviderType(),
+                    getServiceKeyForProvider(request.getProviderType()),
+                    vpc.getResourceId(),
+                    resourceName,
+                    request.getCidrBlock(),
+                    request.getTags()
+            );
+        } catch (Exception e) {
+            log.error("[VpcUseCaseService] DB 저장 실패, 보상 트랜잭션 실행: vpcId={}, error={}",
+                    vpc.getResourceId(), e.getMessage());
+            
+            // 보상 트랜잭션: CSP에 생성된 VPC 삭제
+            executeCompensatingTransaction(request.getProviderType(), vpcPort, vpc.getResourceId(), 
+                    accountScope, request.getRegion(), session);
+            
+            throw new BusinessException(
+                    CloudErrorCode.RESOURCE_CREATION_FAILED,
+                    "VPC 생성 후 DB 저장 실패로 인해 롤백되었습니다: " + vpc.getResourceId()
+            );
+        }
         
         return vpc;
+    }
+
+    /**
+     * 보상 트랜잭션: CSP에 생성된 VPC를 삭제합니다.
+     * Ghost Resource 방지를 위해 DB 저장 실패 시 호출됩니다.
+     */
+    private void executeCompensatingTransaction(
+            ProviderType providerType,
+            VpcManagementPort vpcPort,
+            String vpcId,
+            String accountScope,
+            String region,
+            CloudSessionCredential session
+    ) {
+        try {
+            log.warn("[VpcUseCaseService] 보상 트랜잭션 실행: CSP VPC 삭제 시도 - vpcId={}", vpcId);
+            
+            String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
+            DeleteVpcCommand deleteCommand = DeleteVpcCommand.builder()
+                    .providerType(providerType)
+                    .accountScope(accountScope)
+                    .region(region)
+                    .providerResourceId(vpcId)
+                    .serviceKey(VpcConstants.SERVICE_KEY)
+                    .resourceType(VpcConstants.RESOURCE_TYPE)
+                    .tenantKey(tenantKey)
+                    .session(session)
+                    .build();
+            
+            vpcPort.deleteVpc(deleteCommand);
+            log.info("[VpcUseCaseService] 보상 트랜잭션 완료: CSP VPC 삭제 성공 - vpcId={}", vpcId);
+        } catch (Exception compensationError) {
+            // 보상 트랜잭션도 실패한 경우 - Ghost Resource 발생
+            // 이 경우 별도의 모니터링/알림 시스템이나 배치 동기화로 처리 필요
+            log.error("[VpcUseCaseService] 보상 트랜잭션 실패: Ghost Resource 발생 가능 - vpcId={}, error={}",
+                    vpcId, compensationError.getMessage());
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseService.java
@@ -4,6 +4,8 @@ import com.agenticcp.core.common.context.TenantContextHolder;
 import com.agenticcp.core.common.exception.BusinessException;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.ListVpcsQueryRequest;
+import com.agenticcp.core.domain.cloud.dto.ResourceRegistrationRequest;
+import com.agenticcp.core.domain.cloud.dto.ResourceRegistrationRequest.AttributeKeys;
 import com.agenticcp.core.domain.cloud.dto.VpcCreateRequest;
 import com.agenticcp.core.domain.cloud.dto.VpcQueryRequest;
 import com.agenticcp.core.domain.cloud.dto.VpcUpdateRequest;
@@ -26,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -108,13 +111,18 @@ public class VpcUseCaseService {
         // DB에 CloudResource 저장 (실패 시 보상 트랜잭션 실행)
         try {
             String resourceName = request.getVpcName() != null ? request.getVpcName() : vpc.getResourceId();
-            resourceHelper.registerVpc(
+            ResourceRegistrationRequest registrationRequest = ResourceRegistrationRequest.builder()
+                    .resourceId(vpc.getResourceId())
+                    .resourceName(resourceName)
+                    .resourceType(CloudResource.ResourceType.NETWORK)
+                    .tags(request.getTags())
+                    .attributes(Map.of(AttributeKeys.CONFIGURATION, request.getCidrBlock()))
+                    .build();
+            
+            resourceHelper.registerResource(
                     request.getProviderType(),
                     getServiceKeyForProvider(request.getProviderType()),
-                    vpc.getResourceId(),
-                    resourceName,
-                    request.getCidrBlock(),
-                    request.getTags()
+                    registrationRequest
             );
         } catch (Exception e) {
             log.error("[VpcUseCaseService] DB 저장 실패, 보상 트랜잭션 실행: vpcId={}, error={}",

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseService.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -334,10 +335,13 @@ public class VpcUseCaseService {
 
     /**
      * CSP에서 생성된 VPC 정보를 CloudResource 엔티티로 저장합니다.
+     * DB 저장 실패해도 CSP 생성은 완료되었으므로 별도 트랜잭션으로 분리하여
+     * 메인 트랜잭션에 영향을 주지 않도록 합니다.
      *
      * @param vpcId 생성된 VPC ID
      * @param request 생성 요청 정보
      */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     private void saveCloudResource(String vpcId, VpcCreateRequest request) {
         try {
             String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
@@ -348,10 +352,12 @@ public class VpcUseCaseService {
                     .orElseThrow(() -> new IllegalStateException(
                             "CloudProvider not found for type: " + providerType));
             
-            // Service 조회 (VPC용 서비스)
+            // Service 조회 (프로바이더별 서비스 키 사용)
+            String serviceKey = getServiceKeyForProvider(providerType);
             CloudService cloudService = cloudServiceRepository
-                    .findByProviderTypeAndServiceKey(providerType, getServiceKeyForProvider(providerType))
-                    .orElse(null);
+                    .findByProviderTypeAndServiceKey(providerType, serviceKey)
+                    .orElseThrow(() -> new IllegalStateException(
+                            "CloudService not found for provider: " + providerType + ", serviceKey: " + serviceKey));
             
             // Tenant 조회
             Tenant tenant = tenantRepository.findByTenantKey(tenantKey)
@@ -411,11 +417,11 @@ public class VpcUseCaseService {
 
     /**
      * 프로바이더 타입에 따른 서비스 키 반환
-     * AWS: VPC, Azure: VirtualNetwork, GCP: VPCNetwork 등
+     * AWS: EC2 (VPC는 EC2 서비스에 속함), Azure: VirtualNetwork, GCP: VPCNetwork 등
      */
     private String getServiceKeyForProvider(ProviderType providerType) {
         return switch (providerType) {
-            case AWS -> "VPC";
+            case AWS -> "EC2";  // VPC는 EC2 서비스에 속함
             case AZURE -> "VirtualNetwork";
             case GCP -> "VPCNetwork";
             default -> "Network";

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseService.java
@@ -1,7 +1,6 @@
 package com.agenticcp.core.domain.cloud.service.vpc;
 
 import com.agenticcp.core.common.context.TenantContextHolder;
-import com.agenticcp.core.common.enums.Status;
 import com.agenticcp.core.common.exception.BusinessException;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.ListVpcsQueryRequest;
@@ -11,8 +10,6 @@ import com.agenticcp.core.domain.cloud.dto.VpcUpdateRequest;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
-import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
-import com.agenticcp.core.domain.cloud.entity.CloudResource.ResourceType;
 import com.agenticcp.core.domain.cloud.entity.CloudService;
 import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
 import com.agenticcp.core.domain.cloud.exception.CredentialErrorCode;
@@ -37,7 +34,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -367,23 +363,16 @@ public class VpcUseCaseService {
             // 리소스 이름 결정
             String resourceName = request.getVpcName() != null ? request.getVpcName() : vpcId;
             
-            // CloudResource 엔티티 생성
-            CloudResource cloudResource = CloudResource.builder()
-                    .resourceId(vpcId)
-                    .resourceName(resourceName)
-                    .displayName(resourceName)
-                    .provider(provider)
-                    .service(cloudService)
-                    .tenant(tenant)
-                    .status(Status.ACTIVE)
-                    .resourceType(ResourceType.NETWORK)
-                    .lifecycleState(LifecycleState.RUNNING)
-                    .tags(serializeTagsToJson(request.getTags()))
-                    .configuration(request.getCidrBlock()) // CIDR 정보 저장
-                    .createdInCloud(LocalDateTime.now())
-                    .lastModifiedInCloud(LocalDateTime.now())
-                    .lastSync(LocalDateTime.now())
-                    .build();
+            // Factory Method를 사용한 CloudResource 엔티티 생성
+            CloudResource cloudResource = CloudResource.createVpc(
+                    vpcId,
+                    resourceName,
+                    provider,
+                    cloudService,
+                    tenant,
+                    request.getCidrBlock(),
+                    serializeTagsToJson(request.getTags())
+            );
             
             cloudResourceRepository.save(cloudResource);
             log.debug("[VpcUseCaseService] CloudResource 저장 완료: vpcId={}", vpcId);

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseService.java
@@ -7,10 +7,8 @@ import com.agenticcp.core.domain.cloud.dto.ListVpcsQueryRequest;
 import com.agenticcp.core.domain.cloud.dto.VpcCreateRequest;
 import com.agenticcp.core.domain.cloud.dto.VpcQueryRequest;
 import com.agenticcp.core.domain.cloud.dto.VpcUpdateRequest;
-import com.agenticcp.core.domain.cloud.entity.CloudProvider;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
-import com.agenticcp.core.domain.cloud.entity.CloudService;
 import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
 import com.agenticcp.core.domain.cloud.exception.CredentialErrorCode;
 import com.agenticcp.core.domain.cloud.port.model.ResourceIdentity;
@@ -21,15 +19,10 @@ import com.agenticcp.core.domain.cloud.port.model.vpc.GetVpcCommand;
 import com.agenticcp.core.domain.cloud.port.model.vpc.UpdateVpcCommand;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
 import com.agenticcp.core.domain.cloud.port.outbound.vpc.VpcManagementPort;
-import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
-import com.agenticcp.core.domain.tenant.entity.Tenant;
-import com.agenticcp.core.domain.tenant.repository.TenantRepository;
+import com.agenticcp.core.domain.cloud.service.helper.CloudResourceManagementHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -43,12 +36,7 @@ public class VpcUseCaseService {
     private final VpcPortRouter vpcPortRouter;
     private final CapabilityGuard capabilityGuard;
     private final AccountCredentialManagementPort accountCredentialManagementPort;
-    
-    // DB 저장을 위한 Repository
-    private final CloudResourceRepository cloudResourceRepository;
-    private final CloudProviderRepository cloudProviderRepository;
-    private final CloudServiceRepository cloudServiceRepository;
-    private final TenantRepository tenantRepository;
+    private final CloudResourceManagementHelper resourceHelper;
 
     @Transactional
     public CloudResource createVpc(VpcCreateRequest request) {
@@ -107,7 +95,15 @@ public class VpcUseCaseService {
         CloudResource vpc = vpcPort.createVpc(command);
         
         // DB에 CloudResource 저장
-        saveCloudResource(vpc.getResourceId(), request);
+        String resourceName = request.getVpcName() != null ? request.getVpcName() : vpc.getResourceId();
+        resourceHelper.registerVpc(
+                request.getProviderType(),
+                getServiceKeyForProvider(request.getProviderType()),
+                vpc.getResourceId(),
+                resourceName,
+                request.getCidrBlock(),
+                request.getTags()
+        );
         
         return vpc;
     }
@@ -305,7 +301,7 @@ public class VpcUseCaseService {
         vpcPort.deleteVpc(command);
         
         // DB 소프트 삭제
-        softDeleteResourceIfExists(vpcId.getProviderResourceId());
+        resourceHelper.softDeleteResource(vpcId.getProviderResourceId());
     }
     
     /**
@@ -323,82 +319,7 @@ public class VpcUseCaseService {
         }
     }
 
-    // ==================== DB 저장 헬퍼 메서드 ====================
-
-    /**
-     * CSP에서 생성된 VPC 정보를 CloudResource 엔티티로 저장합니다.
-     * DB 저장 실패해도 CSP 생성은 완료되었으므로 별도 트랜잭션으로 분리하여
-     * 메인 트랜잭션에 영향을 주지 않도록 합니다.
-     *
-     * @param vpcId 생성된 VPC ID
-     * @param request 생성 요청 정보
-     */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    private void saveCloudResource(String vpcId, VpcCreateRequest request) {
-        try {
-            String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
-            ProviderType providerType = request.getProviderType();
-            
-            // Provider 조회
-            CloudProvider provider = cloudProviderRepository.findFirstByProviderType(providerType)
-                    .orElseThrow(() -> new IllegalStateException(
-                            "CloudProvider not found for type: " + providerType));
-            
-            // Service 조회 (프로바이더별 서비스 키 사용)
-            String serviceKey = getServiceKeyForProvider(providerType);
-            CloudService cloudService = cloudServiceRepository
-                    .findByProviderTypeAndServiceKey(providerType, serviceKey)
-                    .orElseThrow(() -> new IllegalStateException(
-                            "CloudService not found for provider: " + providerType + ", serviceKey: " + serviceKey));
-            
-            // Tenant 조회
-            Tenant tenant = tenantRepository.findByTenantKey(tenantKey)
-                    .orElseThrow(() -> new IllegalStateException(
-                            "Tenant not found for key: " + tenantKey));
-            
-            // 리소스 이름 결정
-            String resourceName = request.getVpcName() != null ? request.getVpcName() : vpcId;
-            
-            // Factory Method를 사용한 CloudResource 엔티티 생성
-            CloudResource cloudResource = CloudResource.createVpc(
-                    vpcId,
-                    resourceName,
-                    provider,
-                    cloudService,
-                    tenant,
-                    request.getCidrBlock(),
-                    request.getTags()
-            );
-            
-            cloudResourceRepository.save(cloudResource);
-            log.debug("[VpcUseCaseService] CloudResource 저장 완료: vpcId={}", vpcId);
-            
-        } catch (Exception e) {
-            // DB 저장 실패해도 CSP 생성은 완료되었으므로 경고 로그만 출력
-            log.warn("[VpcUseCaseService] CloudResource 저장 실패 (CSP 생성은 완료됨): vpcId={}, error={}", 
-                    vpcId, e.getMessage());
-        }
-    }
-
-    /**
-     * 리소스가 존재하면 소프트 삭제 처리합니다.
-     *
-     * @param resourceId 리소스 ID (VPC ID)
-     */
-    private void softDeleteResourceIfExists(String resourceId) {
-        try {
-            int deletedCount = cloudResourceRepository.softDeleteByResourceId(resourceId);
-            
-            if (deletedCount > 0) {
-                log.debug("[VpcUseCaseService] 리소스 소프트 삭제 완료: resourceId={}", resourceId);
-            } else {
-                log.debug("[VpcUseCaseService] DB에 리소스가 없어 삭제 스킵: resourceId={}", resourceId);
-            }
-        } catch (Exception e) {
-            log.warn("[VpcUseCaseService] 리소스 소프트 삭제 실패: resourceId={}, error={}", 
-                    resourceId, e.getMessage());
-        }
-    }
+    // ==================== Private Helper Methods ====================
 
     /**
      * 프로바이더 타입에 따른 서비스 키 반환

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseService.java
@@ -26,8 +26,6 @@ import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
 import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
 import com.agenticcp.core.domain.tenant.entity.Tenant;
 import com.agenticcp.core.domain.tenant.repository.TenantRepository;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,7 +33,6 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -52,7 +49,6 @@ public class VpcUseCaseService {
     private final CloudProviderRepository cloudProviderRepository;
     private final CloudServiceRepository cloudServiceRepository;
     private final TenantRepository tenantRepository;
-    private final ObjectMapper objectMapper;
 
     @Transactional
     public CloudResource createVpc(VpcCreateRequest request) {
@@ -371,7 +367,7 @@ public class VpcUseCaseService {
                     cloudService,
                     tenant,
                     request.getCidrBlock(),
-                    serializeTagsToJson(request.getTags())
+                    request.getTags()
             );
             
             cloudResourceRepository.save(cloudResource);
@@ -415,20 +411,5 @@ public class VpcUseCaseService {
             case GCP -> "VPCNetwork";
             default -> "Network";
         };
-    }
-
-    /**
-     * 태그 맵을 JSON 문자열로 직렬화
-     */
-    private String serializeTagsToJson(Map<String, String> tags) {
-        if (tags == null || tags.isEmpty()) {
-            return null;
-        }
-        try {
-            return objectMapper.writeValueAsString(tags);
-        } catch (JsonProcessingException e) {
-            log.warn("[VpcUseCaseService] 태그 JSON 직렬화 실패: {}", e.getMessage());
-            return null;
-        }
     }
 }

--- a/src/test/java/com/agenticcp/core/controller/VmControllerTest.java
+++ b/src/test/java/com/agenticcp/core/controller/VmControllerTest.java
@@ -123,14 +123,15 @@ class VmControllerTest {
             .build();
 
         when(vmUseCaseService.createInstance(any(VmCreateRequest.class)))
-            .thenReturn("i-1234567890abcdef0");
+            .thenReturn(testInstance);
 
         // When & Then
         mockMvc.perform(post(BASE_URL, "AWS", "123456789012")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.data").value("i-1234567890abcdef0"));
+                .andExpect(jsonPath("$.data.resourceId").value("i-1234567890abcdef0"))
+                .andExpect(jsonPath("$.data.resourceName").value("test-instance"));
     }
 
     @Test

--- a/src/test/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/s3/AwsS3BucketDiscoveryAdapterTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/s3/AwsS3BucketDiscoveryAdapterTest.java
@@ -107,7 +107,6 @@ class AwsS3BucketDiscoveryAdapterTest {
                     .resourceName(BUCKET_NAME)
                     .build();
             when(mapper.toCloudResource(any(), any())).thenReturn(mockResource);
-            when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
             ResourceTagMapping mapping = ResourceTagMapping.builder()
                     .resourceARN("arn:aws:s3:::" + BUCKET_NAME)

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/aws/VmUseCaseServiceCreateTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/aws/VmUseCaseServiceCreateTest.java
@@ -7,13 +7,9 @@ import com.agenticcp.core.domain.cloud.dto.VmCreateRequest;
 import com.agenticcp.core.domain.cloud.port.model.vm.VmCreateCommand;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
 import com.agenticcp.core.domain.cloud.port.outbound.vm.VmLifecyclePort;
-import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
+import com.agenticcp.core.domain.cloud.service.helper.CloudResourceManagementHelper;
 import com.agenticcp.core.domain.cloud.service.vm.VmPortRouter;
 import com.agenticcp.core.domain.cloud.service.vm.VmUseCaseService;
-import com.agenticcp.core.domain.tenant.repository.TenantRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,34 +47,18 @@ class VmUseCaseServiceCreateTest {
     private AccountCredentialManagementPort credentialProviderPort;
 
     @Mock
-    private CloudResourceRepository cloudResourceRepository;
-
-    @Mock
-    private CloudProviderRepository cloudProviderRepository;
-
-    @Mock
-    private CloudServiceRepository cloudServiceRepository;
-
-    @Mock
-    private TenantRepository tenantRepository;
-
-    private ObjectMapper objectMapper;
+    private CloudResourceManagementHelper resourceHelper;
 
     private VmUseCaseService vmUseCaseService;
 
     @BeforeEach
     void setUp() {
         TenantContextHolder.setTenantKey("tenant-test");
-        objectMapper = new ObjectMapper();
         vmUseCaseService = new VmUseCaseService(
                 vmPortRouter,
                 capabilityGuard,
                 credentialProviderPort,
-                cloudResourceRepository,
-                cloudProviderRepository,
-                cloudServiceRepository,
-                tenantRepository,
-                objectMapper
+                resourceHelper
         );
 
         when(vmPortRouter.lifecycle(ProviderType.AWS)).thenReturn(vmLifecyclePort);

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/aws/VmUseCaseServiceCreateTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/aws/VmUseCaseServiceCreateTest.java
@@ -3,6 +3,7 @@ package com.agenticcp.core.domain.cloud.service.aws;
 import com.agenticcp.core.common.context.TenantContextHolder;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
 import com.agenticcp.core.domain.cloud.dto.VmCreateRequest;
 import com.agenticcp.core.domain.cloud.port.model.vm.VmCreateCommand;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
@@ -21,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -87,13 +89,23 @@ class VmUseCaseServiceCreateTest {
             .build();
 
         String expectedInstanceId = "i-1234567890abcdef0";
+        CloudResource expectedCloudResource = CloudResource.builder()
+                .resourceId(expectedInstanceId)
+                .resourceName(expectedInstanceId)
+                .build();
+
         when(vmLifecyclePort.createInstance(any(VmCreateCommand.class))).thenReturn(expectedInstanceId);
+        when(resourceHelper.extractResourceName(any(), eq(expectedInstanceId))).thenReturn(expectedInstanceId);
+        when(resourceHelper.registerVmInstance(
+                any(), anyString(), anyString(), anyString(), anyString(), any()
+        )).thenReturn(expectedCloudResource);
 
         // When
-        String result = vmUseCaseService.createInstance(request);
+        CloudResource result = vmUseCaseService.createInstance(request);
 
         // Then
-        assertThat(result).isEqualTo(expectedInstanceId);
+        assertThat(result).isNotNull();
+        assertThat(result.getResourceId()).isEqualTo(expectedInstanceId);
 
         // 포트 호출 확인
         verify(vmLifecyclePort).createInstance(any(VmCreateCommand.class));
@@ -112,13 +124,23 @@ class VmUseCaseServiceCreateTest {
             .build();
 
         String expectedInstanceId = "i-abcdef1234567890";
+        CloudResource expectedCloudResource = CloudResource.builder()
+                .resourceId(expectedInstanceId)
+                .resourceName(expectedInstanceId)
+                .build();
+
         when(vmLifecyclePort.createInstance(any(VmCreateCommand.class))).thenReturn(expectedInstanceId);
+        when(resourceHelper.extractResourceName(any(), eq(expectedInstanceId))).thenReturn(expectedInstanceId);
+        when(resourceHelper.registerVmInstance(
+                any(), anyString(), anyString(), anyString(), anyString(), any()
+        )).thenReturn(expectedCloudResource);
 
         // When
-        String result = vmUseCaseService.createInstance(request);
+        CloudResource result = vmUseCaseService.createInstance(request);
 
         // Then
-        assertThat(result).isEqualTo(expectedInstanceId);
+        assertThat(result).isNotNull();
+        assertThat(result.getResourceId()).isEqualTo(expectedInstanceId);
 
         // 포트 호출 확인
         verify(vmLifecyclePort).createInstance(any(VmCreateCommand.class));
@@ -169,13 +191,24 @@ class VmUseCaseServiceCreateTest {
             .build();
 
         String expectedInstanceId = "i-tagged1234567890";
+        CloudResource expectedCloudResource = CloudResource.builder()
+                .resourceId(expectedInstanceId)
+                .resourceName("test-instance")
+                .build();
+
         when(vmLifecyclePort.createInstance(any(VmCreateCommand.class))).thenReturn(expectedInstanceId);
+        when(resourceHelper.extractResourceName(any(), eq(expectedInstanceId))).thenReturn("test-instance");
+        when(resourceHelper.registerVmInstance(
+                any(), anyString(), anyString(), anyString(), anyString(), any()
+        )).thenReturn(expectedCloudResource);
 
         // When
-        String result = vmUseCaseService.createInstance(request);
+        CloudResource result = vmUseCaseService.createInstance(request);
 
         // Then
-        assertThat(result).isEqualTo(expectedInstanceId);
+        assertThat(result).isNotNull();
+        assertThat(result.getResourceId()).isEqualTo(expectedInstanceId);
+        assertThat(result.getResourceName()).isEqualTo("test-instance");
 
         // 포트 호출 확인
         verify(vmLifecyclePort).createInstance(any(VmCreateCommand.class));

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/aws/VmUseCaseServiceCreateTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/aws/VmUseCaseServiceCreateTest.java
@@ -96,8 +96,8 @@ class VmUseCaseServiceCreateTest {
 
         when(vmLifecyclePort.createInstance(any(VmCreateCommand.class))).thenReturn(expectedInstanceId);
         when(resourceHelper.extractResourceName(any(), eq(expectedInstanceId))).thenReturn(expectedInstanceId);
-        when(resourceHelper.registerVmInstance(
-                any(), anyString(), anyString(), anyString(), anyString(), any()
+        when(resourceHelper.registerResource(
+                any(), anyString(), any()
         )).thenReturn(expectedCloudResource);
 
         // When
@@ -131,8 +131,8 @@ class VmUseCaseServiceCreateTest {
 
         when(vmLifecyclePort.createInstance(any(VmCreateCommand.class))).thenReturn(expectedInstanceId);
         when(resourceHelper.extractResourceName(any(), eq(expectedInstanceId))).thenReturn(expectedInstanceId);
-        when(resourceHelper.registerVmInstance(
-                any(), anyString(), anyString(), anyString(), anyString(), any()
+        when(resourceHelper.registerResource(
+                any(), anyString(), any()
         )).thenReturn(expectedCloudResource);
 
         // When
@@ -198,8 +198,8 @@ class VmUseCaseServiceCreateTest {
 
         when(vmLifecyclePort.createInstance(any(VmCreateCommand.class))).thenReturn(expectedInstanceId);
         when(resourceHelper.extractResourceName(any(), eq(expectedInstanceId))).thenReturn("test-instance");
-        when(resourceHelper.registerVmInstance(
-                any(), anyString(), anyString(), anyString(), anyString(), any()
+        when(resourceHelper.registerResource(
+                any(), anyString(), any()
         )).thenReturn(expectedCloudResource);
 
         // When

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/aws/VmUseCaseServiceCreateTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/aws/VmUseCaseServiceCreateTest.java
@@ -7,8 +7,13 @@ import com.agenticcp.core.domain.cloud.dto.VmCreateRequest;
 import com.agenticcp.core.domain.cloud.port.model.vm.VmCreateCommand;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
 import com.agenticcp.core.domain.cloud.port.outbound.vm.VmLifecyclePort;
+import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
 import com.agenticcp.core.domain.cloud.service.vm.VmPortRouter;
 import com.agenticcp.core.domain.cloud.service.vm.VmUseCaseService;
+import com.agenticcp.core.domain.tenant.repository.TenantRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,12 +50,36 @@ class VmUseCaseServiceCreateTest {
     @Mock
     private AccountCredentialManagementPort credentialProviderPort;
 
+    @Mock
+    private CloudResourceRepository cloudResourceRepository;
+
+    @Mock
+    private CloudProviderRepository cloudProviderRepository;
+
+    @Mock
+    private CloudServiceRepository cloudServiceRepository;
+
+    @Mock
+    private TenantRepository tenantRepository;
+
+    private ObjectMapper objectMapper;
+
     private VmUseCaseService vmUseCaseService;
 
     @BeforeEach
     void setUp() {
         TenantContextHolder.setTenantKey("tenant-test");
-        vmUseCaseService = new VmUseCaseService(vmPortRouter, capabilityGuard, credentialProviderPort);
+        objectMapper = new ObjectMapper();
+        vmUseCaseService = new VmUseCaseService(
+                vmPortRouter,
+                capabilityGuard,
+                credentialProviderPort,
+                cloudResourceRepository,
+                cloudProviderRepository,
+                cloudServiceRepository,
+                tenantRepository,
+                objectMapper
+        );
 
         when(vmPortRouter.lifecycle(ProviderType.AWS)).thenReturn(vmLifecyclePort);
         when(credentialProviderPort.getSession(anyString(), anyString(), any())).thenReturn(null);

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/aws/VmUseCaseServiceLifecycleTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/aws/VmUseCaseServiceLifecycleTest.java
@@ -8,8 +8,13 @@ import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential
 import com.agenticcp.core.domain.cloud.port.model.vm.VmDeleteCommand;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
 import com.agenticcp.core.domain.cloud.port.outbound.vm.VmLifecyclePort;
+import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
 import com.agenticcp.core.domain.cloud.service.vm.VmPortRouter;
 import com.agenticcp.core.domain.cloud.service.vm.VmUseCaseService;
+import com.agenticcp.core.domain.tenant.repository.TenantRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,6 +53,20 @@ class VmUseCaseServiceLifecycleTest {
     @Mock
     private AccountCredentialManagementPort credentialProviderPort;
 
+    @Mock
+    private CloudResourceRepository cloudResourceRepository;
+
+    @Mock
+    private CloudProviderRepository cloudProviderRepository;
+
+    @Mock
+    private CloudServiceRepository cloudServiceRepository;
+
+    @Mock
+    private TenantRepository tenantRepository;
+
+    private ObjectMapper objectMapper;
+
     private VmUseCaseService vmUseCaseService;
 
     private CloudSessionCredential mockSession;
@@ -57,7 +76,17 @@ class VmUseCaseServiceLifecycleTest {
     @BeforeEach
     void setUp() {
         TenantContextHolder.setTenantKey("tenant-test");
-        vmUseCaseService = new VmUseCaseService(vmPortRouter, capabilityGuard, credentialProviderPort);
+        objectMapper = new ObjectMapper();
+        vmUseCaseService = new VmUseCaseService(
+                vmPortRouter,
+                capabilityGuard,
+                credentialProviderPort,
+                cloudResourceRepository,
+                cloudProviderRepository,
+                cloudServiceRepository,
+                tenantRepository,
+                objectMapper
+        );
         mockSession = mock(CloudSessionCredential.class);
 
         when(vmPortRouter.lifecycle(ProviderType.AWS)).thenReturn(vmLifecyclePort);

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/aws/VmUseCaseServiceLifecycleTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/aws/VmUseCaseServiceLifecycleTest.java
@@ -8,13 +8,9 @@ import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential
 import com.agenticcp.core.domain.cloud.port.model.vm.VmDeleteCommand;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
 import com.agenticcp.core.domain.cloud.port.outbound.vm.VmLifecyclePort;
-import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
+import com.agenticcp.core.domain.cloud.service.helper.CloudResourceManagementHelper;
 import com.agenticcp.core.domain.cloud.service.vm.VmPortRouter;
 import com.agenticcp.core.domain.cloud.service.vm.VmUseCaseService;
-import com.agenticcp.core.domain.tenant.repository.TenantRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,18 +50,7 @@ class VmUseCaseServiceLifecycleTest {
     private AccountCredentialManagementPort credentialProviderPort;
 
     @Mock
-    private CloudResourceRepository cloudResourceRepository;
-
-    @Mock
-    private CloudProviderRepository cloudProviderRepository;
-
-    @Mock
-    private CloudServiceRepository cloudServiceRepository;
-
-    @Mock
-    private TenantRepository tenantRepository;
-
-    private ObjectMapper objectMapper;
+    private CloudResourceManagementHelper resourceHelper;
 
     private VmUseCaseService vmUseCaseService;
 
@@ -76,16 +61,11 @@ class VmUseCaseServiceLifecycleTest {
     @BeforeEach
     void setUp() {
         TenantContextHolder.setTenantKey("tenant-test");
-        objectMapper = new ObjectMapper();
         vmUseCaseService = new VmUseCaseService(
                 vmPortRouter,
                 capabilityGuard,
                 credentialProviderPort,
-                cloudResourceRepository,
-                cloudProviderRepository,
-                cloudServiceRepository,
-                tenantRepository,
-                objectMapper
+                resourceHelper
         );
         mockSession = mock(CloudSessionCredential.class);
 

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/aws/VmUseCaseServiceTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/aws/VmUseCaseServiceTest.java
@@ -10,8 +10,13 @@ import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialMa
 import com.agenticcp.core.domain.cloud.port.outbound.vm.VmDiscoveryPort;
 import com.agenticcp.core.domain.cloud.port.outbound.vm.VmLifecyclePort;
 import com.agenticcp.core.domain.cloud.port.outbound.vm.VmTaggingPort;
+import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
 import com.agenticcp.core.domain.cloud.service.vm.VmPortRouter;
 import com.agenticcp.core.domain.cloud.service.vm.VmUseCaseService;
+import com.agenticcp.core.domain.tenant.repository.TenantRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
@@ -58,6 +63,20 @@ class VmUseCaseServiceTest {
     @Mock
     private AccountCredentialManagementPort credentialProviderPort;
 
+    @Mock
+    private CloudResourceRepository cloudResourceRepository;
+
+    @Mock
+    private CloudProviderRepository cloudProviderRepository;
+
+    @Mock
+    private CloudServiceRepository cloudServiceRepository;
+
+    @Mock
+    private TenantRepository tenantRepository;
+
+    private ObjectMapper objectMapper;
+
     private VmUseCaseService vmUseCaseService;
     private CloudSessionCredential mockSession;
     private static final ProviderType PROVIDER_TYPE = ProviderType.AWS;
@@ -66,7 +85,17 @@ class VmUseCaseServiceTest {
     @BeforeEach
     void setUp() {
         TenantContextHolder.setTenantKey("tenant-test");
-        vmUseCaseService = new VmUseCaseService(vmPortRouter, capabilityGuard, credentialProviderPort);
+        objectMapper = new ObjectMapper();
+        vmUseCaseService = new VmUseCaseService(
+                vmPortRouter,
+                capabilityGuard,
+                credentialProviderPort,
+                cloudResourceRepository,
+                cloudProviderRepository,
+                cloudServiceRepository,
+                tenantRepository,
+                objectMapper
+        );
         mockSession = mock(CloudSessionCredential.class);
 
         when(vmPortRouter.discovery(ProviderType.AWS)).thenReturn(vmDiscoveryPort);

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/aws/VmUseCaseServiceTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/aws/VmUseCaseServiceTest.java
@@ -10,13 +10,9 @@ import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialMa
 import com.agenticcp.core.domain.cloud.port.outbound.vm.VmDiscoveryPort;
 import com.agenticcp.core.domain.cloud.port.outbound.vm.VmLifecyclePort;
 import com.agenticcp.core.domain.cloud.port.outbound.vm.VmTaggingPort;
-import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
+import com.agenticcp.core.domain.cloud.service.helper.CloudResourceManagementHelper;
 import com.agenticcp.core.domain.cloud.service.vm.VmPortRouter;
 import com.agenticcp.core.domain.cloud.service.vm.VmUseCaseService;
-import com.agenticcp.core.domain.tenant.repository.TenantRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
@@ -64,18 +60,7 @@ class VmUseCaseServiceTest {
     private AccountCredentialManagementPort credentialProviderPort;
 
     @Mock
-    private CloudResourceRepository cloudResourceRepository;
-
-    @Mock
-    private CloudProviderRepository cloudProviderRepository;
-
-    @Mock
-    private CloudServiceRepository cloudServiceRepository;
-
-    @Mock
-    private TenantRepository tenantRepository;
-
-    private ObjectMapper objectMapper;
+    private CloudResourceManagementHelper resourceHelper;
 
     private VmUseCaseService vmUseCaseService;
     private CloudSessionCredential mockSession;
@@ -85,16 +70,11 @@ class VmUseCaseServiceTest {
     @BeforeEach
     void setUp() {
         TenantContextHolder.setTenantKey("tenant-test");
-        objectMapper = new ObjectMapper();
         vmUseCaseService = new VmUseCaseService(
                 vmPortRouter,
                 capabilityGuard,
                 credentialProviderPort,
-                cloudResourceRepository,
-                cloudProviderRepository,
-                cloudServiceRepository,
-                tenantRepository,
-                objectMapper
+                resourceHelper
         );
         mockSession = mock(CloudSessionCredential.class);
 

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseServiceDbSyncTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseServiceDbSyncTest.java
@@ -3,8 +3,10 @@ package com.agenticcp.core.domain.cloud.service.storage;
 import com.agenticcp.core.common.context.TenantContextHolder;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.CreateObjectStorageContainerRequest;
+import com.agenticcp.core.common.exception.BusinessException;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
 import com.agenticcp.core.domain.cloud.port.outbound.storage.ObjectStorageDiscoveryPort;
@@ -23,6 +25,7 @@ import java.time.LocalDateTime;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -131,8 +134,8 @@ class ObjectStorageUseCaseServiceDbSyncTest {
         }
 
         @Test
-        @DisplayName("DB 저장 실패 시에도 CSP 생성은 성공한다")
-        void createContainer_DbSaveFails_CspCreationSucceeds() {
+        @DisplayName("DB 저장 실패 시 보상 트랜잭션이 실행되고 예외가 발생한다")
+        void createContainer_DbSaveFails_CompensatingTransactionExecuted() {
             // Given
             CreateObjectStorageContainerRequest request = CreateObjectStorageContainerRequest.builder()
                     .providerType(PROVIDER_TYPE)
@@ -147,16 +150,53 @@ class ObjectStorageUseCaseServiceDbSyncTest {
                     .build();
 
             when(managementPort.createContainer(any())).thenReturn(mockCreatedContainer);
-            // Helper 내부에서 예외 발생해도 경고 로그만 출력되고 계속 진행됨
+            // DB 저장 실패
             doThrow(new RuntimeException("DB 저장 실패")).when(resourceHelper)
                     .registerStorageBucket(any(), any(), any(), any());
 
-            // When
-            CloudResource result = objectStorageUseCaseService.createContainer(request);
+            // When & Then
+            assertThatThrownBy(() -> objectStorageUseCaseService.createContainer(request))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(exception -> {
+                        BusinessException be = (BusinessException) exception;
+                        assertThat(be.getErrorCode()).isEqualTo(CloudErrorCode.RESOURCE_CREATION_FAILED);
+                    });
 
-            // Then
-            assertThat(result).isNotNull(); // CSP 생성은 성공
-            verify(resourceHelper).registerStorageBucket(any(), any(), any(), any());
+            // 보상 트랜잭션 실행 검증: CSP 컨테이너 삭제 호출됨
+            verify(managementPort).deleteContainer(any(), eq(CONTAINER_NAME));
+        }
+
+        @Test
+        @DisplayName("보상 트랜잭션도 실패하면 Ghost Resource 경고 로그가 출력된다")
+        void createContainer_CompensationFails_GhostResourceWarningLogged() {
+            // Given
+            CreateObjectStorageContainerRequest request = CreateObjectStorageContainerRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .containerName(CONTAINER_NAME)
+                    .region("us-east-1")
+                    .build();
+
+            CloudResource mockCreatedContainer = CloudResource.builder()
+                    .resourceId(CONTAINER_NAME)
+                    .resourceName(CONTAINER_NAME)
+                    .build();
+
+            when(managementPort.createContainer(any())).thenReturn(mockCreatedContainer);
+            // DB 저장 실패
+            doThrow(new RuntimeException("DB 저장 실패")).when(resourceHelper)
+                    .registerStorageBucket(any(), any(), any(), any());
+            // 보상 트랜잭션(CSP 삭제)도 실패
+            doThrow(new RuntimeException("CSP 삭제 실패")).when(managementPort)
+                    .deleteContainer(any(), eq(CONTAINER_NAME));
+
+            // When & Then
+            assertThatThrownBy(() -> objectStorageUseCaseService.createContainer(request))
+                    .isInstanceOf(BusinessException.class);
+
+            // 보상 트랜잭션 시도 검증
+            verify(managementPort).deleteContainer(any(), eq(CONTAINER_NAME));
+            // Ghost Resource 발생 - 실제로는 모니터링/배치로 처리 필요
         }
     }
 

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseServiceDbSyncTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseServiceDbSyncTest.java
@@ -1,0 +1,261 @@
+package com.agenticcp.core.domain.cloud.service.storage;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
+import com.agenticcp.core.domain.cloud.dto.CreateObjectStorageContainerRequest;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.ResourceType;
+import com.agenticcp.core.domain.cloud.entity.CloudService;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
+import com.agenticcp.core.domain.cloud.port.outbound.storage.ObjectStorageDiscoveryPort;
+import com.agenticcp.core.domain.cloud.port.outbound.storage.ObjectStorageManagementPort;
+import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import com.agenticcp.core.domain.tenant.repository.TenantRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * ObjectStorageUseCaseService DB 동기화 로직 단위 테스트
+ * CSP 작업 후 CloudResource 엔티티가 올바르게 DB에 저장/삭제되는지 검증합니다.
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ObjectStorageUseCaseService DB 동기화 테스트")
+class ObjectStorageUseCaseServiceDbSyncTest {
+
+    @Mock
+    private ObjectStoragePortRouter router;
+
+    @Mock
+    private ObjectStorageManagementPort managementPort;
+
+    @Mock
+    private ObjectStorageDiscoveryPort discoveryPort;
+
+    @Mock
+    private CapabilityGuard capabilityGuard;
+
+    @Mock
+    private AccountCredentialManagementPort accountCredentialManagementPort;
+
+    @Mock
+    private CloudResourceRepository cloudResourceRepository;
+
+    @Mock
+    private CloudProviderRepository cloudProviderRepository;
+
+    @Mock
+    private CloudServiceRepository cloudServiceRepository;
+
+    @Mock
+    private TenantRepository tenantRepository;
+
+    private ObjectMapper objectMapper;
+
+    private ObjectStorageUseCaseService objectStorageUseCaseService;
+    private CloudSessionCredential mockSession;
+
+    private static final ProviderType PROVIDER_TYPE = ProviderType.AWS;
+    private static final String ACCOUNT_SCOPE = "123456789012";
+    private static final String TENANT_KEY = "tenant-test";
+    private static final String CONTAINER_NAME = "my-test-bucket";
+
+    @BeforeEach
+    void setUp() {
+        TenantContextHolder.setTenantKey(TENANT_KEY);
+        objectMapper = new ObjectMapper();
+        
+        objectStorageUseCaseService = new ObjectStorageUseCaseService(
+                router,
+                capabilityGuard,
+                accountCredentialManagementPort,
+                cloudResourceRepository,
+                cloudProviderRepository,
+                cloudServiceRepository,
+                tenantRepository,
+                objectMapper
+        );
+        
+        mockSession = mock(CloudSessionCredential.class);
+        when(mockSession.getExpiresAt()).thenReturn(LocalDateTime.now().plusHours(1));
+
+        // 공통 Mock 설정
+        lenient().when(router.management(PROVIDER_TYPE)).thenReturn(managementPort);
+        lenient().when(router.discovery(PROVIDER_TYPE)).thenReturn(discoveryPort);
+        lenient().when(accountCredentialManagementPort.getSession(eq(TENANT_KEY), eq(ACCOUNT_SCOPE), eq(PROVIDER_TYPE)))
+                .thenReturn(mockSession);
+        lenient().doNothing().when(capabilityGuard).ensureSupported(any(), anyString(), anyString(), any());
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContextHolder.clear();
+    }
+
+    @Nested
+    @DisplayName("컨테이너 생성 테스트")
+    class CreateContainerTest {
+
+        @Test
+        @DisplayName("컨테이너 생성 성공 시 CloudResource가 DB에 저장된다")
+        void createContainer_Success_SavesCloudResource() {
+            // Given
+            CreateObjectStorageContainerRequest request = CreateObjectStorageContainerRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .containerName(CONTAINER_NAME)
+                    .region("us-east-1")
+                    .tags(Map.of("Environment", "test"))
+                    .build();
+
+            CloudResource mockCreatedContainer = CloudResource.builder()
+                    .resourceId(CONTAINER_NAME)
+                    .resourceName(CONTAINER_NAME)
+                    .build();
+
+            CloudProvider mockProvider = CloudProvider.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .providerName("AWS")
+                    .build();
+
+            CloudService mockService = CloudService.builder()
+                    .serviceKey("S3")
+                    .build();
+
+            Tenant mockTenant = Tenant.builder()
+                    .tenantKey(TENANT_KEY)
+                    .build();
+
+            when(managementPort.createContainer(any())).thenReturn(mockCreatedContainer);
+            when(cloudProviderRepository.findFirstByProviderType(PROVIDER_TYPE))
+                    .thenReturn(Optional.of(mockProvider));
+            when(cloudServiceRepository.findByProviderTypeAndServiceKey(eq(PROVIDER_TYPE), eq("S3")))
+                    .thenReturn(Optional.of(mockService));
+            when(tenantRepository.findByTenantKey(TENANT_KEY))
+                    .thenReturn(Optional.of(mockTenant));
+            when(cloudResourceRepository.save(any(CloudResource.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            CloudResource result = objectStorageUseCaseService.createContainer(request);
+
+            // Then
+            assertThat(result).isNotNull();
+            
+            ArgumentCaptor<CloudResource> captor = ArgumentCaptor.forClass(CloudResource.class);
+            verify(cloudResourceRepository).save(captor.capture());
+            
+            CloudResource savedResource = captor.getValue();
+            assertThat(savedResource.getResourceId()).isEqualTo(CONTAINER_NAME);
+            assertThat(savedResource.getResourceName()).isEqualTo(CONTAINER_NAME);
+            assertThat(savedResource.getResourceType()).isEqualTo(ResourceType.BUCKET);
+            assertThat(savedResource.getLifecycleState()).isEqualTo(LifecycleState.RUNNING);
+            assertThat(savedResource.getProvider()).isEqualTo(mockProvider);
+            assertThat(savedResource.getTenant()).isEqualTo(mockTenant);
+        }
+
+        @Test
+        @DisplayName("DB 저장 실패 시에도 CSP 생성은 성공한다")
+        void createContainer_DbSaveFails_CspCreationSucceeds() {
+            // Given
+            CreateObjectStorageContainerRequest request = CreateObjectStorageContainerRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .containerName(CONTAINER_NAME)
+                    .region("us-east-1")
+                    .build();
+
+            CloudResource mockCreatedContainer = CloudResource.builder()
+                    .resourceId(CONTAINER_NAME)
+                    .resourceName(CONTAINER_NAME)
+                    .build();
+
+            when(managementPort.createContainer(any())).thenReturn(mockCreatedContainer);
+            when(cloudProviderRepository.findFirstByProviderType(PROVIDER_TYPE))
+                    .thenReturn(Optional.empty()); // Provider 없음 -> DB 저장 실패
+
+            // When
+            CloudResource result = objectStorageUseCaseService.createContainer(request);
+
+            // Then
+            assertThat(result).isNotNull(); // CSP 생성은 성공
+            verify(cloudResourceRepository, never()).save(any()); // DB 저장은 스킵됨
+        }
+    }
+
+    @Nested
+    @DisplayName("컨테이너 삭제 테스트")
+    class DeleteContainerTest {
+
+        @Test
+        @DisplayName("컨테이너 삭제 시 소프트 삭제가 수행된다")
+        void deleteContainer_Success_SoftDeletesResource() {
+            // Given
+            doNothing().when(managementPort).deleteContainer(any(), eq(CONTAINER_NAME));
+            when(cloudResourceRepository.softDeleteByResourceId(CONTAINER_NAME)).thenReturn(1);
+
+            // When
+            objectStorageUseCaseService.deleteContainer(PROVIDER_TYPE, ACCOUNT_SCOPE, CONTAINER_NAME);
+
+            // Then
+            verify(managementPort).deleteContainer(any(), eq(CONTAINER_NAME));
+            verify(cloudResourceRepository).softDeleteByResourceId(CONTAINER_NAME);
+        }
+
+        @Test
+        @DisplayName("강제 삭제 시 소프트 삭제가 수행된다")
+        void forceDeleteContainer_Success_SoftDeletesResource() {
+            // Given
+            doNothing().when(managementPort).forceDeleteContainer(eq(CONTAINER_NAME), any());
+            when(cloudResourceRepository.softDeleteByResourceId(CONTAINER_NAME)).thenReturn(1);
+
+            // When
+            objectStorageUseCaseService.forceDeleteContainer(PROVIDER_TYPE, ACCOUNT_SCOPE, CONTAINER_NAME);
+
+            // Then
+            verify(managementPort).forceDeleteContainer(eq(CONTAINER_NAME), any());
+            verify(cloudResourceRepository).softDeleteByResourceId(CONTAINER_NAME);
+        }
+
+        @Test
+        @DisplayName("DB에 리소스가 없어도 CSP 삭제는 성공한다")
+        void deleteContainer_ResourceNotInDb_CspDeletionSucceeds() {
+            // Given
+            doNothing().when(managementPort).deleteContainer(any(), eq(CONTAINER_NAME));
+            when(cloudResourceRepository.softDeleteByResourceId(CONTAINER_NAME)).thenReturn(0); // DB에 없음
+
+            // When
+            objectStorageUseCaseService.deleteContainer(PROVIDER_TYPE, ACCOUNT_SCOPE, CONTAINER_NAME);
+
+            // Then
+            verify(managementPort).deleteContainer(any(), eq(CONTAINER_NAME)); // CSP 작업 성공
+        }
+    }
+}

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseServiceDbSyncTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseServiceDbSyncTest.java
@@ -3,35 +3,24 @@ package com.agenticcp.core.domain.cloud.service.storage;
 import com.agenticcp.core.common.context.TenantContextHolder;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.CreateObjectStorageContainerRequest;
-import com.agenticcp.core.domain.cloud.entity.CloudProvider;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
-import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
-import com.agenticcp.core.domain.cloud.entity.CloudResource.ResourceType;
-import com.agenticcp.core.domain.cloud.entity.CloudService;
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
 import com.agenticcp.core.domain.cloud.port.outbound.storage.ObjectStorageDiscoveryPort;
 import com.agenticcp.core.domain.cloud.port.outbound.storage.ObjectStorageManagementPort;
-import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
-import com.agenticcp.core.domain.tenant.entity.Tenant;
-import com.agenticcp.core.domain.tenant.repository.TenantRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.agenticcp.core.domain.cloud.service.helper.CloudResourceManagementHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -66,18 +55,7 @@ class ObjectStorageUseCaseServiceDbSyncTest {
     private AccountCredentialManagementPort accountCredentialManagementPort;
 
     @Mock
-    private CloudResourceRepository cloudResourceRepository;
-
-    @Mock
-    private CloudProviderRepository cloudProviderRepository;
-
-    @Mock
-    private CloudServiceRepository cloudServiceRepository;
-
-    @Mock
-    private TenantRepository tenantRepository;
-
-    private ObjectMapper objectMapper;
+    private CloudResourceManagementHelper resourceHelper;
 
     private ObjectStorageUseCaseService objectStorageUseCaseService;
     private CloudSessionCredential mockSession;
@@ -90,17 +68,12 @@ class ObjectStorageUseCaseServiceDbSyncTest {
     @BeforeEach
     void setUp() {
         TenantContextHolder.setTenantKey(TENANT_KEY);
-        objectMapper = new ObjectMapper();
         
         objectStorageUseCaseService = new ObjectStorageUseCaseService(
                 router,
                 capabilityGuard,
                 accountCredentialManagementPort,
-                cloudResourceRepository,
-                cloudProviderRepository,
-                cloudServiceRepository,
-                tenantRepository,
-                objectMapper
+                resourceHelper
         );
         
         mockSession = mock(CloudSessionCredential.class);
@@ -127,12 +100,13 @@ class ObjectStorageUseCaseServiceDbSyncTest {
         @DisplayName("컨테이너 생성 성공 시 CloudResource가 DB에 저장된다")
         void createContainer_Success_SavesCloudResource() {
             // Given
+            Map<String, String> tags = Map.of("Environment", "test");
             CreateObjectStorageContainerRequest request = CreateObjectStorageContainerRequest.builder()
                     .providerType(PROVIDER_TYPE)
                     .accountScope(ACCOUNT_SCOPE)
                     .containerName(CONTAINER_NAME)
                     .region("us-east-1")
-                    .tags(Map.of("Environment", "test"))
+                    .tags(tags)
                     .build();
 
             CloudResource mockCreatedContainer = CloudResource.builder()
@@ -140,28 +114,7 @@ class ObjectStorageUseCaseServiceDbSyncTest {
                     .resourceName(CONTAINER_NAME)
                     .build();
 
-            CloudProvider mockProvider = CloudProvider.builder()
-                    .providerType(PROVIDER_TYPE)
-                    .providerName("AWS")
-                    .build();
-
-            CloudService mockService = CloudService.builder()
-                    .serviceKey("S3")
-                    .build();
-
-            Tenant mockTenant = Tenant.builder()
-                    .tenantKey(TENANT_KEY)
-                    .build();
-
             when(managementPort.createContainer(any())).thenReturn(mockCreatedContainer);
-            when(cloudProviderRepository.findFirstByProviderType(PROVIDER_TYPE))
-                    .thenReturn(Optional.of(mockProvider));
-            when(cloudServiceRepository.findByProviderTypeAndServiceKey(eq(PROVIDER_TYPE), eq("S3")))
-                    .thenReturn(Optional.of(mockService));
-            when(tenantRepository.findByTenantKey(TENANT_KEY))
-                    .thenReturn(Optional.of(mockTenant));
-            when(cloudResourceRepository.save(any(CloudResource.class)))
-                    .thenAnswer(invocation -> invocation.getArgument(0));
 
             // When
             CloudResource result = objectStorageUseCaseService.createContainer(request);
@@ -169,16 +122,12 @@ class ObjectStorageUseCaseServiceDbSyncTest {
             // Then
             assertThat(result).isNotNull();
             
-            ArgumentCaptor<CloudResource> captor = ArgumentCaptor.forClass(CloudResource.class);
-            verify(cloudResourceRepository).save(captor.capture());
-            
-            CloudResource savedResource = captor.getValue();
-            assertThat(savedResource.getResourceId()).isEqualTo(CONTAINER_NAME);
-            assertThat(savedResource.getResourceName()).isEqualTo(CONTAINER_NAME);
-            assertThat(savedResource.getResourceType()).isEqualTo(ResourceType.BUCKET);
-            assertThat(savedResource.getLifecycleState()).isEqualTo(LifecycleState.RUNNING);
-            assertThat(savedResource.getProvider()).isEqualTo(mockProvider);
-            assertThat(savedResource.getTenant()).isEqualTo(mockTenant);
+            verify(resourceHelper).registerStorageBucket(
+                    eq(PROVIDER_TYPE),
+                    eq("S3"),
+                    eq(CONTAINER_NAME),
+                    eq(tags)
+            );
         }
 
         @Test
@@ -198,15 +147,16 @@ class ObjectStorageUseCaseServiceDbSyncTest {
                     .build();
 
             when(managementPort.createContainer(any())).thenReturn(mockCreatedContainer);
-            when(cloudProviderRepository.findFirstByProviderType(PROVIDER_TYPE))
-                    .thenReturn(Optional.empty()); // Provider 없음 -> DB 저장 실패
+            // Helper 내부에서 예외 발생해도 경고 로그만 출력되고 계속 진행됨
+            doThrow(new RuntimeException("DB 저장 실패")).when(resourceHelper)
+                    .registerStorageBucket(any(), any(), any(), any());
 
             // When
             CloudResource result = objectStorageUseCaseService.createContainer(request);
 
             // Then
             assertThat(result).isNotNull(); // CSP 생성은 성공
-            verify(cloudResourceRepository, never()).save(any()); // DB 저장은 스킵됨
+            verify(resourceHelper).registerStorageBucket(any(), any(), any(), any());
         }
     }
 
@@ -219,14 +169,13 @@ class ObjectStorageUseCaseServiceDbSyncTest {
         void deleteContainer_Success_SoftDeletesResource() {
             // Given
             doNothing().when(managementPort).deleteContainer(any(), eq(CONTAINER_NAME));
-            when(cloudResourceRepository.softDeleteByResourceId(CONTAINER_NAME)).thenReturn(1);
 
             // When
             objectStorageUseCaseService.deleteContainer(PROVIDER_TYPE, ACCOUNT_SCOPE, CONTAINER_NAME);
 
             // Then
             verify(managementPort).deleteContainer(any(), eq(CONTAINER_NAME));
-            verify(cloudResourceRepository).softDeleteByResourceId(CONTAINER_NAME);
+            verify(resourceHelper).softDeleteResource(CONTAINER_NAME);
         }
 
         @Test
@@ -234,14 +183,13 @@ class ObjectStorageUseCaseServiceDbSyncTest {
         void forceDeleteContainer_Success_SoftDeletesResource() {
             // Given
             doNothing().when(managementPort).forceDeleteContainer(eq(CONTAINER_NAME), any());
-            when(cloudResourceRepository.softDeleteByResourceId(CONTAINER_NAME)).thenReturn(1);
 
             // When
             objectStorageUseCaseService.forceDeleteContainer(PROVIDER_TYPE, ACCOUNT_SCOPE, CONTAINER_NAME);
 
             // Then
             verify(managementPort).forceDeleteContainer(eq(CONTAINER_NAME), any());
-            verify(cloudResourceRepository).softDeleteByResourceId(CONTAINER_NAME);
+            verify(resourceHelper).softDeleteResource(CONTAINER_NAME);
         }
 
         @Test
@@ -249,13 +197,14 @@ class ObjectStorageUseCaseServiceDbSyncTest {
         void deleteContainer_ResourceNotInDb_CspDeletionSucceeds() {
             // Given
             doNothing().when(managementPort).deleteContainer(any(), eq(CONTAINER_NAME));
-            when(cloudResourceRepository.softDeleteByResourceId(CONTAINER_NAME)).thenReturn(0); // DB에 없음
+            // Helper 내부에서 리소스가 없으면 로그만 출력하고 예외 발생 안함
 
             // When
             objectStorageUseCaseService.deleteContainer(PROVIDER_TYPE, ACCOUNT_SCOPE, CONTAINER_NAME);
 
             // Then
             verify(managementPort).deleteContainer(any(), eq(CONTAINER_NAME)); // CSP 작업 성공
+            verify(resourceHelper).softDeleteResource(CONTAINER_NAME);
         }
     }
 }

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseServiceDbSyncTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/storage/ObjectStorageUseCaseServiceDbSyncTest.java
@@ -3,6 +3,7 @@ package com.agenticcp.core.domain.cloud.service.storage;
 import com.agenticcp.core.common.context.TenantContextHolder;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.CreateObjectStorageContainerRequest;
+import com.agenticcp.core.domain.cloud.dto.ResourceRegistrationRequest;
 import com.agenticcp.core.common.exception.BusinessException;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
@@ -125,11 +126,10 @@ class ObjectStorageUseCaseServiceDbSyncTest {
             // Then
             assertThat(result).isNotNull();
             
-            verify(resourceHelper).registerStorageBucket(
+            verify(resourceHelper).registerResource(
                     eq(PROVIDER_TYPE),
                     eq("S3"),
-                    eq(CONTAINER_NAME),
-                    eq(tags)
+                    any(ResourceRegistrationRequest.class)
             );
         }
 
@@ -152,7 +152,7 @@ class ObjectStorageUseCaseServiceDbSyncTest {
             when(managementPort.createContainer(any())).thenReturn(mockCreatedContainer);
             // DB 저장 실패
             doThrow(new RuntimeException("DB 저장 실패")).when(resourceHelper)
-                    .registerStorageBucket(any(), any(), any(), any());
+                    .registerResource(any(), any(), any());
 
             // When & Then
             assertThatThrownBy(() -> objectStorageUseCaseService.createContainer(request))
@@ -185,7 +185,7 @@ class ObjectStorageUseCaseServiceDbSyncTest {
             when(managementPort.createContainer(any())).thenReturn(mockCreatedContainer);
             // DB 저장 실패
             doThrow(new RuntimeException("DB 저장 실패")).when(resourceHelper)
-                    .registerStorageBucket(any(), any(), any(), any());
+                    .registerResource(any(), any(), any());
             // 보상 트랜잭션(CSP 삭제)도 실패
             doThrow(new RuntimeException("CSP 삭제 실패")).when(managementPort)
                     .deleteContainer(any(), eq(CONTAINER_NAME));

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/storage/S3BucketUseCaseServiceTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/storage/S3BucketUseCaseServiceTest.java
@@ -13,6 +13,7 @@ import com.agenticcp.core.domain.cloud.port.model.storage.*;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
 import com.agenticcp.core.domain.cloud.port.outbound.storage.ObjectStorageDiscoveryPort;
 import com.agenticcp.core.domain.cloud.port.outbound.storage.ObjectStorageManagementPort;
+import com.agenticcp.core.domain.cloud.service.helper.CloudResourceManagementHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -60,6 +61,9 @@ class S3BucketUseCaseServiceTest {
 
     @Mock
     private ObjectStorageDiscoveryPort discoveryPort;
+
+    @Mock
+    private CloudResourceManagementHelper resourceHelper;
 
     @InjectMocks
     private ObjectStorageUseCaseService objectStorageUseCaseService;
@@ -124,6 +128,7 @@ class S3BucketUseCaseServiceTest {
                 mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
                 when(accountCredentialManagementPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
                 when(managementPort.createContainer(any(CreateObjectStorageContainerCommand.class))).thenReturn(expectedContainer);
+                doNothing().when(resourceHelper).registerStorageBucket(any(), any(), any(), any());
 
                 // When
                 CloudResource result = objectStorageUseCaseService.createContainer(request);
@@ -133,9 +138,10 @@ class S3BucketUseCaseServiceTest {
                 assertThat(result.getResourceName()).isEqualTo(CONTAINER_NAME);
                 assertThat(result.getResourceId()).isEqualTo("container-" + CONTAINER_NAME);
 
-                verify(capabilityGuard).ensureSupported(AWS, "OBJECT_STORAGE", "CONTAINER", CapabilityGuard.Operation.TAGGING);
+                verify(capabilityGuard).ensureSupported(AWS, "S3", "BUCKET", CapabilityGuard.Operation.TAGGING);
                 verify(accountCredentialManagementPort).getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS);
                 verify(managementPort).createContainer(any(CreateObjectStorageContainerCommand.class));
+                verify(resourceHelper).registerStorageBucket(eq(AWS), eq("S3"), eq(CONTAINER_NAME), any());
             }
         }
 
@@ -151,7 +157,7 @@ class S3BucketUseCaseServiceTest {
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("Capability not supported");
 
-            verify(capabilityGuard).ensureSupported(AWS, "OBJECT_STORAGE", "CONTAINER", CapabilityGuard.Operation.TAGGING);
+            verify(capabilityGuard).ensureSupported(AWS, "S3", "BUCKET", CapabilityGuard.Operation.TAGGING);
             verify(accountCredentialManagementPort, never()).getSession(any(), any(), any());
             verify(managementPort, never()).createContainer(any());
         }
@@ -171,7 +177,7 @@ class S3BucketUseCaseServiceTest {
                         .hasMessageContaining("Invalid credentials");
 
                 verify(accountCredentialManagementPort).getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS);
-                verify(capabilityGuard).ensureSupported(AWS, "OBJECT_STORAGE", "CONTAINER", CapabilityGuard.Operation.TAGGING);
+                verify(capabilityGuard).ensureSupported(AWS, "S3", "BUCKET", CapabilityGuard.Operation.TAGGING);
                 verify(managementPort, never()).createContainer(any());
             }
         }
@@ -223,7 +229,7 @@ class S3BucketUseCaseServiceTest {
                 assertThat(result.getDisplayName()).isEqualTo("Updated Test Container");
 
                 verify(accountCredentialManagementPort).getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS);
-                verify(capabilityGuard).ensureSupported(AWS, "OBJECT_STORAGE", "CONTAINER", CapabilityGuard.Operation.TAGGING);
+                verify(capabilityGuard).ensureSupported(AWS, "S3", "BUCKET", CapabilityGuard.Operation.TAGGING);
                 verify(managementPort).updateContainer(any(UpdateObjectStorageContainerCommand.class));
             }
         }
@@ -392,14 +398,16 @@ class S3BucketUseCaseServiceTest {
                 mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
                 when(accountCredentialManagementPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
                 doNothing().when(managementPort).deleteContainer(any(CloudSessionCredential.class), eq(CONTAINER_NAME));
+                doNothing().when(resourceHelper).softDeleteResource(eq(CONTAINER_NAME));
 
                 // When
                 objectStorageUseCaseService.deleteContainer(AWS, ACCOUNT_SCOPE, CONTAINER_NAME);
 
                 // Then
-                verify(capabilityGuard).ensureSupported(AWS, "OBJECT_STORAGE", "CONTAINER", CapabilityGuard.Operation.TERMINATE);
+                verify(capabilityGuard).ensureSupported(AWS, "S3", "BUCKET", CapabilityGuard.Operation.TERMINATE);
                 verify(accountCredentialManagementPort).getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS);
                 verify(managementPort).deleteContainer(mockSession, CONTAINER_NAME);
+                verify(resourceHelper).softDeleteResource(CONTAINER_NAME);
             }
         }
 
@@ -415,7 +423,7 @@ class S3BucketUseCaseServiceTest {
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("Delete capability not supported");
 
-            verify(capabilityGuard).ensureSupported(AWS, "OBJECT_STORAGE", "CONTAINER", CapabilityGuard.Operation.TERMINATE);
+            verify(capabilityGuard).ensureSupported(AWS, "S3", "BUCKET", CapabilityGuard.Operation.TERMINATE);
             verify(accountCredentialManagementPort, never()).getSession(any(), any(), any());
             verify(managementPort, never()).deleteContainer(any(), any());
         }
@@ -433,14 +441,16 @@ class S3BucketUseCaseServiceTest {
                 mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
                 when(accountCredentialManagementPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
                 doNothing().when(managementPort).forceDeleteContainer(eq(CONTAINER_NAME), any(CloudSessionCredential.class));
+                doNothing().when(resourceHelper).softDeleteResource(eq(CONTAINER_NAME));
 
                 // When
                 objectStorageUseCaseService.forceDeleteContainer(AWS, ACCOUNT_SCOPE, CONTAINER_NAME);
 
                 // Then
-                verify(capabilityGuard).ensureSupported(AWS, "OBJECT_STORAGE", "CONTAINER", CapabilityGuard.Operation.TERMINATE);
+                verify(capabilityGuard).ensureSupported(AWS, "S3", "BUCKET", CapabilityGuard.Operation.TERMINATE);
                 verify(accountCredentialManagementPort).getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS);
                 verify(managementPort).forceDeleteContainer(CONTAINER_NAME, mockSession);
+                verify(resourceHelper).softDeleteResource(CONTAINER_NAME);
             }
         }
 
@@ -458,7 +468,7 @@ class S3BucketUseCaseServiceTest {
                         .isInstanceOf(RuntimeException.class)
                         .hasMessageContaining("Invalid credentials for force delete");
 
-                verify(capabilityGuard).ensureSupported(AWS, "OBJECT_STORAGE", "CONTAINER", CapabilityGuard.Operation.TERMINATE);
+                verify(capabilityGuard).ensureSupported(AWS, "S3", "BUCKET", CapabilityGuard.Operation.TERMINATE);
                 verify(accountCredentialManagementPort).getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS);
                 verify(managementPort, never()).forceDeleteContainer(any(), any());
             }

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/storage/S3BucketUseCaseServiceTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/storage/S3BucketUseCaseServiceTest.java
@@ -128,7 +128,7 @@ class S3BucketUseCaseServiceTest {
                 mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
                 when(accountCredentialManagementPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
                 when(managementPort.createContainer(any(CreateObjectStorageContainerCommand.class))).thenReturn(expectedContainer);
-                doNothing().when(resourceHelper).registerStorageBucket(any(), any(), any(), any());
+                when(resourceHelper.registerResource(any(), any(), any())).thenReturn(expectedContainer);
 
                 // When
                 CloudResource result = objectStorageUseCaseService.createContainer(request);
@@ -141,7 +141,7 @@ class S3BucketUseCaseServiceTest {
                 verify(capabilityGuard).ensureSupported(AWS, "S3", "BUCKET", CapabilityGuard.Operation.TAGGING);
                 verify(accountCredentialManagementPort).getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS);
                 verify(managementPort).createContainer(any(CreateObjectStorageContainerCommand.class));
-                verify(resourceHelper).registerStorageBucket(eq(AWS), eq("S3"), eq(CONTAINER_NAME), any());
+                verify(resourceHelper).registerResource(eq(AWS), eq("S3"), any());
             }
         }
 

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseServiceDbSyncTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseServiceDbSyncTest.java
@@ -6,6 +6,7 @@ import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.VmCreateRequest;
 import com.agenticcp.core.domain.cloud.dto.VmDeleteRequest;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
 import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
 import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
@@ -118,14 +119,29 @@ class VmUseCaseServiceDbSyncTest {
                     .tags(tags)
                     .build();
 
+            CloudResource mockCloudResource = CloudResource.builder()
+                    .resourceId(INSTANCE_ID)
+                    .resourceName("test-instance")
+                    .build();
+
             when(vmLifecyclePort.createInstance(any())).thenReturn(INSTANCE_ID);
             when(resourceHelper.extractResourceName(tags, INSTANCE_ID)).thenReturn("test-instance");
+            when(resourceHelper.registerVmInstance(
+                    eq(PROVIDER_TYPE),
+                    eq("EC2"),
+                    eq(INSTANCE_ID),
+                    eq("test-instance"),
+                    eq("t3.micro"),
+                    eq(tags)
+            )).thenReturn(mockCloudResource);
 
             // When
-            String result = vmUseCaseService.createInstance(request);
+            CloudResource result = vmUseCaseService.createInstance(request);
 
             // Then
-            assertThat(result).isEqualTo(INSTANCE_ID);
+            assertThat(result).isNotNull();
+            assertThat(result.getResourceId()).isEqualTo(INSTANCE_ID);
+            assertThat(result.getResourceName()).isEqualTo("test-instance");
             
             verify(resourceHelper).registerVmInstance(
                     eq(PROVIDER_TYPE),

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseServiceDbSyncTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseServiceDbSyncTest.java
@@ -1,11 +1,13 @@
 package com.agenticcp.core.domain.cloud.service.vm;
 
 import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.common.exception.BusinessException;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.VmCreateRequest;
 import com.agenticcp.core.domain.cloud.dto.VmDeleteRequest;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
+import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
 import com.agenticcp.core.domain.cloud.port.outbound.vm.VmDiscoveryPort;
@@ -25,6 +27,7 @@ import java.time.LocalDateTime;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -135,8 +138,8 @@ class VmUseCaseServiceDbSyncTest {
         }
 
         @Test
-        @DisplayName("DB 저장 실패 시에도 CSP 생성은 성공한다")
-        void createInstance_DbSaveFails_CspCreationSucceeds() {
+        @DisplayName("DB 저장 실패 시 보상 트랜잭션이 실행되고 예외가 발생한다")
+        void createInstance_DbSaveFails_CompensatingTransactionExecuted() {
             // Given
             VmCreateRequest request = VmCreateRequest.builder()
                     .providerType(PROVIDER_TYPE)
@@ -147,16 +150,20 @@ class VmUseCaseServiceDbSyncTest {
 
             when(vmLifecyclePort.createInstance(any())).thenReturn(INSTANCE_ID);
             when(resourceHelper.extractResourceName(any(), eq(INSTANCE_ID))).thenReturn(INSTANCE_ID);
-            // Helper 내부에서 예외 발생해도 경고 로그만 출력되고 계속 진행됨
+            // DB 저장 실패
             doThrow(new RuntimeException("DB 저장 실패")).when(resourceHelper)
                     .registerVmInstance(any(), any(), any(), any(), any(), any());
 
-            // When
-            String result = vmUseCaseService.createInstance(request);
+            // When & Then
+            assertThatThrownBy(() -> vmUseCaseService.createInstance(request))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(exception -> {
+                        BusinessException be = (BusinessException) exception;
+                        assertThat(be.getErrorCode()).isEqualTo(CloudErrorCode.RESOURCE_CREATION_FAILED);
+                    });
 
-            // Then
-            assertThat(result).isEqualTo(INSTANCE_ID); // CSP 생성은 성공
-            verify(resourceHelper).registerVmInstance(any(), any(), any(), any(), any(), any());
+            // 보상 트랜잭션 실행 검증: CSP 인스턴스 종료 호출됨
+            verify(vmLifecyclePort).terminateInstance(eq(INSTANCE_ID), any());
         }
     }
 

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseServiceDbSyncTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseServiceDbSyncTest.java
@@ -4,35 +4,25 @@ import com.agenticcp.core.common.context.TenantContextHolder;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.VmCreateRequest;
 import com.agenticcp.core.domain.cloud.dto.VmDeleteRequest;
-import com.agenticcp.core.domain.cloud.entity.CloudProvider;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
-import com.agenticcp.core.domain.cloud.entity.CloudResource;
 import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
-import com.agenticcp.core.domain.cloud.entity.CloudService;
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
 import com.agenticcp.core.domain.cloud.port.outbound.vm.VmDiscoveryPort;
 import com.agenticcp.core.domain.cloud.port.outbound.vm.VmLifecyclePort;
 import com.agenticcp.core.domain.cloud.port.outbound.vm.VmTaggingPort;
-import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
-import com.agenticcp.core.domain.tenant.entity.Tenant;
-import com.agenticcp.core.domain.tenant.repository.TenantRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.agenticcp.core.domain.cloud.service.helper.CloudResourceManagementHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -70,18 +60,7 @@ class VmUseCaseServiceDbSyncTest {
     private AccountCredentialManagementPort credentialProviderPort;
 
     @Mock
-    private CloudResourceRepository cloudResourceRepository;
-
-    @Mock
-    private CloudProviderRepository cloudProviderRepository;
-
-    @Mock
-    private CloudServiceRepository cloudServiceRepository;
-
-    @Mock
-    private TenantRepository tenantRepository;
-
-    private ObjectMapper objectMapper;
+    private CloudResourceManagementHelper resourceHelper;
 
     private VmUseCaseService vmUseCaseService;
     private CloudSessionCredential mockSession;
@@ -94,17 +73,12 @@ class VmUseCaseServiceDbSyncTest {
     @BeforeEach
     void setUp() {
         TenantContextHolder.setTenantKey(TENANT_KEY);
-        objectMapper = new ObjectMapper();
         
         vmUseCaseService = new VmUseCaseService(
                 vmPortRouter,
                 capabilityGuard,
                 credentialProviderPort,
-                cloudResourceRepository,
-                cloudProviderRepository,
-                cloudServiceRepository,
-                tenantRepository,
-                objectMapper
+                resourceHelper
         );
         
         mockSession = mock(CloudSessionCredential.class);
@@ -132,36 +106,17 @@ class VmUseCaseServiceDbSyncTest {
         @DisplayName("인스턴스 생성 성공 시 CloudResource가 DB에 저장된다")
         void createInstance_Success_SavesCloudResource() {
             // Given
+            Map<String, String> tags = Map.of("Name", "test-instance", "Environment", "test");
             VmCreateRequest request = VmCreateRequest.builder()
                     .providerType(PROVIDER_TYPE)
                     .accountScope(ACCOUNT_SCOPE)
                     .image("ami-12345678")
                     .instanceSize("t3.micro")
-                    .tags(Map.of("Name", "test-instance", "Environment", "test"))
-                    .build();
-
-            CloudProvider mockProvider = CloudProvider.builder()
-                    .providerType(PROVIDER_TYPE)
-                    .providerName("AWS")
-                    .build();
-
-            CloudService mockService = CloudService.builder()
-                    .serviceKey("EC2")
-                    .build();
-
-            Tenant mockTenant = Tenant.builder()
-                    .tenantKey(TENANT_KEY)
+                    .tags(tags)
                     .build();
 
             when(vmLifecyclePort.createInstance(any())).thenReturn(INSTANCE_ID);
-            when(cloudProviderRepository.findFirstByProviderType(PROVIDER_TYPE))
-                    .thenReturn(Optional.of(mockProvider));
-            when(cloudServiceRepository.findByProviderTypeAndServiceKey(eq(PROVIDER_TYPE), eq("EC2")))
-                    .thenReturn(Optional.of(mockService));
-            when(tenantRepository.findByTenantKey(TENANT_KEY))
-                    .thenReturn(Optional.of(mockTenant));
-            when(cloudResourceRepository.save(any(CloudResource.class)))
-                    .thenAnswer(invocation -> invocation.getArgument(0));
+            when(resourceHelper.extractResourceName(tags, INSTANCE_ID)).thenReturn("test-instance");
 
             // When
             String result = vmUseCaseService.createInstance(request);
@@ -169,16 +124,14 @@ class VmUseCaseServiceDbSyncTest {
             // Then
             assertThat(result).isEqualTo(INSTANCE_ID);
             
-            ArgumentCaptor<CloudResource> captor = ArgumentCaptor.forClass(CloudResource.class);
-            verify(cloudResourceRepository).save(captor.capture());
-            
-            CloudResource savedResource = captor.getValue();
-            assertThat(savedResource.getResourceId()).isEqualTo(INSTANCE_ID);
-            assertThat(savedResource.getResourceName()).isEqualTo("test-instance");
-            assertThat(savedResource.getResourceType()).isEqualTo(CloudResource.ResourceType.INSTANCE);
-            assertThat(savedResource.getLifecycleState()).isEqualTo(LifecycleState.PENDING);
-            assertThat(savedResource.getProvider()).isEqualTo(mockProvider);
-            assertThat(savedResource.getTenant()).isEqualTo(mockTenant);
+            verify(resourceHelper).registerVmInstance(
+                    eq(PROVIDER_TYPE),
+                    eq("EC2"),
+                    eq(INSTANCE_ID),
+                    eq("test-instance"),
+                    eq("t3.micro"),
+                    eq(tags)
+            );
         }
 
         @Test
@@ -193,15 +146,17 @@ class VmUseCaseServiceDbSyncTest {
                     .build();
 
             when(vmLifecyclePort.createInstance(any())).thenReturn(INSTANCE_ID);
-            when(cloudProviderRepository.findFirstByProviderType(PROVIDER_TYPE))
-                    .thenReturn(Optional.empty()); // Provider 없음 -> DB 저장 실패
+            when(resourceHelper.extractResourceName(any(), eq(INSTANCE_ID))).thenReturn(INSTANCE_ID);
+            // Helper 내부에서 예외 발생해도 경고 로그만 출력되고 계속 진행됨
+            doThrow(new RuntimeException("DB 저장 실패")).when(resourceHelper)
+                    .registerVmInstance(any(), any(), any(), any(), any(), any());
 
             // When
             String result = vmUseCaseService.createInstance(request);
 
             // Then
             assertThat(result).isEqualTo(INSTANCE_ID); // CSP 생성은 성공
-            verify(cloudResourceRepository, never()).save(any()); // DB 저장은 스킵됨
+            verify(resourceHelper).registerVmInstance(any(), any(), any(), any(), any(), any());
         }
     }
 
@@ -214,17 +169,13 @@ class VmUseCaseServiceDbSyncTest {
         void startInstance_Success_UpdatesLifecycleStateToRunning() {
             // Given
             doNothing().when(vmLifecyclePort).startInstance(eq(INSTANCE_ID), any());
-            when(cloudResourceRepository.updateLifecycleState(
-                    eq(INSTANCE_ID), eq(LifecycleState.RUNNING), any(LocalDateTime.class)))
-                    .thenReturn(1);
 
             // When
             vmUseCaseService.startInstance(PROVIDER_TYPE, ACCOUNT_SCOPE, INSTANCE_ID);
 
             // Then
             verify(vmLifecyclePort).startInstance(eq(INSTANCE_ID), any());
-            verify(cloudResourceRepository).updateLifecycleState(
-                    eq(INSTANCE_ID), eq(LifecycleState.RUNNING), any(LocalDateTime.class));
+            verify(resourceHelper).updateLifecycleState(eq(INSTANCE_ID), eq(LifecycleState.RUNNING));
         }
 
         @Test
@@ -232,17 +183,13 @@ class VmUseCaseServiceDbSyncTest {
         void stopInstance_Success_UpdatesLifecycleStateToStopped() {
             // Given
             doNothing().when(vmLifecyclePort).stopInstance(eq(INSTANCE_ID), any());
-            when(cloudResourceRepository.updateLifecycleState(
-                    eq(INSTANCE_ID), eq(LifecycleState.STOPPED), any(LocalDateTime.class)))
-                    .thenReturn(1);
 
             // When
             vmUseCaseService.stopInstance(PROVIDER_TYPE, ACCOUNT_SCOPE, INSTANCE_ID);
 
             // Then
             verify(vmLifecyclePort).stopInstance(eq(INSTANCE_ID), any());
-            verify(cloudResourceRepository).updateLifecycleState(
-                    eq(INSTANCE_ID), eq(LifecycleState.STOPPED), any(LocalDateTime.class));
+            verify(resourceHelper).updateLifecycleState(eq(INSTANCE_ID), eq(LifecycleState.STOPPED));
         }
 
         @Test
@@ -250,17 +197,13 @@ class VmUseCaseServiceDbSyncTest {
         void rebootInstance_Success_KeepsLifecycleStateRunning() {
             // Given
             doNothing().when(vmLifecyclePort).rebootInstance(eq(INSTANCE_ID), any());
-            when(cloudResourceRepository.updateLifecycleState(
-                    eq(INSTANCE_ID), eq(LifecycleState.RUNNING), any(LocalDateTime.class)))
-                    .thenReturn(1);
 
             // When
             vmUseCaseService.rebootInstance(PROVIDER_TYPE, ACCOUNT_SCOPE, INSTANCE_ID);
 
             // Then
             verify(vmLifecyclePort).rebootInstance(eq(INSTANCE_ID), any());
-            verify(cloudResourceRepository).updateLifecycleState(
-                    eq(INSTANCE_ID), eq(LifecycleState.RUNNING), any(LocalDateTime.class));
+            verify(resourceHelper).updateLifecycleState(eq(INSTANCE_ID), eq(LifecycleState.RUNNING));
         }
 
         @Test
@@ -268,17 +211,13 @@ class VmUseCaseServiceDbSyncTest {
         void terminateInstance_Success_UpdatesLifecycleStateToTerminated() {
             // Given
             doNothing().when(vmLifecyclePort).terminateInstance(eq(INSTANCE_ID), any());
-            when(cloudResourceRepository.updateLifecycleState(
-                    eq(INSTANCE_ID), eq(LifecycleState.TERMINATED), any(LocalDateTime.class)))
-                    .thenReturn(1);
 
             // When
             vmUseCaseService.terminateInstance(PROVIDER_TYPE, ACCOUNT_SCOPE, INSTANCE_ID);
 
             // Then
             verify(vmLifecyclePort).terminateInstance(eq(INSTANCE_ID), any());
-            verify(cloudResourceRepository).updateLifecycleState(
-                    eq(INSTANCE_ID), eq(LifecycleState.TERMINATED), any(LocalDateTime.class));
+            verify(resourceHelper).updateLifecycleState(eq(INSTANCE_ID), eq(LifecycleState.TERMINATED));
         }
 
         @Test
@@ -286,15 +225,14 @@ class VmUseCaseServiceDbSyncTest {
         void startInstance_ResourceNotInDb_CspOperationSucceeds() {
             // Given
             doNothing().when(vmLifecyclePort).startInstance(eq(INSTANCE_ID), any());
-            when(cloudResourceRepository.updateLifecycleState(
-                    eq(INSTANCE_ID), eq(LifecycleState.RUNNING), any(LocalDateTime.class)))
-                    .thenReturn(0); // DB에 리소스 없음
+            // Helper 내부에서 리소스가 없으면 로그만 출력하고 예외 발생 안함
 
             // When
             vmUseCaseService.startInstance(PROVIDER_TYPE, ACCOUNT_SCOPE, INSTANCE_ID);
 
             // Then
             verify(vmLifecyclePort).startInstance(eq(INSTANCE_ID), any()); // CSP 작업 성공
+            verify(resourceHelper).updateLifecycleState(eq(INSTANCE_ID), eq(LifecycleState.RUNNING));
         }
     }
 
@@ -314,14 +252,13 @@ class VmUseCaseServiceDbSyncTest {
                     .build();
 
             doNothing().when(vmLifecyclePort).deleteInstance(any());
-            when(cloudResourceRepository.softDeleteByResourceId(INSTANCE_ID)).thenReturn(1);
 
             // When
             vmUseCaseService.deleteInstance(request);
 
             // Then
             verify(vmLifecyclePort).deleteInstance(any());
-            verify(cloudResourceRepository).softDeleteByResourceId(INSTANCE_ID);
+            verify(resourceHelper).softDeleteResource(INSTANCE_ID);
         }
 
         @Test
@@ -336,13 +273,14 @@ class VmUseCaseServiceDbSyncTest {
                     .build();
 
             doNothing().when(vmLifecyclePort).deleteInstance(any());
-            when(cloudResourceRepository.softDeleteByResourceId(INSTANCE_ID)).thenReturn(0); // DB에 없음
+            // Helper 내부에서 리소스가 없으면 로그만 출력하고 예외 발생 안함
 
             // When
             vmUseCaseService.deleteInstance(request);
 
             // Then
             verify(vmLifecyclePort).deleteInstance(any()); // CSP 작업 성공
+            verify(resourceHelper).softDeleteResource(INSTANCE_ID);
         }
     }
 }

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseServiceDbSyncTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseServiceDbSyncTest.java
@@ -1,0 +1,348 @@
+package com.agenticcp.core.domain.cloud.service.vm;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
+import com.agenticcp.core.domain.cloud.dto.VmCreateRequest;
+import com.agenticcp.core.domain.cloud.dto.VmDeleteRequest;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
+import com.agenticcp.core.domain.cloud.entity.CloudService;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
+import com.agenticcp.core.domain.cloud.port.outbound.vm.VmDiscoveryPort;
+import com.agenticcp.core.domain.cloud.port.outbound.vm.VmLifecyclePort;
+import com.agenticcp.core.domain.cloud.port.outbound.vm.VmTaggingPort;
+import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import com.agenticcp.core.domain.tenant.repository.TenantRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * VmUseCaseService DB 동기화 로직 단위 테스트
+ * CSP 작업 후 CloudResource 엔티티가 올바르게 DB에 저장/업데이트되는지 검증합니다.
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VmUseCaseService DB 동기화 테스트")
+class VmUseCaseServiceDbSyncTest {
+
+    @Mock
+    private VmPortRouter vmPortRouter;
+
+    @Mock
+    private VmDiscoveryPort vmDiscoveryPort;
+
+    @Mock
+    private VmLifecyclePort vmLifecyclePort;
+
+    @Mock
+    private VmTaggingPort vmTaggingPort;
+
+    @Mock
+    private CapabilityGuard capabilityGuard;
+
+    @Mock
+    private AccountCredentialManagementPort credentialProviderPort;
+
+    @Mock
+    private CloudResourceRepository cloudResourceRepository;
+
+    @Mock
+    private CloudProviderRepository cloudProviderRepository;
+
+    @Mock
+    private CloudServiceRepository cloudServiceRepository;
+
+    @Mock
+    private TenantRepository tenantRepository;
+
+    private ObjectMapper objectMapper;
+
+    private VmUseCaseService vmUseCaseService;
+    private CloudSessionCredential mockSession;
+
+    private static final ProviderType PROVIDER_TYPE = ProviderType.AWS;
+    private static final String ACCOUNT_SCOPE = "123456789012";
+    private static final String TENANT_KEY = "tenant-test";
+    private static final String INSTANCE_ID = "i-1234567890abcdef0";
+
+    @BeforeEach
+    void setUp() {
+        TenantContextHolder.setTenantKey(TENANT_KEY);
+        objectMapper = new ObjectMapper();
+        
+        vmUseCaseService = new VmUseCaseService(
+                vmPortRouter,
+                capabilityGuard,
+                credentialProviderPort,
+                cloudResourceRepository,
+                cloudProviderRepository,
+                cloudServiceRepository,
+                tenantRepository,
+                objectMapper
+        );
+        
+        mockSession = mock(CloudSessionCredential.class);
+        lenient().when(mockSession.getExpiresAt()).thenReturn(LocalDateTime.now().plusHours(1));
+
+        // 공통 Mock 설정
+        lenient().when(vmPortRouter.discovery(PROVIDER_TYPE)).thenReturn(vmDiscoveryPort);
+        lenient().when(vmPortRouter.lifecycle(PROVIDER_TYPE)).thenReturn(vmLifecyclePort);
+        lenient().when(vmPortRouter.tagging(PROVIDER_TYPE)).thenReturn(vmTaggingPort);
+        lenient().when(credentialProviderPort.getSession(eq(TENANT_KEY), eq(ACCOUNT_SCOPE), eq(PROVIDER_TYPE)))
+                .thenReturn(mockSession);
+        lenient().doNothing().when(capabilityGuard).ensureSupported(any(), anyString(), anyString(), any());
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContextHolder.clear();
+    }
+
+    @Nested
+    @DisplayName("인스턴스 생성 테스트")
+    class CreateInstanceTest {
+
+        @Test
+        @DisplayName("인스턴스 생성 성공 시 CloudResource가 DB에 저장된다")
+        void createInstance_Success_SavesCloudResource() {
+            // Given
+            VmCreateRequest request = VmCreateRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .image("ami-12345678")
+                    .instanceSize("t3.micro")
+                    .tags(Map.of("Name", "test-instance", "Environment", "test"))
+                    .build();
+
+            CloudProvider mockProvider = CloudProvider.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .providerName("AWS")
+                    .build();
+
+            CloudService mockService = CloudService.builder()
+                    .serviceKey("EC2")
+                    .build();
+
+            Tenant mockTenant = Tenant.builder()
+                    .tenantKey(TENANT_KEY)
+                    .build();
+
+            when(vmLifecyclePort.createInstance(any())).thenReturn(INSTANCE_ID);
+            when(cloudProviderRepository.findFirstByProviderType(PROVIDER_TYPE))
+                    .thenReturn(Optional.of(mockProvider));
+            when(cloudServiceRepository.findByProviderTypeAndServiceKey(eq(PROVIDER_TYPE), eq("EC2")))
+                    .thenReturn(Optional.of(mockService));
+            when(tenantRepository.findByTenantKey(TENANT_KEY))
+                    .thenReturn(Optional.of(mockTenant));
+            when(cloudResourceRepository.save(any(CloudResource.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            String result = vmUseCaseService.createInstance(request);
+
+            // Then
+            assertThat(result).isEqualTo(INSTANCE_ID);
+            
+            ArgumentCaptor<CloudResource> captor = ArgumentCaptor.forClass(CloudResource.class);
+            verify(cloudResourceRepository).save(captor.capture());
+            
+            CloudResource savedResource = captor.getValue();
+            assertThat(savedResource.getResourceId()).isEqualTo(INSTANCE_ID);
+            assertThat(savedResource.getResourceName()).isEqualTo("test-instance");
+            assertThat(savedResource.getResourceType()).isEqualTo(CloudResource.ResourceType.INSTANCE);
+            assertThat(savedResource.getLifecycleState()).isEqualTo(LifecycleState.PENDING);
+            assertThat(savedResource.getProvider()).isEqualTo(mockProvider);
+            assertThat(savedResource.getTenant()).isEqualTo(mockTenant);
+        }
+
+        @Test
+        @DisplayName("DB 저장 실패 시에도 CSP 생성은 성공한다")
+        void createInstance_DbSaveFails_CspCreationSucceeds() {
+            // Given
+            VmCreateRequest request = VmCreateRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .image("ami-12345678")
+                    .instanceSize("t3.micro")
+                    .build();
+
+            when(vmLifecyclePort.createInstance(any())).thenReturn(INSTANCE_ID);
+            when(cloudProviderRepository.findFirstByProviderType(PROVIDER_TYPE))
+                    .thenReturn(Optional.empty()); // Provider 없음 -> DB 저장 실패
+
+            // When
+            String result = vmUseCaseService.createInstance(request);
+
+            // Then
+            assertThat(result).isEqualTo(INSTANCE_ID); // CSP 생성은 성공
+            verify(cloudResourceRepository, never()).save(any()); // DB 저장은 스킵됨
+        }
+    }
+
+    @Nested
+    @DisplayName("인스턴스 생명주기 상태 업데이트 테스트")
+    class LifecycleStateUpdateTest {
+
+        @Test
+        @DisplayName("인스턴스 시작 시 lifecycleState가 RUNNING으로 업데이트된다")
+        void startInstance_Success_UpdatesLifecycleStateToRunning() {
+            // Given
+            doNothing().when(vmLifecyclePort).startInstance(eq(INSTANCE_ID), any());
+            when(cloudResourceRepository.updateLifecycleState(
+                    eq(INSTANCE_ID), eq(LifecycleState.RUNNING), any(LocalDateTime.class)))
+                    .thenReturn(1);
+
+            // When
+            vmUseCaseService.startInstance(PROVIDER_TYPE, ACCOUNT_SCOPE, INSTANCE_ID);
+
+            // Then
+            verify(vmLifecyclePort).startInstance(eq(INSTANCE_ID), any());
+            verify(cloudResourceRepository).updateLifecycleState(
+                    eq(INSTANCE_ID), eq(LifecycleState.RUNNING), any(LocalDateTime.class));
+        }
+
+        @Test
+        @DisplayName("인스턴스 중지 시 lifecycleState가 STOPPED로 업데이트된다")
+        void stopInstance_Success_UpdatesLifecycleStateToStopped() {
+            // Given
+            doNothing().when(vmLifecyclePort).stopInstance(eq(INSTANCE_ID), any());
+            when(cloudResourceRepository.updateLifecycleState(
+                    eq(INSTANCE_ID), eq(LifecycleState.STOPPED), any(LocalDateTime.class)))
+                    .thenReturn(1);
+
+            // When
+            vmUseCaseService.stopInstance(PROVIDER_TYPE, ACCOUNT_SCOPE, INSTANCE_ID);
+
+            // Then
+            verify(vmLifecyclePort).stopInstance(eq(INSTANCE_ID), any());
+            verify(cloudResourceRepository).updateLifecycleState(
+                    eq(INSTANCE_ID), eq(LifecycleState.STOPPED), any(LocalDateTime.class));
+        }
+
+        @Test
+        @DisplayName("인스턴스 재부팅 시 lifecycleState가 RUNNING으로 유지된다")
+        void rebootInstance_Success_KeepsLifecycleStateRunning() {
+            // Given
+            doNothing().when(vmLifecyclePort).rebootInstance(eq(INSTANCE_ID), any());
+            when(cloudResourceRepository.updateLifecycleState(
+                    eq(INSTANCE_ID), eq(LifecycleState.RUNNING), any(LocalDateTime.class)))
+                    .thenReturn(1);
+
+            // When
+            vmUseCaseService.rebootInstance(PROVIDER_TYPE, ACCOUNT_SCOPE, INSTANCE_ID);
+
+            // Then
+            verify(vmLifecyclePort).rebootInstance(eq(INSTANCE_ID), any());
+            verify(cloudResourceRepository).updateLifecycleState(
+                    eq(INSTANCE_ID), eq(LifecycleState.RUNNING), any(LocalDateTime.class));
+        }
+
+        @Test
+        @DisplayName("인스턴스 종료 시 lifecycleState가 TERMINATED로 업데이트된다")
+        void terminateInstance_Success_UpdatesLifecycleStateToTerminated() {
+            // Given
+            doNothing().when(vmLifecyclePort).terminateInstance(eq(INSTANCE_ID), any());
+            when(cloudResourceRepository.updateLifecycleState(
+                    eq(INSTANCE_ID), eq(LifecycleState.TERMINATED), any(LocalDateTime.class)))
+                    .thenReturn(1);
+
+            // When
+            vmUseCaseService.terminateInstance(PROVIDER_TYPE, ACCOUNT_SCOPE, INSTANCE_ID);
+
+            // Then
+            verify(vmLifecyclePort).terminateInstance(eq(INSTANCE_ID), any());
+            verify(cloudResourceRepository).updateLifecycleState(
+                    eq(INSTANCE_ID), eq(LifecycleState.TERMINATED), any(LocalDateTime.class));
+        }
+
+        @Test
+        @DisplayName("DB에 리소스가 없어도 CSP 작업은 성공한다")
+        void startInstance_ResourceNotInDb_CspOperationSucceeds() {
+            // Given
+            doNothing().when(vmLifecyclePort).startInstance(eq(INSTANCE_ID), any());
+            when(cloudResourceRepository.updateLifecycleState(
+                    eq(INSTANCE_ID), eq(LifecycleState.RUNNING), any(LocalDateTime.class)))
+                    .thenReturn(0); // DB에 리소스 없음
+
+            // When
+            vmUseCaseService.startInstance(PROVIDER_TYPE, ACCOUNT_SCOPE, INSTANCE_ID);
+
+            // Then
+            verify(vmLifecyclePort).startInstance(eq(INSTANCE_ID), any()); // CSP 작업 성공
+        }
+    }
+
+    @Nested
+    @DisplayName("인스턴스 삭제 테스트")
+    class DeleteInstanceTest {
+
+        @Test
+        @DisplayName("인스턴스 삭제 시 소프트 삭제가 수행된다")
+        void deleteInstance_Success_SoftDeletesResource() {
+            // Given
+            VmDeleteRequest request = VmDeleteRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .instanceId(INSTANCE_ID)
+                    .force(false)
+                    .build();
+
+            doNothing().when(vmLifecyclePort).deleteInstance(any());
+            when(cloudResourceRepository.softDeleteByResourceId(INSTANCE_ID)).thenReturn(1);
+
+            // When
+            vmUseCaseService.deleteInstance(request);
+
+            // Then
+            verify(vmLifecyclePort).deleteInstance(any());
+            verify(cloudResourceRepository).softDeleteByResourceId(INSTANCE_ID);
+        }
+
+        @Test
+        @DisplayName("DB에 리소스가 없어도 CSP 삭제는 성공한다")
+        void deleteInstance_ResourceNotInDb_CspDeletionSucceeds() {
+            // Given
+            VmDeleteRequest request = VmDeleteRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .instanceId(INSTANCE_ID)
+                    .force(false)
+                    .build();
+
+            doNothing().when(vmLifecyclePort).deleteInstance(any());
+            when(cloudResourceRepository.softDeleteByResourceId(INSTANCE_ID)).thenReturn(0); // DB에 없음
+
+            // When
+            vmUseCaseService.deleteInstance(request);
+
+            // Then
+            verify(vmLifecyclePort).deleteInstance(any()); // CSP 작업 성공
+        }
+    }
+}

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseServiceDbSyncTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/vm/VmUseCaseServiceDbSyncTest.java
@@ -3,6 +3,7 @@ package com.agenticcp.core.domain.cloud.service.vm;
 import com.agenticcp.core.common.context.TenantContextHolder;
 import com.agenticcp.core.common.exception.BusinessException;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
+import com.agenticcp.core.domain.cloud.dto.ResourceRegistrationRequest;
 import com.agenticcp.core.domain.cloud.dto.VmCreateRequest;
 import com.agenticcp.core.domain.cloud.dto.VmDeleteRequest;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
@@ -126,13 +127,10 @@ class VmUseCaseServiceDbSyncTest {
 
             when(vmLifecyclePort.createInstance(any())).thenReturn(INSTANCE_ID);
             when(resourceHelper.extractResourceName(tags, INSTANCE_ID)).thenReturn("test-instance");
-            when(resourceHelper.registerVmInstance(
+            when(resourceHelper.registerResource(
                     eq(PROVIDER_TYPE),
                     eq("EC2"),
-                    eq(INSTANCE_ID),
-                    eq("test-instance"),
-                    eq("t3.micro"),
-                    eq(tags)
+                    any(ResourceRegistrationRequest.class)
             )).thenReturn(mockCloudResource);
 
             // When
@@ -143,13 +141,10 @@ class VmUseCaseServiceDbSyncTest {
             assertThat(result.getResourceId()).isEqualTo(INSTANCE_ID);
             assertThat(result.getResourceName()).isEqualTo("test-instance");
             
-            verify(resourceHelper).registerVmInstance(
+            verify(resourceHelper).registerResource(
                     eq(PROVIDER_TYPE),
                     eq("EC2"),
-                    eq(INSTANCE_ID),
-                    eq("test-instance"),
-                    eq("t3.micro"),
-                    eq(tags)
+                    any(ResourceRegistrationRequest.class)
             );
         }
 
@@ -168,7 +163,7 @@ class VmUseCaseServiceDbSyncTest {
             when(resourceHelper.extractResourceName(any(), eq(INSTANCE_ID))).thenReturn(INSTANCE_ID);
             // DB 저장 실패
             doThrow(new RuntimeException("DB 저장 실패")).when(resourceHelper)
-                    .registerVmInstance(any(), any(), any(), any(), any(), any());
+                    .registerResource(any(), any(), any());
 
             // When & Then
             assertThatThrownBy(() -> vmUseCaseService.createInstance(request))

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseServiceDbSyncTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseServiceDbSyncTest.java
@@ -3,6 +3,7 @@ package com.agenticcp.core.domain.cloud.service.vpc;
 import com.agenticcp.core.common.context.TenantContextHolder;
 import com.agenticcp.core.common.exception.BusinessException;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
+import com.agenticcp.core.domain.cloud.dto.ResourceRegistrationRequest;
 import com.agenticcp.core.domain.cloud.dto.VpcCreateRequest;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
@@ -125,13 +126,10 @@ class VpcUseCaseServiceDbSyncTest {
             assertThat(result).isNotNull();
             assertThat(result.getResourceId()).isEqualTo(VPC_ID);
             
-            verify(resourceHelper).registerVpc(
+            verify(resourceHelper).registerResource(
                     eq(PROVIDER_TYPE),
                     eq("EC2"),
-                    eq(VPC_ID),
-                    eq(VPC_NAME),
-                    eq(CIDR_BLOCK),
-                    eq(tags)
+                    any(ResourceRegistrationRequest.class)
             );
         }
 
@@ -155,7 +153,7 @@ class VpcUseCaseServiceDbSyncTest {
             when(vpcManagementPort.createVpc(any())).thenReturn(mockCreatedVpc);
             // DB 저장 실패
             doThrow(new RuntimeException("DB 저장 실패")).when(resourceHelper)
-                    .registerVpc(any(), any(), any(), any(), any(), any());
+                    .registerResource(any(), any(), any());
 
             // When & Then
             assertThatThrownBy(() -> vpcUseCaseService.createVpc(request))
@@ -192,13 +190,10 @@ class VpcUseCaseServiceDbSyncTest {
             vpcUseCaseService.createVpc(request);
 
             // Then
-            verify(resourceHelper).registerVpc(
+            verify(resourceHelper).registerResource(
                     eq(PROVIDER_TYPE),
                     eq("EC2"),
-                    eq(VPC_ID),
-                    eq(VPC_ID),  // VPC ID가 이름으로 사용됨
-                    eq(CIDR_BLOCK),
-                    any()
+                    any(ResourceRegistrationRequest.class)
             );
         }
     }

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseServiceDbSyncTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseServiceDbSyncTest.java
@@ -3,35 +3,24 @@ package com.agenticcp.core.domain.cloud.service.vpc;
 import com.agenticcp.core.common.context.TenantContextHolder;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.VpcCreateRequest;
-import com.agenticcp.core.domain.cloud.entity.CloudProvider;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
-import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
-import com.agenticcp.core.domain.cloud.entity.CloudResource.ResourceType;
-import com.agenticcp.core.domain.cloud.entity.CloudService;
 import com.agenticcp.core.domain.cloud.port.model.ResourceIdentity;
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
 import com.agenticcp.core.domain.cloud.port.outbound.vpc.VpcManagementPort;
-import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
-import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
-import com.agenticcp.core.domain.tenant.entity.Tenant;
-import com.agenticcp.core.domain.tenant.repository.TenantRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.agenticcp.core.domain.cloud.service.helper.CloudResourceManagementHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -63,18 +52,7 @@ class VpcUseCaseServiceDbSyncTest {
     private AccountCredentialManagementPort accountCredentialManagementPort;
 
     @Mock
-    private CloudResourceRepository cloudResourceRepository;
-
-    @Mock
-    private CloudProviderRepository cloudProviderRepository;
-
-    @Mock
-    private CloudServiceRepository cloudServiceRepository;
-
-    @Mock
-    private TenantRepository tenantRepository;
-
-    private ObjectMapper objectMapper;
+    private CloudResourceManagementHelper resourceHelper;
 
     private VpcUseCaseService vpcUseCaseService;
     private CloudSessionCredential mockSession;
@@ -89,17 +67,12 @@ class VpcUseCaseServiceDbSyncTest {
     @BeforeEach
     void setUp() {
         TenantContextHolder.setTenantKey(TENANT_KEY);
-        objectMapper = new ObjectMapper();
         
         vpcUseCaseService = new VpcUseCaseService(
                 vpcPortRouter,
                 capabilityGuard,
                 accountCredentialManagementPort,
-                cloudResourceRepository,
-                cloudProviderRepository,
-                cloudServiceRepository,
-                tenantRepository,
-                objectMapper
+                resourceHelper
         );
         
         mockSession = mock(CloudSessionCredential.class);
@@ -125,13 +98,14 @@ class VpcUseCaseServiceDbSyncTest {
         @DisplayName("VPC 생성 성공 시 CloudResource가 DB에 저장된다")
         void createVpc_Success_SavesCloudResource() {
             // Given
+            Map<String, String> tags = Map.of("Environment", "test");
             VpcCreateRequest request = VpcCreateRequest.builder()
                     .providerType(PROVIDER_TYPE)
                     .accountScope(ACCOUNT_SCOPE)
                     .vpcName(VPC_NAME)
                     .cidrBlock(CIDR_BLOCK)
                     .region("us-east-1")
-                    .tags(Map.of("Environment", "test"))
+                    .tags(tags)
                     .build();
 
             CloudResource mockCreatedVpc = CloudResource.builder()
@@ -139,28 +113,7 @@ class VpcUseCaseServiceDbSyncTest {
                     .resourceName(VPC_NAME)
                     .build();
 
-            CloudProvider mockProvider = CloudProvider.builder()
-                    .providerType(PROVIDER_TYPE)
-                    .providerName("AWS")
-                    .build();
-
-            CloudService mockService = CloudService.builder()
-                    .serviceKey("VPC")
-                    .build();
-
-            Tenant mockTenant = Tenant.builder()
-                    .tenantKey(TENANT_KEY)
-                    .build();
-
             when(vpcManagementPort.createVpc(any())).thenReturn(mockCreatedVpc);
-            when(cloudProviderRepository.findFirstByProviderType(PROVIDER_TYPE))
-                    .thenReturn(Optional.of(mockProvider));
-            when(cloudServiceRepository.findByProviderTypeAndServiceKey(eq(PROVIDER_TYPE), eq("VPC")))
-                    .thenReturn(Optional.of(mockService));
-            when(tenantRepository.findByTenantKey(TENANT_KEY))
-                    .thenReturn(Optional.of(mockTenant));
-            when(cloudResourceRepository.save(any(CloudResource.class)))
-                    .thenAnswer(invocation -> invocation.getArgument(0));
 
             // When
             CloudResource result = vpcUseCaseService.createVpc(request);
@@ -169,17 +122,14 @@ class VpcUseCaseServiceDbSyncTest {
             assertThat(result).isNotNull();
             assertThat(result.getResourceId()).isEqualTo(VPC_ID);
             
-            ArgumentCaptor<CloudResource> captor = ArgumentCaptor.forClass(CloudResource.class);
-            verify(cloudResourceRepository).save(captor.capture());
-            
-            CloudResource savedResource = captor.getValue();
-            assertThat(savedResource.getResourceId()).isEqualTo(VPC_ID);
-            assertThat(savedResource.getResourceName()).isEqualTo(VPC_NAME);
-            assertThat(savedResource.getResourceType()).isEqualTo(ResourceType.NETWORK);
-            assertThat(savedResource.getLifecycleState()).isEqualTo(LifecycleState.RUNNING);
-            assertThat(savedResource.getConfiguration()).isEqualTo(CIDR_BLOCK);
-            assertThat(savedResource.getProvider()).isEqualTo(mockProvider);
-            assertThat(savedResource.getTenant()).isEqualTo(mockTenant);
+            verify(resourceHelper).registerVpc(
+                    eq(PROVIDER_TYPE),
+                    eq("EC2"),
+                    eq(VPC_ID),
+                    eq(VPC_NAME),
+                    eq(CIDR_BLOCK),
+                    eq(tags)
+            );
         }
 
         @Test
@@ -200,8 +150,9 @@ class VpcUseCaseServiceDbSyncTest {
                     .build();
 
             when(vpcManagementPort.createVpc(any())).thenReturn(mockCreatedVpc);
-            when(cloudProviderRepository.findFirstByProviderType(PROVIDER_TYPE))
-                    .thenReturn(Optional.empty()); // Provider 없음 -> DB 저장 실패
+            // Helper 내부에서 예외 발생해도 경고 로그만 출력되고 계속 진행됨
+            doThrow(new RuntimeException("DB 저장 실패")).when(resourceHelper)
+                    .registerVpc(any(), any(), any(), any(), any(), any());
 
             // When
             CloudResource result = vpcUseCaseService.createVpc(request);
@@ -209,7 +160,7 @@ class VpcUseCaseServiceDbSyncTest {
             // Then
             assertThat(result).isNotNull(); // CSP 생성은 성공
             assertThat(result.getResourceId()).isEqualTo(VPC_ID);
-            verify(cloudResourceRepository, never()).save(any()); // DB 저장은 스킵됨
+            verify(resourceHelper).registerVpc(any(), any(), any(), any(), any(), any());
         }
 
         @Test
@@ -229,33 +180,20 @@ class VpcUseCaseServiceDbSyncTest {
                     .resourceName(VPC_ID)
                     .build();
 
-            CloudProvider mockProvider = CloudProvider.builder()
-                    .providerType(PROVIDER_TYPE)
-                    .build();
-
-            Tenant mockTenant = Tenant.builder()
-                    .tenantKey(TENANT_KEY)
-                    .build();
-
             when(vpcManagementPort.createVpc(any())).thenReturn(mockCreatedVpc);
-            when(cloudProviderRepository.findFirstByProviderType(PROVIDER_TYPE))
-                    .thenReturn(Optional.of(mockProvider));
-            when(cloudServiceRepository.findByProviderTypeAndServiceKey(any(), any()))
-                    .thenReturn(Optional.empty());
-            when(tenantRepository.findByTenantKey(TENANT_KEY))
-                    .thenReturn(Optional.of(mockTenant));
-            when(cloudResourceRepository.save(any(CloudResource.class)))
-                    .thenAnswer(invocation -> invocation.getArgument(0));
 
             // When
             vpcUseCaseService.createVpc(request);
 
             // Then
-            ArgumentCaptor<CloudResource> captor = ArgumentCaptor.forClass(CloudResource.class);
-            verify(cloudResourceRepository).save(captor.capture());
-            
-            CloudResource savedResource = captor.getValue();
-            assertThat(savedResource.getResourceName()).isEqualTo(VPC_ID); // VPC ID가 이름으로 사용됨
+            verify(resourceHelper).registerVpc(
+                    eq(PROVIDER_TYPE),
+                    eq("EC2"),
+                    eq(VPC_ID),
+                    eq(VPC_ID),  // VPC ID가 이름으로 사용됨
+                    eq(CIDR_BLOCK),
+                    any()
+            );
         }
     }
 
@@ -275,14 +213,13 @@ class VpcUseCaseServiceDbSyncTest {
                     .build();
 
             doNothing().when(vpcManagementPort).deleteVpc(any());
-            when(cloudResourceRepository.softDeleteByResourceId(VPC_ID)).thenReturn(1);
 
             // When
             vpcUseCaseService.deleteVpc(vpcId);
 
             // Then
             verify(vpcManagementPort).deleteVpc(any());
-            verify(cloudResourceRepository).softDeleteByResourceId(VPC_ID);
+            verify(resourceHelper).softDeleteResource(VPC_ID);
         }
 
         @Test
@@ -297,13 +234,14 @@ class VpcUseCaseServiceDbSyncTest {
                     .build();
 
             doNothing().when(vpcManagementPort).deleteVpc(any());
-            when(cloudResourceRepository.softDeleteByResourceId(VPC_ID)).thenReturn(0); // DB에 없음
+            // Helper 내부에서 리소스가 없으면 로그만 출력하고 예외 발생 안함
 
             // When
             vpcUseCaseService.deleteVpc(vpcId);
 
             // Then
             verify(vpcManagementPort).deleteVpc(any()); // CSP 작업 성공
+            verify(resourceHelper).softDeleteResource(VPC_ID);
         }
     }
 }

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseServiceDbSyncTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseServiceDbSyncTest.java
@@ -1,0 +1,309 @@
+package com.agenticcp.core.domain.cloud.service.vpc;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
+import com.agenticcp.core.domain.cloud.dto.VpcCreateRequest;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.ResourceType;
+import com.agenticcp.core.domain.cloud.entity.CloudService;
+import com.agenticcp.core.domain.cloud.port.model.ResourceIdentity;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
+import com.agenticcp.core.domain.cloud.port.outbound.vpc.VpcManagementPort;
+import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudResourceRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
+import com.agenticcp.core.domain.tenant.entity.Tenant;
+import com.agenticcp.core.domain.tenant.repository.TenantRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * VpcUseCaseService DB 동기화 로직 단위 테스트
+ * CSP 작업 후 CloudResource 엔티티가 올바르게 DB에 저장/삭제되는지 검증합니다.
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VpcUseCaseService DB 동기화 테스트")
+class VpcUseCaseServiceDbSyncTest {
+
+    @Mock
+    private VpcPortRouter vpcPortRouter;
+
+    @Mock
+    private VpcManagementPort vpcManagementPort;
+
+    @Mock
+    private CapabilityGuard capabilityGuard;
+
+    @Mock
+    private AccountCredentialManagementPort accountCredentialManagementPort;
+
+    @Mock
+    private CloudResourceRepository cloudResourceRepository;
+
+    @Mock
+    private CloudProviderRepository cloudProviderRepository;
+
+    @Mock
+    private CloudServiceRepository cloudServiceRepository;
+
+    @Mock
+    private TenantRepository tenantRepository;
+
+    private ObjectMapper objectMapper;
+
+    private VpcUseCaseService vpcUseCaseService;
+    private CloudSessionCredential mockSession;
+
+    private static final ProviderType PROVIDER_TYPE = ProviderType.AWS;
+    private static final String ACCOUNT_SCOPE = "123456789012";
+    private static final String TENANT_KEY = "tenant-test";
+    private static final String VPC_ID = "vpc-12345678";
+    private static final String VPC_NAME = "my-test-vpc";
+    private static final String CIDR_BLOCK = "10.0.0.0/16";
+
+    @BeforeEach
+    void setUp() {
+        TenantContextHolder.setTenantKey(TENANT_KEY);
+        objectMapper = new ObjectMapper();
+        
+        vpcUseCaseService = new VpcUseCaseService(
+                vpcPortRouter,
+                capabilityGuard,
+                accountCredentialManagementPort,
+                cloudResourceRepository,
+                cloudProviderRepository,
+                cloudServiceRepository,
+                tenantRepository,
+                objectMapper
+        );
+        
+        mockSession = mock(CloudSessionCredential.class);
+        when(mockSession.getExpiresAt()).thenReturn(LocalDateTime.now().plusHours(1));
+
+        // 공통 Mock 설정
+        lenient().when(vpcPortRouter.getPort(PROVIDER_TYPE)).thenReturn(vpcManagementPort);
+        lenient().when(accountCredentialManagementPort.getSession(eq(TENANT_KEY), eq(ACCOUNT_SCOPE), eq(PROVIDER_TYPE)))
+                .thenReturn(mockSession);
+        lenient().doNothing().when(capabilityGuard).ensureSupported(any(), anyString(), anyString(), any());
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContextHolder.clear();
+    }
+
+    @Nested
+    @DisplayName("VPC 생성 테스트")
+    class CreateVpcTest {
+
+        @Test
+        @DisplayName("VPC 생성 성공 시 CloudResource가 DB에 저장된다")
+        void createVpc_Success_SavesCloudResource() {
+            // Given
+            VpcCreateRequest request = VpcCreateRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .vpcName(VPC_NAME)
+                    .cidrBlock(CIDR_BLOCK)
+                    .region("us-east-1")
+                    .tags(Map.of("Environment", "test"))
+                    .build();
+
+            CloudResource mockCreatedVpc = CloudResource.builder()
+                    .resourceId(VPC_ID)
+                    .resourceName(VPC_NAME)
+                    .build();
+
+            CloudProvider mockProvider = CloudProvider.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .providerName("AWS")
+                    .build();
+
+            CloudService mockService = CloudService.builder()
+                    .serviceKey("VPC")
+                    .build();
+
+            Tenant mockTenant = Tenant.builder()
+                    .tenantKey(TENANT_KEY)
+                    .build();
+
+            when(vpcManagementPort.createVpc(any())).thenReturn(mockCreatedVpc);
+            when(cloudProviderRepository.findFirstByProviderType(PROVIDER_TYPE))
+                    .thenReturn(Optional.of(mockProvider));
+            when(cloudServiceRepository.findByProviderTypeAndServiceKey(eq(PROVIDER_TYPE), eq("VPC")))
+                    .thenReturn(Optional.of(mockService));
+            when(tenantRepository.findByTenantKey(TENANT_KEY))
+                    .thenReturn(Optional.of(mockTenant));
+            when(cloudResourceRepository.save(any(CloudResource.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            CloudResource result = vpcUseCaseService.createVpc(request);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getResourceId()).isEqualTo(VPC_ID);
+            
+            ArgumentCaptor<CloudResource> captor = ArgumentCaptor.forClass(CloudResource.class);
+            verify(cloudResourceRepository).save(captor.capture());
+            
+            CloudResource savedResource = captor.getValue();
+            assertThat(savedResource.getResourceId()).isEqualTo(VPC_ID);
+            assertThat(savedResource.getResourceName()).isEqualTo(VPC_NAME);
+            assertThat(savedResource.getResourceType()).isEqualTo(ResourceType.NETWORK);
+            assertThat(savedResource.getLifecycleState()).isEqualTo(LifecycleState.RUNNING);
+            assertThat(savedResource.getConfiguration()).isEqualTo(CIDR_BLOCK);
+            assertThat(savedResource.getProvider()).isEqualTo(mockProvider);
+            assertThat(savedResource.getTenant()).isEqualTo(mockTenant);
+        }
+
+        @Test
+        @DisplayName("DB 저장 실패 시에도 CSP 생성은 성공한다")
+        void createVpc_DbSaveFails_CspCreationSucceeds() {
+            // Given
+            VpcCreateRequest request = VpcCreateRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .vpcName(VPC_NAME)
+                    .cidrBlock(CIDR_BLOCK)
+                    .region("us-east-1")
+                    .build();
+
+            CloudResource mockCreatedVpc = CloudResource.builder()
+                    .resourceId(VPC_ID)
+                    .resourceName(VPC_NAME)
+                    .build();
+
+            when(vpcManagementPort.createVpc(any())).thenReturn(mockCreatedVpc);
+            when(cloudProviderRepository.findFirstByProviderType(PROVIDER_TYPE))
+                    .thenReturn(Optional.empty()); // Provider 없음 -> DB 저장 실패
+
+            // When
+            CloudResource result = vpcUseCaseService.createVpc(request);
+
+            // Then
+            assertThat(result).isNotNull(); // CSP 생성은 성공
+            assertThat(result.getResourceId()).isEqualTo(VPC_ID);
+            verify(cloudResourceRepository, never()).save(any()); // DB 저장은 스킵됨
+        }
+
+        @Test
+        @DisplayName("VPC 이름이 없으면 VPC ID가 리소스 이름으로 사용된다")
+        void createVpc_NoVpcName_UsesVpcIdAsResourceName() {
+            // Given
+            VpcCreateRequest request = VpcCreateRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .vpcName(null) // VPC 이름 없음
+                    .cidrBlock(CIDR_BLOCK)
+                    .region("us-east-1")
+                    .build();
+
+            CloudResource mockCreatedVpc = CloudResource.builder()
+                    .resourceId(VPC_ID)
+                    .resourceName(VPC_ID)
+                    .build();
+
+            CloudProvider mockProvider = CloudProvider.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .build();
+
+            Tenant mockTenant = Tenant.builder()
+                    .tenantKey(TENANT_KEY)
+                    .build();
+
+            when(vpcManagementPort.createVpc(any())).thenReturn(mockCreatedVpc);
+            when(cloudProviderRepository.findFirstByProviderType(PROVIDER_TYPE))
+                    .thenReturn(Optional.of(mockProvider));
+            when(cloudServiceRepository.findByProviderTypeAndServiceKey(any(), any()))
+                    .thenReturn(Optional.empty());
+            when(tenantRepository.findByTenantKey(TENANT_KEY))
+                    .thenReturn(Optional.of(mockTenant));
+            when(cloudResourceRepository.save(any(CloudResource.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            vpcUseCaseService.createVpc(request);
+
+            // Then
+            ArgumentCaptor<CloudResource> captor = ArgumentCaptor.forClass(CloudResource.class);
+            verify(cloudResourceRepository).save(captor.capture());
+            
+            CloudResource savedResource = captor.getValue();
+            assertThat(savedResource.getResourceName()).isEqualTo(VPC_ID); // VPC ID가 이름으로 사용됨
+        }
+    }
+
+    @Nested
+    @DisplayName("VPC 삭제 테스트")
+    class DeleteVpcTest {
+
+        @Test
+        @DisplayName("VPC 삭제 시 소프트 삭제가 수행된다")
+        void deleteVpc_Success_SoftDeletesResource() {
+            // Given
+            ResourceIdentity vpcId = ResourceIdentity.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .providerResourceId(VPC_ID)
+                    .region("us-east-1")
+                    .build();
+
+            doNothing().when(vpcManagementPort).deleteVpc(any());
+            when(cloudResourceRepository.softDeleteByResourceId(VPC_ID)).thenReturn(1);
+
+            // When
+            vpcUseCaseService.deleteVpc(vpcId);
+
+            // Then
+            verify(vpcManagementPort).deleteVpc(any());
+            verify(cloudResourceRepository).softDeleteByResourceId(VPC_ID);
+        }
+
+        @Test
+        @DisplayName("DB에 리소스가 없어도 CSP 삭제는 성공한다")
+        void deleteVpc_ResourceNotInDb_CspDeletionSucceeds() {
+            // Given
+            ResourceIdentity vpcId = ResourceIdentity.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .providerResourceId(VPC_ID)
+                    .region("us-east-1")
+                    .build();
+
+            doNothing().when(vpcManagementPort).deleteVpc(any());
+            when(cloudResourceRepository.softDeleteByResourceId(VPC_ID)).thenReturn(0); // DB에 없음
+
+            // When
+            vpcUseCaseService.deleteVpc(vpcId);
+
+            // Then
+            verify(vpcManagementPort).deleteVpc(any()); // CSP 작업 성공
+        }
+    }
+}

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseServiceDbSyncTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseServiceDbSyncTest.java
@@ -1,10 +1,12 @@
 package com.agenticcp.core.domain.cloud.service.vpc;
 
 import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.common.exception.BusinessException;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.VpcCreateRequest;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
 import com.agenticcp.core.domain.cloud.port.model.ResourceIdentity;
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
@@ -23,6 +25,7 @@ import java.time.LocalDateTime;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -133,8 +136,8 @@ class VpcUseCaseServiceDbSyncTest {
         }
 
         @Test
-        @DisplayName("DB 저장 실패 시에도 CSP 생성은 성공한다")
-        void createVpc_DbSaveFails_CspCreationSucceeds() {
+        @DisplayName("DB 저장 실패 시 보상 트랜잭션이 실행되고 예외가 발생한다")
+        void createVpc_DbSaveFails_CompensatingTransactionExecuted() {
             // Given
             VpcCreateRequest request = VpcCreateRequest.builder()
                     .providerType(PROVIDER_TYPE)
@@ -150,17 +153,20 @@ class VpcUseCaseServiceDbSyncTest {
                     .build();
 
             when(vpcManagementPort.createVpc(any())).thenReturn(mockCreatedVpc);
-            // Helper 내부에서 예외 발생해도 경고 로그만 출력되고 계속 진행됨
+            // DB 저장 실패
             doThrow(new RuntimeException("DB 저장 실패")).when(resourceHelper)
                     .registerVpc(any(), any(), any(), any(), any(), any());
 
-            // When
-            CloudResource result = vpcUseCaseService.createVpc(request);
+            // When & Then
+            assertThatThrownBy(() -> vpcUseCaseService.createVpc(request))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(exception -> {
+                        BusinessException be = (BusinessException) exception;
+                        assertThat(be.getErrorCode()).isEqualTo(CloudErrorCode.RESOURCE_CREATION_FAILED);
+                    });
 
-            // Then
-            assertThat(result).isNotNull(); // CSP 생성은 성공
-            assertThat(result.getResourceId()).isEqualTo(VPC_ID);
-            verify(resourceHelper).registerVpc(any(), any(), any(), any(), any(), any());
+            // 보상 트랜잭션 실행 검증: CSP VPC 삭제 호출됨
+            verify(vpcManagementPort).deleteVpc(any());
         }
 
         @Test

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseServiceTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseServiceTest.java
@@ -16,7 +16,7 @@ import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential
 import com.agenticcp.core.domain.cloud.port.model.vpc.*;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
-
+import com.agenticcp.core.domain.cloud.service.helper.CloudResourceManagementHelper;
 import com.agenticcp.core.domain.cloud.port.outbound.vpc.VpcManagementPort;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,6 +63,9 @@ class VpcUseCaseServiceTest {
 
     @Mock
     private VpcManagementPort vpcManagementPort;
+
+    @Mock
+    private CloudResourceManagementHelper resourceHelper;
 
     @InjectMocks
     private VpcUseCaseService vpcUseCaseService;
@@ -119,6 +122,8 @@ class VpcUseCaseServiceTest {
 
             given(vpcManagementPort.createVpc(any(CreateVpcCommand.class)))
                 .willReturn(mockVpcResource);
+            
+            doNothing().when(resourceHelper).registerVpc(any(), any(), any(), any(), any(), any());
 
             // When
             CloudResource result = vpcUseCaseService.createVpc(request);
@@ -640,6 +645,7 @@ class VpcUseCaseServiceTest {
             )).willReturn(mockSession);
 
             doNothing().when(vpcManagementPort).deleteVpc(any(DeleteVpcCommand.class));
+            doNothing().when(resourceHelper).softDeleteResource(anyString());
 
             // When
             vpcUseCaseService.deleteVpc(vpcId);
@@ -746,6 +752,8 @@ class VpcUseCaseServiceTest {
 
             given(vpcManagementPort.createVpc(any(CreateVpcCommand.class)))
                 .willReturn(mockVpcResource);
+            
+            doNothing().when(resourceHelper).registerVpc(any(), any(), any(), any(), any(), any());
 
             // When
             vpcUseCaseService.createVpc(request);
@@ -776,6 +784,8 @@ class VpcUseCaseServiceTest {
 
             given(vpcManagementPort.createVpc(any(CreateVpcCommand.class)))
                 .willReturn(mockVpcResource);
+            
+            doNothing().when(resourceHelper).registerVpc(any(), any(), any(), any(), any(), any());
 
             // When
             vpcUseCaseService.createVpc(request);
@@ -807,6 +817,8 @@ class VpcUseCaseServiceTest {
 
             given(vpcManagementPort.createVpc(any(CreateVpcCommand.class)))
                 .willReturn(mockVpcResource);
+            
+            doNothing().when(resourceHelper).registerVpc(any(), any(), any(), any(), any(), any());
 
             // When
             vpcUseCaseService.createVpc(request);

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseServiceTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/vpc/VpcUseCaseServiceTest.java
@@ -123,7 +123,7 @@ class VpcUseCaseServiceTest {
             given(vpcManagementPort.createVpc(any(CreateVpcCommand.class)))
                 .willReturn(mockVpcResource);
             
-            doNothing().when(resourceHelper).registerVpc(any(), any(), any(), any(), any(), any());
+            when(resourceHelper.registerResource(any(), any(), any())).thenReturn(mockVpcResource);
 
             // When
             CloudResource result = vpcUseCaseService.createVpc(request);
@@ -753,7 +753,7 @@ class VpcUseCaseServiceTest {
             given(vpcManagementPort.createVpc(any(CreateVpcCommand.class)))
                 .willReturn(mockVpcResource);
             
-            doNothing().when(resourceHelper).registerVpc(any(), any(), any(), any(), any(), any());
+            when(resourceHelper.registerResource(any(), any(), any())).thenReturn(mockVpcResource);
 
             // When
             vpcUseCaseService.createVpc(request);
@@ -785,7 +785,7 @@ class VpcUseCaseServiceTest {
             given(vpcManagementPort.createVpc(any(CreateVpcCommand.class)))
                 .willReturn(mockVpcResource);
             
-            doNothing().when(resourceHelper).registerVpc(any(), any(), any(), any(), any(), any());
+            when(resourceHelper.registerResource(any(), any(), any())).thenReturn(mockVpcResource);
 
             // When
             vpcUseCaseService.createVpc(request);
@@ -818,7 +818,7 @@ class VpcUseCaseServiceTest {
             given(vpcManagementPort.createVpc(any(CreateVpcCommand.class)))
                 .willReturn(mockVpcResource);
             
-            doNothing().when(resourceHelper).registerVpc(any(), any(), any(), any(), any(), any());
+            when(resourceHelper.registerResource(any(), any(), any())).thenReturn(mockVpcResource);
 
             // When
             vpcUseCaseService.createVpc(request);


### PR DESCRIPTION
## 📋 개요

클라우드 리소스(VM, S3 버킷, VPC) 생성 시 CSP에서 생성된 리소스 정보를 `CloudResource` 엔티티에 저장하는 로직을 구현하고, 구현 과정에서 발생한 여러 이슈를 해결했습니다.

## 🎯 주요 변경사항

### 1. DB 저장 로직 구현

#### 1.1 VM 인스턴스 DB 저장 로직
- **파일**: `VmUseCaseService.java`
- **구현 내용**:
  - `saveCloudResource` 메서드 추가
  - CSP에서 VM 인스턴스 생성 후 `CloudResource` 엔티티에 저장
  - `CloudProvider`, `CloudService`, `Tenant` 엔티티 조회 및 연관 관계 설정
  - 리소스 타입: `ResourceType.INSTANCE`
  - 생명주기 상태: `LifecycleState.PENDING` (생성 직후)
  - 인스턴스 크기(`instanceSize`) 정보 저장
  - 태그에서 리소스 이름 추출 (`extractResourceName` 메서드 사용)
  - 태그 정보를 JSON 문자열로 직렬화하여 저장
  - DB 저장 실패 시에도 CSP 생성은 완료되므로 예외 처리로 경고 로그만 출력

#### 1.2 Object Storage (S3) DB 저장 로직
- **파일**: `ObjectStorageUseCaseService.java`
- **구현 내용**:
  - `saveCloudResource` 메서드 추가
  - CSP에서 버킷 생성 후 `CloudResource` 엔티티에 저장
  - `CloudProvider`, `CloudService`, `Tenant` 엔티티 조회 및 연관 관계 설정
  - 리소스 타입: `ResourceType.BUCKET`
  - 생명주기 상태: `LifecycleState.RUNNING`
  - 태그 정보를 JSON 문자열로 직렬화하여 저장
  - DB 저장 실패 시에도 CSP 생성은 완료되므로 예외 처리로 경고 로그만 출력

#### 1.3 VPC DB 저장 로직
- **파일**: `VpcUseCaseService.java`
- **구현 내용**:
  - `saveCloudResource` 메서드 추가
  - CSP에서 VPC 생성 후 `CloudResource` 엔티티에 저장
  - `CloudProvider`, `CloudService`, `Tenant` 엔티티 조회 및 연관 관계 설정
  - 리소스 타입: `ResourceType.NETWORK`
  - 생명주기 상태: `LifecycleState.RUNNING`
  - CIDR 블록 정보를 `configuration` 필드에 저장
  - 태그 정보를 JSON 문자열로 직렬화하여 저장
  - **트랜잭션 분리**: `@Transactional(propagation = Propagation.REQUIRES_NEW)`로 별도 트랜잭션으로 분리하여 DB 저장 실패가 메인 트랜잭션에 영향을 주지 않도록 개선

#### 1.4 저장 로직 공통 패턴
- **엔티티 조회**: `CloudProvider`, `CloudService`, `Tenant` 조회
- **리소스 정보 매핑**: CSP에서 생성된 리소스 정보를 `CloudResource` 엔티티로 변환
- **메타데이터 저장**: 태그, 생성 시간, 수정 시간, 동기화 시간 저장
- **에러 처리**: DB 저장 실패 시에도 CSP 생성은 완료되었으므로 예외를 catch하여 경고 로그만 출력
- **멀티 테넌트 지원**: `TenantContextHolder`를 통해 현재 테넌트 정보 획득

### 2. Object Storage (S3) 관련 수정

#### 2.1 권한 변경
- **파일**: `ObjectStorageController.java`
- **변경**: 모든 `@PreAuthorize` 어노테이션에서 `hasRole('ADMIN')` → `hasRole('SUPER_ADMIN')`으로 변경
- **영향**: CREATE, UPDATE, READ, DELETE, HEAD 엔드포인트 모두 적용
- **이유**: S3 버킷 생성/관리 권한을 더 엄격하게 제한

#### 2.2 Capability 체크 로직 수정
- **파일**: `ObjectStorageUseCaseService.java`
- **변경**: 
  - `RESOURCE_TYPE` 상수를 `"BUCKET"`으로 정의
  - Capability 체크를 `"OBJECT_STORAGE"/"CONTAINER"` → `getServiceKeyForProvider()` + `"BUCKET"`으로 변경
- **이유**: `AwsCapabilityConfig`에 등록된 `AWS|S3|BUCKET` Capability와 일치하도록 수정

#### 2.3 ProviderScoped 인터페이스 구현
- **파일**: `AwsS3BucketManagementAdapter.java`
- **변경**: `ProviderScoped` 인터페이스 구현 및 `getProviderType()` 메서드 추가
- **이유**: `ObjectStoragePortRouter`에서 AWS 어댑터를 정상적으로 라우팅할 수 있도록 수정

### 3. VPC 관련 수정

#### 3.1 Jackson 역직렬화 수정
- **파일**: `VpcCreateRequest.java`
- **변경**: `@Jacksonized` 어노테이션 추가
- **이유**: Jackson이 `@Value`와 `@Builder`를 사용한 DTO를 역직렬화할 수 있도록 수정
- **해결**: VPC 생성 API 호출 시 `HttpMessageConversionException` 해결

#### 3.2 권한 변경
- **파일**: `VpcController.java`
- **변경**: 모든 `@PreAuthorize` 어노테이션에서 `hasRole('ADMIN')` → `hasRole('SUPER_ADMIN')`으로 변경
- **영향**: CREATE, READ, UPDATE, DELETE 엔드포인트 모두 적용

#### 3.3 서비스 키 로직 개선 및 멀티 클라우드 지원 준비
- **파일**: `VpcUseCaseService.java`
- **변경사항**:
  1. `getServiceKeyForProvider`의 AWS 케이스를 `"VPC"` → `"EC2"`로 수정 (VPC는 EC2 서비스에 속함)
  2. `saveCloudResource`에서 하드코딩된 `VpcConstants.SERVICE_KEY` 대신 `getServiceKeyForProvider(providerType)` 사용
  3. `cloudService` null 체크를 예외 처리로 변경하여 명확한 에러 메시지 제공
  4. `saveCloudResource`를 `@Transactional(propagation = Propagation.REQUIRES_NEW)`로 분리하여 DB 저장 실패가 메인 트랜잭션에 영향을 주지 않도록 개선
- **효과**: 향후 Azure, GCP 지원 시 코드 수정 없이 확장 가능

## 🐛 해결한 이슈

### 1. Object Storage 관련
- ❌ **문제**: `403 FORBIDDEN` - 권한 부족
  - **원인**: `hasRole('ADMIN')` 사용, 실제 사용자 역할은 `SUPER_ADMIN`
  - **해결**: 모든 권한 체크를 `hasRole('SUPER_ADMIN')`으로 변경

- ❌ **문제**: `BusinessException: 지원 Capability가 정의되지 않았습니다`
  - **원인**: Capability 체크 시 `"OBJECT_STORAGE"/"CONTAINER"` 사용, 실제 등록된 Capability는 `AWS|S3|BUCKET`
  - **해결**: `getServiceKeyForProvider()`와 `RESOURCE_TYPE = "BUCKET"` 사용

- ❌ **문제**: `IllegalArgumentException: 지원하지 않는 프로바이더 타입입니다: AWS`
  - **원인**: `AwsS3BucketManagementAdapter`가 `ProviderScoped` 인터페이스를 구현하지 않아 라우터에 등록되지 않음
  - **해결**: `ProviderScoped` 인터페이스 구현 및 `getProviderType()` 메서드 추가

### 2. VPC 관련
- ❌ **문제**: `HttpMessageConversionException: Type definition error`
  - **원인**: `VpcCreateRequest`에 `@Jacksonized` 어노테이션 누락
  - **해결**: `@Jacksonized` 어노테이션 추가

- ❌ **문제**: `403 FORBIDDEN` - 권한 부족
  - **원인**: `hasRole('ADMIN')` 사용
  - **해결**: 모든 권한 체크를 `hasRole('SUPER_ADMIN')`으로 변경

- ❌ **문제**: `UnexpectedRollbackException: Transaction silently rolled back`
  - **원인**: 
    1. `getServiceKeyForProvider`가 `"VPC"`를 반환하지만 실제로는 `"EC2"`가 필요
    2. `cloudService`가 `null`인데 `CloudResource.service` 필드가 `nullable = false`
    3. DB 저장 실패 시 트랜잭션이 롤백 전용으로 표시됨
  - **해결**: 
    1. `getServiceKeyForProvider`의 AWS 케이스를 `"EC2"`로 수정
    2. `cloudService` null 체크를 예외 처리로 변경
    3. `saveCloudResource`를 별도 트랜잭션으로 분리

## 🧪 테스트

### 테스트 시나리오
1. ✅ VM 인스턴스 생성 API 호출 성공 및 DB 저장 확인
2. ✅ S3 버킷 생성 API 호출 성공 및 DB 저장 확인
3. ✅ VPC 생성 API 호출 성공 및 DB 저장 확인
4. ✅ CloudResource 엔티티에 리소스 정보 정상 저장 확인
5. ✅ 권한 체크 정상 동작 확인 (SUPER_ADMIN만 접근 가능)

## 🔄 향후 작업

- [ ] VPC 태그 처리 우선순위 수정 (`vpcName`이 태그의 `Name`보다 우선하도록)
- [ ] VPC 생성 로직 엔드포인트 나머지 리소스와 일치