### PR TITLE
Feature: RDBMS 관리 기능 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,11 @@
             <artifactId>resourcegroupstaggingapi</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+        </dependency>
+
         <!-- AWS SDK v2 for Java - EC2 only -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/src/main/java/com/agenticcp/core/common/enums/AuditResourceType.java
+++ b/src/main/java/com/agenticcp/core/common/enums/AuditResourceType.java
@@ -25,8 +25,6 @@ public enum AuditResourceType {
     CLOUD_ACCOUNT("클라우드계정"),
     TARGETING_RULE("타겟팅규칙"),
     PLATFORM_CONFIG("플랫폼설정"),
-    S3_BUCKET("S3버킷"),
-    OBJECT_STORAGE_CONTAINER("오브젝트스토리지컨테이너"),
     UI("사용자인터페이스");
     
     private final String description;

--- a/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/config/AwsCapabilityConfig.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/config/AwsCapabilityConfig.java
@@ -87,4 +87,26 @@ public class AwsCapabilityConfig {
 
         log.info("AWS S3 Bucket capabilities registered successfully - AWS|S3|BUCKET");
     }
+
+    @PostConstruct
+    public void initializeRdsCapabilities() {
+        log.info("Registering AWS RDS capabilities...");
+
+        CspCapability awsRdsCapability = CspCapability.builder()
+                .supportsStart(true)      // RDS 인스턴스 시작 지원 (일부 엔진만 지원)
+                .supportsStop(true)       // RDS 인스턴스 중지 지원 (일부 엔진만 지원)
+                .supportsTerminate(true)  // RDS 인스턴스 삭제 지원
+                .supportsTagging(true)    // AWS RDS 인스턴스 태그 지원
+                .supportsListByTag(true)  // 태그 기반 목록 조회 지원
+                .build();
+
+        capabilityRegistry.register(
+                CloudProvider.ProviderType.AWS,
+                "RDS",  // 서비스 타입
+                "DATABASE",       // 리소스 타입
+                awsRdsCapability
+        );
+
+        log.info("AWS RDS capabilities registered successfully - AWS|RDS|DATABASE");
+    }
 }

--- a/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/config/AwsRdsConfig.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/config/AwsRdsConfig.java
@@ -1,0 +1,90 @@
+package com.agenticcp.core.domain.cloud.adapter.outbound.aws.config;
+
+import com.agenticcp.core.common.exception.BusinessException;
+import com.agenticcp.core.domain.cloud.adapter.outbound.aws.account.AwsSessionCredential;
+import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.rds.RdsClient;
+
+/**
+ * AWS RDS 설정 클래스
+ * 
+ * 세션 자격증명 기반으로 RdsClient를 생성합니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Slf4j
+@Configuration
+@ConditionalOnProperty(name = "aws.enabled", havingValue = "true", matchIfMissing = true)
+public class AwsRdsConfig {
+
+    /**
+     * 세션 자격증명으로 RDS Client를 생성합니다.
+     * 
+     * @param session AWS 세션 자격증명
+     * @param region AWS 리전 (RDS는 리전이 중요하므로 명시적 전달 권장, null이면 세션 리전 사용)
+     * @return RdsClient 인스턴스
+     */
+    public RdsClient createRdsClient(CloudSessionCredential session, String region) {
+        AwsSessionCredential awsSession = validateAndCastSession(session);
+        String targetRegion = region != null ? region : awsSession.getRegion();
+
+        return RdsClient.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(toSdkCredentials(awsSession)))
+                .region(Region.of(resolveRegion(targetRegion)))
+                .build();
+    }
+    
+    /**
+     * 리전 기본값 처리
+     * 
+     * @param region AWS 리전 (null이거나 빈 문자열이면 us-east-1 반환)
+     * @return 처리된 리전 문자열
+     */
+    private String resolveRegion(String region) {
+        return (region != null && !region.isBlank()) ? region : "us-east-1";
+    }
+
+    /**
+     * 세션 검증 및 AWS 세션으로 캐스팅
+     *
+     * @param session 도메인 세션 자격증명
+     * @return AWS 세션 자격증명
+     * @throws BusinessException 세션이 유효하지 않거나 AWS 세션이 아닌 경우
+     */
+    private AwsSessionCredential validateAndCastSession(CloudSessionCredential session) {
+        if (session == null) {
+            throw new BusinessException(CloudErrorCode.CLOUD_CONNECTION_FAILED, "세션 자격증명이 필요합니다.");
+        }
+        if (!(session instanceof AwsSessionCredential awsSession)) {
+            throw new BusinessException(CloudErrorCode.CLOUD_CONNECTION_FAILED,
+                    "AWS 세션 자격증명이 필요합니다. 제공된 타입: " + session.getClass().getSimpleName());
+        }
+        if (!awsSession.isValid()) {
+            throw new BusinessException(CloudErrorCode.CLOUD_CONNECTION_FAILED,
+                    "세션이 만료되었습니다. expiresAt: " + awsSession.getExpiresAt());
+        }
+        return awsSession;
+    }
+
+    /**
+     * 도메인 세션 객체를 AWS SDK 세션 객체로 변환
+     *
+     * @param session AWS 도메인 세션 자격증명
+     * @return AWS SDK 세션 자격증명
+     */
+    private AwsSessionCredentials toSdkCredentials(AwsSessionCredential session) {
+        return AwsSessionCredentials.create(
+                session.getAccessKeyId(),
+                session.getSecretAccessKey(),
+                session.getSessionToken()
+        );
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/config/AwsS3Config.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/config/AwsS3Config.java
@@ -2,15 +2,13 @@ package com.agenticcp.core.domain.cloud.adapter.outbound.aws.config;
 
 import com.agenticcp.core.common.exception.BusinessException;
 import com.agenticcp.core.domain.cloud.adapter.outbound.aws.account.AwsSessionCredential;
-import com.agenticcp.core.domain.cloud.adapter.outbound.common.ThreadLocalCredentialCache;
-import com.agenticcp.core.common.context.TenantContextHolder;
 import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -18,45 +16,22 @@ import software.amazon.awssdk.services.resourcegroupstaggingapi.ResourceGroupsTa
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.sts.StsClient;
 
-import java.net.URI;
-
 /**
  * AWS S3 설정 클래스
  * 
- * S3Client, ResourceGroupsTaggingApiClient, StsClient Bean을 생성합니다.
- * ThreadLocal 기반 자격증명을 사용하여 멀티 테넌트 환경을 지원합니다.
+ * 세션 자격증명 기반으로 S3Client, ResourceGroupsTaggingApiClient를 생성합니다.
+ * StsClient Bean을 생성합니다.
  * 
  * @author AgenticCP Team
  * @version 1.0.0
  */
 @Slf4j
 @Configuration
+@ConditionalOnProperty(name = "aws.enabled", havingValue = "true", matchIfMissing = true)
 public class AwsS3Config {
 
     @Value("${aws.s3.region:us-east-1}")
     private String defaultRegion;
-
-    @Value("${aws.s3.endpoint:}")
-    private String endpoint;
-
-    /**
-     * S3Client Bean을 생성합니다.
-     * ThreadLocal 기반 자격증명을 사용하여 동적 자격증명을 지원합니다.
-     * 
-     * @return S3Client 인스턴스
-     */
-    @Bean
-    public S3Client s3Client() {
-        var builder = S3Client.builder()
-                .region(Region.of(resolveRegion(defaultRegion)))
-                .credentialsProvider(createThreadLocalCredentialsProvider());
-        
-        // 커스텀 엔드포인트 설정 (LocalStack 등 테스트 환경용)
-        if (endpoint != null && !endpoint.isEmpty()) {
-            builder.endpointOverride(URI.create(endpoint));
-        }
-        return builder.build();
-    }
 
     /**
      * 세션 자격증명으로 S3 Client를 생성합니다.
@@ -73,26 +48,6 @@ public class AwsS3Config {
                 .credentialsProvider(StaticCredentialsProvider.create(toSdkCredentials(awsSession)))
                 .region(Region.of(resolveRegion(targetRegion)))
                 .build();
-    }
-
-    /**
-     * ResourceGroupsTaggingApiClient Bean을 생성합니다.
-     * 태그 기반 리소스 조회에 사용됩니다.
-     * ThreadLocal 기반 자격증명을 사용하여 동적 자격증명을 지원합니다.
-     * 
-     * @return ResourceGroupsTaggingApiClient 인스턴스
-     */
-    @Bean
-    public ResourceGroupsTaggingApiClient resourceGroupsTaggingApiClient() {
-        var builder = ResourceGroupsTaggingApiClient.builder()
-                .region(Region.of(resolveRegion(defaultRegion)))
-                .credentialsProvider(createThreadLocalCredentialsProvider());
-
-        // 커스텀 엔드포인트 설정 (LocalStack 등 테스트 환경용)
-        if (endpoint != null && !endpoint.isEmpty()) {
-            builder.endpointOverride(URI.create(endpoint));
-        }
-        return builder.build();
     }
 
     /**
@@ -134,35 +89,6 @@ public class AwsS3Config {
      */
     private String resolveRegion(String region) {
         return (region != null && !region.isBlank()) ? region : "us-east-1";
-    }
-    
-    /**
-     * ThreadLocal 기반 자격증명 제공자 생성
-     * 
-     * 현재 스레드의 ThreadLocal 캐시에서 자격증명을 조회하여 제공합니다.
-     * 멀티 테넌트 환경에서 각 요청별로 다른 자격증명을 사용할 수 있도록 합니다.
-     */
-    private AwsCredentialsProvider createThreadLocalCredentialsProvider() {
-        return () -> {
-            try {
-                // 현재 테넌트 키 조회
-                String tenantKey = TenantContextHolder.getCurrentTenantKey();
-                
-                if (tenantKey == null) {
-                    log.warn("테넌트 컨텍스트가 설정되지 않음 - 기본 자격증명 사용");
-                    return null; // 기본 자격증명 사용
-                }
-                
-                // ThreadLocal 캐시에서 자격증명 조회
-                // 현재는 첫 번째 캐시된 자격증명을 반환
-                // TODO: 실제로는 요청 컨텍스트에서 프로바이더 타입과 계정 스코프를 가져와야 함
-                return ThreadLocalCredentialCache.getFirstCredentials();
-                
-            } catch (Exception e) {
-                log.error("ThreadLocal 자격증명 조회 실패: {}", e.getMessage(), e);
-                return null; // 기본 자격증명 사용
-            }
-        };
     }
 
     /**

--- a/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/rds/AwsRdsDiscoveryAdapter.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/rds/AwsRdsDiscoveryAdapter.java
@@ -1,0 +1,239 @@
+package com.agenticcp.core.domain.cloud.adapter.outbound.aws.rds;
+
+import com.agenticcp.core.domain.cloud.adapter.outbound.aws.config.AwsRdsConfig;
+import com.agenticcp.core.domain.cloud.adapter.outbound.common.CloudErrorTranslator;
+import com.agenticcp.core.domain.cloud.adapter.outbound.common.ProviderScoped;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsQuery;
+import com.agenticcp.core.domain.cloud.port.outbound.rdbms.RdbmsDiscoveryPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * AWS RDS 조회 어댑터
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "aws.enabled", havingValue = "true", matchIfMissing = true)
+@RequiredArgsConstructor
+public class AwsRdsDiscoveryAdapter implements RdbmsDiscoveryPort, ProviderScoped {
+
+    private final AwsRdsConfig awsRdsConfig;
+    private final AwsRdsMapper mapper;
+
+    @Override
+    public CloudProvider.ProviderType getProviderType() {
+        return CloudProvider.ProviderType.AWS;
+    }
+
+    /**
+     *
+     * @param session 세션 자격증명
+     * @param operation RDS 클라이언트를 사용하는 작업
+     * @param <T> 반환 타입
+     * @return 작업 결과
+     */
+    private <T> T executeWithRdsClient(CloudSessionCredential session, String region, Function<RdsClient, T> operation) {
+        RdsClient client = awsRdsConfig.createRdsClient(session, region);
+        
+        try {
+            return operation.apply(client);
+        } finally {
+            client.close();
+        }
+    }
+
+    @Override
+    public Page<CloudResource> listRdbmsInstances(RdbmsQuery query, CloudSessionCredential session) {
+        log.debug("[AwsRdsDiscoveryAdapter] Listing RDBMS instances with query: {}", query);
+        
+        String region = query.getRegions() != null && !query.getRegions().isEmpty()
+            ? query.getRegions().iterator().next()
+            : null;
+        
+        return executeWithRdsClient(session, region, client -> {
+            try {
+                DescribeDbInstancesRequest request = buildDescribeRequest(query);
+                DescribeDbInstancesResponse response = client.describeDBInstances(request);
+
+                List<CloudResource> resources = response.dbInstances().stream()
+                        .filter(dbInstance -> matchesQuery(dbInstance, query))
+                        .map(dbInstance -> mapper.toCloudResource(
+                            dbInstance, 
+                            query.getProviderType(), 
+                            "RDS", // 기본 서비스 키
+                            region
+                        ))
+                        .collect(Collectors.toList());
+
+                // 페이징 처리
+                Pageable pageable = PageRequest.of(query.getPage(), query.getSize());
+                int start = (int) pageable.getOffset();
+                int end = Math.min(start + pageable.getPageSize(), resources.size());
+                List<CloudResource> pagedResources = start < resources.size() 
+                    ? resources.subList(start, end) 
+                    : List.of();
+
+                log.debug("[AwsRdsDiscoveryAdapter] Found {} RDBMS instances", resources.size());
+                return new PageImpl<>(pagedResources, pageable, resources.size());
+
+            } catch (Throwable t) {
+                log.error("[AwsRdsDiscoveryAdapter] Failed to list RDBMS instances", t);
+                throw CloudErrorTranslator.translate(t);
+            }
+        });
+    }
+
+    @Override
+    public Optional<CloudResource> getRdbmsInstance(String instanceId, CloudSessionCredential session) {
+        log.debug("[AwsRdsDiscoveryAdapter] Getting RDBMS instance: {}", instanceId);
+        
+        return executeWithRdsClient(session, null, client -> {
+            try {
+                DescribeDbInstancesRequest request = buildDescribeRequestById(instanceId);
+                DescribeDbInstancesResponse response = client.describeDBInstances(request);
+
+                Optional<CloudResource> result = response.dbInstances().stream()
+                        .findFirst()
+                        .map(dbInstance -> {
+                            String region = extractRegionFromAvailabilityZone(dbInstance.availabilityZone());
+                            return mapper.toCloudResource(
+                                dbInstance, 
+                                CloudProvider.ProviderType.AWS, 
+                                "RDS", 
+                                region
+                            );
+                        });
+
+                log.debug("[AwsRdsDiscoveryAdapter] Instance {} found: {}", instanceId, result.isPresent());
+                return result;
+
+            } catch (Throwable t) {
+                log.error("[AwsRdsDiscoveryAdapter] Failed to get RDBMS instance: {}", instanceId, t);
+                throw CloudErrorTranslator.translate(t);
+            }
+        });
+    }
+
+    @Override
+    public String getInstanceStatus(String instanceId, CloudSessionCredential session) {
+        log.debug("[AwsRdsDiscoveryAdapter] Getting status for RDBMS instance: {}", instanceId);
+        
+        return executeWithRdsClient(session, null, client -> {
+            try {
+                DescribeDbInstancesRequest request = buildDescribeRequestById(instanceId);
+                DescribeDbInstancesResponse response = client.describeDBInstances(request);
+
+                String status = response.dbInstances().stream()
+                        .findFirst()
+                        .map(DBInstance::dbInstanceStatus)
+                        .orElse("unknown");
+
+                log.debug("[AwsRdsDiscoveryAdapter] RDBMS instance {} status: {}", instanceId, status);
+                return status;
+
+            } catch (Throwable t) {
+                log.error("[AwsRdsDiscoveryAdapter] Failed to get status for RDBMS instance: {}", instanceId, t);
+                throw CloudErrorTranslator.translate(t);
+            }
+        });
+    }
+
+    /**
+     * DBInstance가 쿼리 조건과 일치하는지 확인합니다.
+     */
+    private boolean matchesQuery(DBInstance dbInstance, RdbmsQuery query) {
+        // instanceName 필터
+        if (query.getInstanceName() != null) {
+            if (!dbInstance.dbInstanceIdentifier().equals(query.getInstanceName())) {
+                return false;
+            }
+        }
+        
+        // engine 필터
+        if (query.getEngine() != null) {
+            if (!dbInstance.engine().equalsIgnoreCase(query.getEngine())) {
+                return false;
+            }
+        }
+        
+        // instanceSize 필터
+        if (query.getInstanceSize() != null) {
+            if (!dbInstance.dbInstanceClass().equals(query.getInstanceSize())) {
+                return false;
+            }
+        }
+        
+        // status 필터
+        if (query.getStatus() != null) {
+            if (!dbInstance.dbInstanceStatus().equalsIgnoreCase(query.getStatus())) {
+                return false;
+            }
+        }
+        
+        // tags 필터 (간단한 구현, 향후 개선 가능)
+        // TODO: 태그 필터링 로직 추가
+        
+        return true;
+    }
+    
+    /**
+     * Availability Zone에서 리전을 추출합니다.
+     * 예: "us-east-1a" -> "us-east-1"
+     */
+    private String extractRegionFromAvailabilityZone(String availabilityZone) {
+        if (availabilityZone == null || availabilityZone.isEmpty()) {
+            return null;
+        }
+        
+        if (availabilityZone.length() > 1) {
+            return availabilityZone.substring(0, availabilityZone.length() - 1);
+        }
+        
+        return availabilityZone;
+    }
+    
+    /**
+     * RdbmsQuery를 AWS DescribeDbInstancesRequest로 변환합니다.
+     */
+    private DescribeDbInstancesRequest buildDescribeRequest(RdbmsQuery query) {
+        log.debug("[AwsRdsDiscoveryAdapter] Building DescribeDbInstancesRequest from query");
+        
+        DescribeDbInstancesRequest.Builder builder = DescribeDbInstancesRequest.builder();
+        
+        if (query.getInstanceName() != null) {
+            builder.dbInstanceIdentifier(query.getInstanceName());
+        }
+        
+        return builder.build();
+    }
+    
+    /**
+     * 인스턴스 ID로 AWS DescribeDbInstancesRequest를 생성합니다.
+     */
+    private DescribeDbInstancesRequest buildDescribeRequestById(String instanceId) {
+        log.debug("[AwsRdsDiscoveryAdapter] Building DescribeDbInstancesRequest for instanceId: {}", instanceId);
+        
+        return DescribeDbInstancesRequest.builder()
+                .dbInstanceIdentifier(instanceId)
+                .build();
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/rds/AwsRdsLifecycleAdapter.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/rds/AwsRdsLifecycleAdapter.java
@@ -1,0 +1,127 @@
+package com.agenticcp.core.domain.cloud.adapter.outbound.aws.rds;
+
+import com.agenticcp.core.domain.cloud.adapter.outbound.aws.config.AwsRdsConfig;
+import com.agenticcp.core.domain.cloud.adapter.outbound.common.CloudErrorTranslator;
+import com.agenticcp.core.domain.cloud.adapter.outbound.common.ProviderScoped;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import com.agenticcp.core.domain.cloud.port.outbound.rdbms.RdbmsLifecyclePort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.*;
+
+/**
+ * AWS RDS 생명주기 어댑터
+ * 
+ * RDBMS 인스턴스의 시작, 중지, 재시작 기능을 제공합니다.
+ * 모든 Lifecycle 작업은 세션 자격증명을 사용하여 요청별로 RDS 클라이언트를 생성합니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "aws.enabled", havingValue = "true", matchIfMissing = true)
+@RequiredArgsConstructor
+public class AwsRdsLifecycleAdapter implements RdbmsLifecyclePort, ProviderScoped {
+
+    private final AwsRdsConfig awsRdsConfig;
+
+    @Override
+    public CloudProvider.ProviderType getProviderType() {
+        return CloudProvider.ProviderType.AWS;
+    }
+
+    @Override
+    public void startInstance(String instanceId, CloudSessionCredential session) {
+        log.debug("[AwsRdsLifecycleAdapter] Starting RDBMS instance: {}", instanceId);
+
+        RdsClient client = awsRdsConfig.createRdsClient(session, null);
+        
+        try {
+            log.warn("[AwsRdsLifecycleAdapter] RDS does not support startInstance operation. " +
+                    "RDS instances cannot be stopped and started like EC2 instances. " +
+                    "Use modifyDBInstance to change instance configuration instead.");
+            
+            throw new UnsupportedOperationException(
+                "AWS RDS does not support startInstance operation. " +
+                "RDS instances are always running when available. " +
+                "To resume a stopped instance, use modifyDBInstance or wait for automatic resume."
+            );
+
+        } catch (Throwable t) {
+            log.error("[AwsRdsLifecycleAdapter] Failed to start RDBMS instance: {}", instanceId, t);
+            throw CloudErrorTranslator.translate(t);
+        } finally {
+            client.close();
+        }
+    }
+
+    @Override
+    public void stopInstance(String instanceId, CloudSessionCredential session) {
+        log.debug("[AwsRdsLifecycleAdapter] Stopping RDBMS instance: {}", instanceId);
+        
+        RdsClient client = awsRdsConfig.createRdsClient(session, null);
+        
+        try {
+            StopDbInstanceRequest request = buildStopRequest(instanceId);
+            client.stopDBInstance(request);
+            
+            log.info("[AwsRdsLifecycleAdapter] Successfully stopped RDBMS instance: {}", instanceId);
+
+        } catch (Throwable t) {
+            log.error("[AwsRdsLifecycleAdapter] Failed to stop RDBMS instance: {}", instanceId, t);
+            throw CloudErrorTranslator.translate(t);
+        } finally {
+            client.close();
+        }
+    }
+
+    @Override
+    public void rebootInstance(String instanceId, CloudSessionCredential session) {
+        log.debug("[AwsRdsLifecycleAdapter] Rebooting RDBMS instance: {}", instanceId);
+        
+        RdsClient client = awsRdsConfig.createRdsClient(session, null);
+        
+        try {
+            // Command → AWS SDK Request 변환 (Adapter에서 직접 생성)
+            RebootDbInstanceRequest request = buildRebootRequest(instanceId);
+            RebootDbInstanceResponse response = client.rebootDBInstance(request);
+            
+            log.info("[AwsRdsLifecycleAdapter] Successfully rebooted RDBMS instance: {}", instanceId);
+            log.debug("[AwsRdsLifecycleAdapter] Reboot operation initiated for instance: {}", 
+                response.dbInstance().dbInstanceIdentifier());
+
+        } catch (Throwable t) {
+            log.error("[AwsRdsLifecycleAdapter] Failed to reboot RDBMS instance: {}", instanceId, t);
+            throw CloudErrorTranslator.translate(t);
+        } finally {
+            client.close();
+        }
+    }
+
+    /**
+     * 인스턴스 ID로 AWS StopDbInstanceRequest를 생성합니다.
+     */
+    private StopDbInstanceRequest buildStopRequest(String instanceId) {
+        log.debug("[AwsRdsLifecycleAdapter] Building StopDbInstanceRequest for instanceId: {}", instanceId);
+        
+        return StopDbInstanceRequest.builder()
+                .dbInstanceIdentifier(instanceId)
+                .build();
+    }
+    
+    /**
+     * 인스턴스 ID로 AWS RebootDbInstanceRequest를 생성합니다.
+     */
+    private RebootDbInstanceRequest buildRebootRequest(String instanceId) {
+        log.debug("[AwsRdsLifecycleAdapter] Building RebootDbInstanceRequest for instanceId: {}", instanceId);
+        
+        return RebootDbInstanceRequest.builder()
+                .dbInstanceIdentifier(instanceId)
+                .build();
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/rds/AwsRdsLifecycleAdapter.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/rds/AwsRdsLifecycleAdapter.java
@@ -5,6 +5,7 @@ import com.agenticcp.core.domain.cloud.adapter.outbound.common.CloudErrorTransla
 import com.agenticcp.core.domain.cloud.adapter.outbound.common.ProviderScoped;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider;
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import com.agenticcp.core.domain.cloud.port.model.ResourceIdentity;
 import com.agenticcp.core.domain.cloud.port.outbound.rdbms.RdbmsLifecyclePort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,8 +20,11 @@ import software.amazon.awssdk.services.rds.model.*;
  * RDBMS 인스턴스의 시작, 중지, 재시작 기능을 제공합니다.
  * 모든 Lifecycle 작업은 세션 자격증명을 사용하여 요청별로 RDS 클라이언트를 생성합니다.
  * 
+ * RdbmsLifecyclePort를 구현하여 ResourceLifecyclePort의 start, stop, terminate와
+ * RDBMS 특화 기능인 reboot를 제공합니다.
+ * 
  * @author AgenticCP Team
- * @version 1.0.0
+ * @version 2.0.0
  */
 @Slf4j
 @Component
@@ -35,11 +39,14 @@ public class AwsRdsLifecycleAdapter implements RdbmsLifecyclePort, ProviderScope
         return CloudProvider.ProviderType.AWS;
     }
 
-    @Override
-    public void startInstance(String instanceId, CloudSessionCredential session) {
-        log.debug("[AwsRdsLifecycleAdapter] Starting RDBMS instance: {}", instanceId);
+    // ==================== ResourceLifecyclePort 구현 (RdbmsLifecyclePort를 통해 상속) ====================
 
-        RdsClient client = awsRdsConfig.createRdsClient(session, null);
+    @Override
+    public void start(ResourceIdentity id, CloudSessionCredential session) {
+        String instanceId = id.getProviderResourceId();
+        log.debug("[AwsRdsLifecycleAdapter] Starting RDBMS instance via ResourceLifecyclePort: {}", instanceId);
+
+        RdsClient client = awsRdsConfig.createRdsClient(session, id.getRegion());
         
         try {
             log.warn("[AwsRdsLifecycleAdapter] RDS does not support startInstance operation. " +
@@ -61,10 +68,11 @@ public class AwsRdsLifecycleAdapter implements RdbmsLifecyclePort, ProviderScope
     }
 
     @Override
-    public void stopInstance(String instanceId, CloudSessionCredential session) {
-        log.debug("[AwsRdsLifecycleAdapter] Stopping RDBMS instance: {}", instanceId);
+    public void stop(ResourceIdentity id, CloudSessionCredential session) {
+        String instanceId = id.getProviderResourceId();
+        log.debug("[AwsRdsLifecycleAdapter] Stopping RDBMS instance via ResourceLifecyclePort: {}", instanceId);
         
-        RdsClient client = awsRdsConfig.createRdsClient(session, null);
+        RdsClient client = awsRdsConfig.createRdsClient(session, id.getRegion());
         
         try {
             StopDbInstanceRequest request = buildStopRequest(instanceId);
@@ -79,6 +87,23 @@ public class AwsRdsLifecycleAdapter implements RdbmsLifecyclePort, ProviderScope
             client.close();
         }
     }
+
+    @Override
+    public void terminate(ResourceIdentity id, CloudSessionCredential session) {
+        String instanceId = id.getProviderResourceId();
+        log.debug("[AwsRdsLifecycleAdapter] Terminating RDBMS instance via ResourceLifecyclePort: {}", instanceId);
+        
+        // RDS의 경우 terminate는 delete와 동일하지만, 실제로는 RdbmsManagementPort의 deleteRdbms를 사용해야 합니다.
+        // 여기서는 UnsupportedOperationException을 던지거나, 실제 삭제 로직을 구현할 수 있습니다.
+        log.warn("[AwsRdsLifecycleAdapter] terminate() is called for RDS instance. " +
+                "RDS termination should be handled through RdbmsManagementPort.deleteRdbms() instead.");
+        
+        throw new UnsupportedOperationException(
+            "RDS 인스턴스 종료는 RdbmsManagementPort.deleteRdbms()를 통해 처리해야 합니다."
+        );
+    }
+
+    // ==================== RdbmsLifecyclePort 구현 (reboot 추가 기능) ====================
 
     @Override
     public void rebootInstance(String instanceId, CloudSessionCredential session) {
@@ -102,6 +127,8 @@ public class AwsRdsLifecycleAdapter implements RdbmsLifecyclePort, ProviderScope
             client.close();
         }
     }
+
+    // ==================== Private Helper Methods ====================
 
     /**
      * 인스턴스 ID로 AWS StopDbInstanceRequest를 생성합니다.

--- a/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/rds/AwsRdsManagementAdapter.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/rds/AwsRdsManagementAdapter.java
@@ -1,14 +1,17 @@
 package com.agenticcp.core.domain.cloud.adapter.outbound.aws.rds;
 
+import com.agenticcp.core.common.crypto.EncryptionService;
 import com.agenticcp.core.domain.cloud.adapter.outbound.aws.config.AwsRdsConfig;
 import com.agenticcp.core.domain.cloud.adapter.outbound.common.CloudErrorTranslator;
 import com.agenticcp.core.domain.cloud.adapter.outbound.common.ProviderScoped;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
 import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsCreateCommand;
 import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsDeleteCommand;
 import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsUpdateCommand;
 import com.agenticcp.core.domain.cloud.port.outbound.rdbms.RdbmsManagementPort;
+import com.agenticcp.core.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -38,6 +41,7 @@ public class AwsRdsManagementAdapter implements RdbmsManagementPort, ProviderSco
 
     private final AwsRdsConfig awsRdsConfig;
     private final AwsRdsMapper mapper;
+    private final EncryptionService encryptionService;
 
     @Override
     public CloudProvider.ProviderType getProviderType() {
@@ -222,13 +226,28 @@ public class AwsRdsManagementAdapter implements RdbmsManagementPort, ProviderSco
         log.debug("[AwsRdsManagementAdapter] Building CreateDbInstanceRequest: instanceName={}, engine={}", 
             command.instanceName(), command.engine());
         
+        // adminPassword 복호화
+        String decryptedPassword = null;
+        if (command.adminPassword() != null) {
+            try {
+                decryptedPassword = encryptionService.decrypt(command.adminPassword());
+                log.debug("[AwsRdsManagementAdapter] adminPassword 복호화 완료");
+            } catch (Exception e) {
+                log.error("[AwsRdsManagementAdapter] adminPassword 복호화 실패", e);
+                throw new BusinessException(
+                    CloudErrorCode.DECRYPTION_FAILED,
+                    "관리자 패스워드 복호화에 실패했습니다: " + e.getMessage()
+                );
+            }
+        }
+        
         CreateDbInstanceRequest.Builder builder = CreateDbInstanceRequest.builder()
             .dbInstanceIdentifier(command.instanceName())  // instanceName → dbInstanceIdentifier
             .engine(command.engine())
             .dbInstanceClass(command.instanceSize())  // instanceSize → dbInstanceClass
             .allocatedStorage(command.allocatedStorage())
             .masterUsername(command.adminUsername())
-            .masterUserPassword(command.adminPassword())
+            .masterUserPassword(decryptedPassword)  // 복호화된 패스워드 사용
             .publiclyAccessible(command.publiclyAccessible() != null ? command.publiclyAccessible() : false);
         
         // engineVersion
@@ -295,9 +314,19 @@ public class AwsRdsManagementAdapter implements RdbmsManagementPort, ProviderSco
             builder.allocatedStorage(command.allocatedStorage());
         }
         
-        // adminPassword
+        // adminPassword 복호화
         if (command.adminPassword() != null) {
-            builder.masterUserPassword(command.adminPassword());
+            try {
+                String decryptedPassword = encryptionService.decrypt(command.adminPassword());
+                builder.masterUserPassword(decryptedPassword);
+                log.debug("[AwsRdsManagementAdapter] adminPassword 복호화 완료 (수정)");
+            } catch (Exception e) {
+                log.error("[AwsRdsManagementAdapter] adminPassword 복호화 실패 (수정)", e);
+                throw new BusinessException(
+                    CloudErrorCode.DECRYPTION_FAILED,
+                    "관리자 패스워드 복호화에 실패했습니다: " + e.getMessage()
+                );
+            }
         }
         
         // applyImmediately

--- a/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/rds/AwsRdsManagementAdapter.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/rds/AwsRdsManagementAdapter.java
@@ -1,0 +1,365 @@
+package com.agenticcp.core.domain.cloud.adapter.outbound.aws.rds;
+
+import com.agenticcp.core.domain.cloud.adapter.outbound.aws.config.AwsRdsConfig;
+import com.agenticcp.core.domain.cloud.adapter.outbound.common.CloudErrorTranslator;
+import com.agenticcp.core.domain.cloud.adapter.outbound.common.ProviderScoped;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsCreateCommand;
+import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsDeleteCommand;
+import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsUpdateCommand;
+import com.agenticcp.core.domain.cloud.port.outbound.rdbms.RdbmsManagementPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.*;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AWS RDS 관리 어댑터
+ * 
+ * RDBMS 인스턴스의 생성, 수정, 삭제 기능을 제공합니다.
+ * 모든 Management 작업은 세션 자격증명을 사용하여 요청별로 RDS 클라이언트를 생성합니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "aws.enabled", havingValue = "true", matchIfMissing = true)
+@RequiredArgsConstructor
+public class AwsRdsManagementAdapter implements RdbmsManagementPort, ProviderScoped {
+
+    private final AwsRdsConfig awsRdsConfig;
+    private final AwsRdsMapper mapper;
+
+    @Override
+    public CloudProvider.ProviderType getProviderType() {
+        return CloudProvider.ProviderType.AWS;
+    }
+
+    @Override
+    public CloudResource createRdbms(RdbmsCreateCommand command) {
+        log.debug("[AwsRdsManagementAdapter] Creating RDBMS instance with command: instanceName={}, engine={}", 
+            command.instanceName(), command.engine());
+        
+        RdsClient client = awsRdsConfig.createRdsClient(command.session(), command.region());
+
+        try {
+            // Command → AWS SDK Request 변환 (Adapter에서 직접 생성)
+            CreateDbInstanceRequest request = buildCreateRequest(command);
+            CreateDbInstanceResponse response = client.createDBInstance(request);
+            
+            String instanceIdentifier = response.dbInstance().dbInstanceIdentifier();
+            log.info("[AwsRdsManagementAdapter] RDBMS instance creation initiated: {}", instanceIdentifier);
+            
+            // 인스턴스가 available 상태가 될 때까지 대기
+            DBInstance dbInstance = waitForInstanceAvailable(client, instanceIdentifier);
+            
+            // CloudResource로 변환
+            CloudResource resource = mapper.toCloudResource(
+                dbInstance,
+                command.providerType(), 
+                command.serviceKey(), 
+                command.region()
+            );
+            
+            log.info("[AwsRdsManagementAdapter] Successfully created RDBMS instance: {}", instanceIdentifier);
+            return resource;
+
+        } catch (Throwable t) {
+            log.error("[AwsRdsManagementAdapter] Failed to create RDBMS instance", t);
+            throw CloudErrorTranslator.translate(t);
+        } finally {
+            client.close();
+        }
+    }
+
+    @Override
+    public CloudResource updateRdbms(RdbmsUpdateCommand command) {
+        log.debug("[AwsRdsManagementAdapter] Updating RDBMS instance: instanceId={}", 
+            command.providerResourceId());
+        
+        RdsClient client = awsRdsConfig.createRdsClient(command.session(), command.region());
+        
+        try {
+            // Command → AWS SDK Request 변환 (Adapter에서 직접 생성)
+            ModifyDbInstanceRequest request = buildModifyRequest(command);
+            ModifyDbInstanceResponse response = client.modifyDBInstance(request);
+            
+            String instanceIdentifier = response.dbInstance().dbInstanceIdentifier();
+            log.info("[AwsRdsManagementAdapter] RDBMS instance modification initiated: {}", instanceIdentifier);
+            
+            // 인스턴스가 available 상태가 될 때까지 대기
+            DBInstance dbInstance = waitForInstanceAvailable(client, instanceIdentifier);
+            
+            // CloudResource로 변환 (providerType과 serviceKey는 command에서 추출 필요)
+            // TODO: command에 serviceKey 추가하거나 다른 방법으로 조회
+            CloudResource resource = mapper.toCloudResource(
+                dbInstance, 
+                command.providerType(), 
+                "RDS", // 기본값, command에 serviceKey가 없을 경우
+                command.region()
+            );
+            
+            log.info("[AwsRdsManagementAdapter] Successfully updated RDBMS instance: {}", instanceIdentifier);
+            return resource;
+
+        } catch (Throwable t) {
+            log.error("[AwsRdsManagementAdapter] Failed to update RDBMS instance: {}", 
+                command.providerResourceId(), t);
+            throw CloudErrorTranslator.translate(t);
+        } finally {
+            client.close();
+        }
+    }
+
+    @Override
+    public void deleteRdbms(RdbmsDeleteCommand command) {
+        log.debug("[AwsRdsManagementAdapter] Deleting RDBMS instance: instanceId={}", 
+            command.providerResourceId());
+        
+        RdsClient client = awsRdsConfig.createRdsClient(command.session(), command.region());
+        
+        try {
+            // Command → AWS SDK Request 변환 (Adapter에서 직접 생성)
+            DeleteDbInstanceRequest request = buildDeleteRequest(command);
+            DeleteDbInstanceResponse response = client.deleteDBInstance(request);
+            
+            String instanceIdentifier = response.dbInstance().dbInstanceIdentifier();
+            log.info("[AwsRdsManagementAdapter] RDBMS instance deletion initiated: {}", instanceIdentifier);
+            
+            // 삭제는 비동기로 진행되므로 대기하지 않음
+            // 필요시 별도로 상태 확인 가능
+
+        } catch (Throwable t) {
+            log.error("[AwsRdsManagementAdapter] Failed to delete RDBMS instance: {}", 
+                command.providerResourceId(), t);
+            throw CloudErrorTranslator.translate(t);
+        } finally {
+            client.close();
+        }
+    }
+    
+    /**
+     * RDS 인스턴스가 available 상태가 될 때까지 대기합니다.
+     * 
+     * @param client RDS 클라이언트
+     * @param instanceIdentifier 인스턴스 식별자
+     * @return available 상태의 DBInstance
+     */
+    private DBInstance waitForInstanceAvailable(RdsClient client, String instanceIdentifier) {
+        log.debug("[AwsRdsManagementAdapter] Waiting for instance to be available: {}", instanceIdentifier);
+        
+        int maxWaitMinutes = 30; // 최대 대기 시간 (분)
+        int pollIntervalSeconds = 30; // 폴링 간격 (초)
+        Instant startTime = Instant.now();
+        
+        while (true) {
+            try {
+                DescribeDbInstancesRequest request = DescribeDbInstancesRequest.builder()
+                    .dbInstanceIdentifier(instanceIdentifier)
+                    .build();
+
+                DescribeDbInstancesResponse response = client.describeDBInstances(request);
+                
+                if (response.dbInstances().isEmpty()) {
+                    throw new RuntimeException("DBInstance not found: " + instanceIdentifier);
+                }
+                
+                DBInstance dbInstance = response.dbInstances().get(0);
+                String status = dbInstance.dbInstanceStatus();
+                
+                log.debug("[AwsRdsManagementAdapter] Instance status: {} (waiting for available)", status);
+                
+                if ("available".equalsIgnoreCase(status)) {
+                    log.info("[AwsRdsManagementAdapter] Instance is now available: {}", instanceIdentifier);
+                    return dbInstance;
+                }
+                
+                if ("failed".equalsIgnoreCase(status) || "deleted".equalsIgnoreCase(status)) {
+                    throw new RuntimeException("Instance is in failed or deleted state: " + status);
+                }
+                
+                // 타임아웃 확인
+                Duration elapsed = Duration.between(startTime, Instant.now());
+                if (elapsed.toMinutes() > maxWaitMinutes) {
+                    throw new RuntimeException("Timeout waiting for instance to be available: " + instanceIdentifier);
+                }
+                
+                // 대기
+                Thread.sleep(pollIntervalSeconds * 1000L);
+                
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted while waiting for instance to be available", e);
+            } catch (Throwable t) {
+                log.error("[AwsRdsManagementAdapter] Error while waiting for instance to be available", t);
+                throw CloudErrorTranslator.translate(t);
+            }
+        }
+    }
+    
+    // ==================== Command → AWS Request 변환 ====================
+    
+    /**
+     * RdbmsCreateCommand를 AWS CreateDbInstanceRequest로 변환합니다.
+     * 
+     * CSP 중립 필드 → AWS 특화 필드 매핑:
+     * - instanceName → dbInstanceIdentifier
+     * - instanceSize → dbInstanceClass
+     * - networkSecurityId → vpcSecurityGroupIds
+     * - zone → availabilityZone
+     * - highAvailability → multiAz
+     */
+    private CreateDbInstanceRequest buildCreateRequest(RdbmsCreateCommand command) {
+        log.debug("[AwsRdsManagementAdapter] Building CreateDbInstanceRequest: instanceName={}, engine={}", 
+            command.instanceName(), command.engine());
+        
+        CreateDbInstanceRequest.Builder builder = CreateDbInstanceRequest.builder()
+            .dbInstanceIdentifier(command.instanceName())  // instanceName → dbInstanceIdentifier
+            .engine(command.engine())
+            .dbInstanceClass(command.instanceSize())  // instanceSize → dbInstanceClass
+            .allocatedStorage(command.allocatedStorage())
+            .masterUsername(command.adminUsername())
+            .masterUserPassword(command.adminPassword())
+            .publiclyAccessible(command.publiclyAccessible() != null ? command.publiclyAccessible() : false);
+        
+        // engineVersion
+        if (command.engineVersion() != null) {
+            builder.engineVersion(command.engineVersion());
+        }
+        
+        // dbName
+        if (command.dbName() != null) {
+            builder.dbName(command.dbName());
+        }
+        
+        // networkSecurityId → vpcSecurityGroupIds
+        if (command.networkSecurityId() != null) {
+            builder.vpcSecurityGroupIds(command.networkSecurityId());
+        }
+        
+        // subnetId → dbSubnetGroupName (providerSpecificConfig에서 추출)
+        String subnetGroupName = getSubnetGroupName(command);
+        if (subnetGroupName != null) {
+            builder.dbSubnetGroupName(subnetGroupName);
+        }
+        
+        // port
+        if (command.port() != null) {
+            builder.port(command.port());
+        }
+        
+        // zone → availabilityZone
+        if (command.zone() != null) {
+            builder.availabilityZone(command.zone());
+        }
+        
+        // highAvailability → multiAZ
+        if (command.highAvailability() != null) {
+            builder.multiAZ(command.highAvailability());
+        }
+        
+        // tags
+        if (command.tags() != null && !command.tags().isEmpty()) {
+            builder.tags(convertTagsToAwsTags(command.tags()));
+        }
+        
+        return builder.build();
+    }
+    
+    /**
+     * RdbmsUpdateCommand를 AWS ModifyDbInstanceRequest로 변환합니다.
+     */
+    private ModifyDbInstanceRequest buildModifyRequest(RdbmsUpdateCommand command) {
+        log.debug("[AwsRdsManagementAdapter] Building ModifyDbInstanceRequest: instanceId={}", 
+            command.providerResourceId());
+        
+        ModifyDbInstanceRequest.Builder builder = ModifyDbInstanceRequest.builder()
+            .dbInstanceIdentifier(command.providerResourceId());
+        
+        // instanceSize → dbInstanceClass
+        if (command.instanceSize() != null) {
+            builder.dbInstanceClass(command.instanceSize());
+        }
+        
+        // allocatedStorage
+        if (command.allocatedStorage() != null) {
+            builder.allocatedStorage(command.allocatedStorage());
+        }
+        
+        // adminPassword
+        if (command.adminPassword() != null) {
+            builder.masterUserPassword(command.adminPassword());
+        }
+        
+        // applyImmediately
+        if (command.applyImmediately() != null) {
+            builder.applyImmediately(command.applyImmediately());
+        }
+        
+        return builder.build();
+    }
+    
+    /**
+     * RdbmsDeleteCommand를 AWS DeleteDbInstanceRequest로 변환합니다.
+     */
+    private DeleteDbInstanceRequest buildDeleteRequest(RdbmsDeleteCommand command) {
+        log.debug("[AwsRdsManagementAdapter] Building DeleteDbInstanceRequest: instanceId={}", 
+            command.providerResourceId());
+        
+        DeleteDbInstanceRequest.Builder builder = DeleteDbInstanceRequest.builder()
+            .dbInstanceIdentifier(command.providerResourceId());
+        
+        // skipSnapshot → skipFinalSnapshot
+        if (command.skipSnapshot() != null) {
+            builder.skipFinalSnapshot(command.skipSnapshot());
+        }
+        
+        // snapshotName → finalDBSnapshotIdentifier
+        if (command.snapshotName() != null && !command.skipSnapshot()) {
+            builder.finalDBSnapshotIdentifier(command.snapshotName());
+        }
+        
+        // deleteAutomatedBackups
+        if (command.deleteAutomatedBackups() != null) {
+            builder.deleteAutomatedBackups(command.deleteAutomatedBackups());
+        }
+        
+        return builder.build();
+    }
+    
+    /**
+     * providerSpecificConfig에서 AWS 특화 설정 추출
+     */
+    private String getSubnetGroupName(RdbmsCreateCommand command) {
+        if (command.providerSpecificConfig() != null) {
+            Object subnetGroupName = command.providerSpecificConfig().get("subnetGroupName");
+            return subnetGroupName != null ? subnetGroupName.toString() : null;
+        }
+        return null;
+    }
+    
+    /**
+     * Map을 AWS Tag 리스트로 변환합니다.
+     */
+    private List<software.amazon.awssdk.services.rds.model.Tag> convertTagsToAwsTags(Map<String, String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return List.of();
+        }
+        
+        return tags.entrySet().stream()
+            .map(entry -> software.amazon.awssdk.services.rds.model.Tag.builder()
+                .key(entry.getKey())
+                .value(entry.getValue())
+                .build())
+            .collect(java.util.stream.Collectors.toList());
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/rds/AwsRdsMapper.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/rds/AwsRdsMapper.java
@@ -1,0 +1,210 @@
+package com.agenticcp.core.domain.cloud.adapter.outbound.aws.rds;
+
+import com.agenticcp.core.common.enums.Status;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.entity.CloudRegion;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.entity.CloudService;
+import com.agenticcp.core.domain.cloud.repository.CloudProviderRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudRegionRepository;
+import com.agenticcp.core.domain.cloud.repository.CloudServiceRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.rds.model.*;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * AWS RDS와 도메인 모델 간의 데이터 변환을 담당하는 매퍼
+ *
+ * 이 매퍼는 AWS SDK의 DBInstance 객체를 우리 도메인의 CloudResource로 변환하는 역할을 합니다.
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Slf4j
+@Component
+public class AwsRdsMapper {
+    
+    private final ObjectMapper objectMapper;
+    private final CloudProviderRepository cloudProviderRepository;
+    private final CloudServiceRepository cloudServiceRepository;
+    private final CloudRegionRepository cloudRegionRepository;
+    
+    public AwsRdsMapper(
+            ObjectMapper objectMapper,
+            CloudProviderRepository cloudProviderRepository,
+            CloudServiceRepository cloudServiceRepository,
+            CloudRegionRepository cloudRegionRepository) {
+        this.objectMapper = objectMapper;
+        this.cloudProviderRepository = cloudProviderRepository;
+        this.cloudServiceRepository = cloudServiceRepository;
+        this.cloudRegionRepository = cloudRegionRepository;
+    }
+
+    /**
+     * AWS DBInstance를 CloudResource로 변환합니다.
+     * 
+     * @param dbInstance AWS SDK DBInstance 객체
+     * @param providerType 프로바이더 타입
+     * @param serviceKey 서비스 키 (예: "RDS")
+     * @param region 리전
+     * @return CloudResource 도메인 객체
+     */
+    public CloudResource toCloudResource(DBInstance dbInstance, CloudProvider.ProviderType providerType, 
+                                         String serviceKey, String region) {
+        try {
+            log.debug("[AwsRdsMapper] Converting AWS DBInstance to CloudResource: {}", dbInstance.dbInstanceIdentifier());
+            
+            CloudProvider provider = findProvider(providerType);
+            CloudService service = findService(providerType, serviceKey);
+            CloudRegion cloudRegion = findRegion(providerType, region);
+            
+            return CloudResource.builder()
+                .resourceId(dbInstance.dbInstanceIdentifier())
+                .resourceName(dbInstance.dbInstanceIdentifier())
+                .displayName(dbInstance.dbInstanceIdentifier())
+                .provider(provider)
+                .region(cloudRegion)
+                .service(service)
+                .resourceType(CloudResource.ResourceType.DATABASE)
+                .lifecycleState(mapLifecycleState(dbInstance.dbInstanceStatus()))
+                .instanceType(dbInstance.dbInstanceClass())
+                .instanceSize(dbInstance.dbInstanceClass())
+                .storageGb((long) dbInstance.allocatedStorage())
+                .ipAddress(dbInstance.endpoint() != null ? dbInstance.endpoint().address() : null)
+                .tags(convertTagsToMap(dbInstance.tagList()))
+                .configuration(convertConfigurationToJson(dbInstance))
+                .status(mapStatus(dbInstance.dbInstanceStatus()))
+                .createdInCloud(dbInstance.instanceCreateTime() != null 
+                    ? LocalDateTime.ofInstant(dbInstance.instanceCreateTime(), ZoneId.systemDefault())
+                    : LocalDateTime.now())
+                .lastSync(LocalDateTime.now())
+                .build();
+                
+        } catch (Exception e) {
+            log.error("[AwsRdsMapper] Failed to convert AWS DBInstance to CloudResource: {}", 
+                dbInstance.dbInstanceIdentifier(), e);
+            throw new RuntimeException("Failed to convert AWS DBInstance to CloudResource", e);
+        }
+    }
+
+    /**
+     * AWS DBInstance 상태를 도메인 LifecycleState로 매핑합니다.
+     */
+    private CloudResource.LifecycleState mapLifecycleState(String awsStatus) {
+        if (awsStatus == null) {
+            return CloudResource.LifecycleState.UNKNOWN;
+        }
+        
+        return switch (awsStatus.toLowerCase()) {
+            case "available" -> CloudResource.LifecycleState.RUNNING;
+            case "creating" -> CloudResource.LifecycleState.PENDING;
+            case "deleting" -> CloudResource.LifecycleState.TERMINATING;
+            case "deleted" -> CloudResource.LifecycleState.TERMINATED;
+            case "modifying" -> CloudResource.LifecycleState.PENDING;
+            case "rebooting" -> CloudResource.LifecycleState.PENDING;
+            case "stopped" -> CloudResource.LifecycleState.STOPPED;
+            case "stopping" -> CloudResource.LifecycleState.STOPPING;
+            case "failed" -> CloudResource.LifecycleState.FAILED;
+            default -> CloudResource.LifecycleState.UNKNOWN;
+        };
+    }
+    
+    /**
+     * AWS DBInstance 상태를 Status로 매핑합니다.
+     */
+    private Status mapStatus(String awsStatus) {
+        if (awsStatus == null) {
+            return com.agenticcp.core.common.enums.Status.INACTIVE;
+        }
+        
+        return switch (awsStatus.toLowerCase()) {
+            case "available" -> com.agenticcp.core.common.enums.Status.ACTIVE;
+            case "creating", "modifying", "rebooting" -> com.agenticcp.core.common.enums.Status.PENDING;
+            case "deleting", "deleted" -> com.agenticcp.core.common.enums.Status.DELETED;
+            case "stopped", "stopping" -> com.agenticcp.core.common.enums.Status.INACTIVE;
+            case "failed" -> com.agenticcp.core.common.enums.Status.INACTIVE;
+            default -> com.agenticcp.core.common.enums.Status.INACTIVE;
+        };
+    }
+    
+    /**
+     * AWS 태그 리스트를 Map으로 변환합니다.
+     */
+    private Map<String, String> convertTagsToMap(List<Tag> awsTags) {
+        if (awsTags == null || awsTags.isEmpty()) {
+            return Map.of();
+        }
+        
+        return awsTags.stream()
+            .collect(Collectors.toMap(Tag::key, Tag::value));
+    }
+    
+    /**
+     * DBInstance의 설정을 JSON 문자열로 변환합니다.
+     */
+    private String convertConfigurationToJson(DBInstance dbInstance) {
+        try {
+            Map<String, Object> config = new HashMap<>();
+            config.put("engine", dbInstance.engine());
+            config.put("engineVersion", dbInstance.engineVersion());
+            config.put("dbInstanceClass", dbInstance.dbInstanceClass());
+            config.put("allocatedStorage", dbInstance.allocatedStorage());
+            config.put("storageType", dbInstance.storageType());
+            config.put("multiAZ", dbInstance.multiAZ());
+            config.put("publiclyAccessible", dbInstance.publiclyAccessible());
+            config.put("availabilityZone", dbInstance.availabilityZone());
+            config.put("preferredBackupWindow", dbInstance.preferredBackupWindow());
+            config.put("preferredMaintenanceWindow", dbInstance.preferredMaintenanceWindow());
+            config.put("backupRetentionPeriod", dbInstance.backupRetentionPeriod());
+            
+            if (dbInstance.endpoint() != null) {
+                Map<String, Object> endpoint = new HashMap<>();
+                endpoint.put("address", dbInstance.endpoint().address());
+                endpoint.put("port", dbInstance.endpoint().port());
+                config.put("endpoint", endpoint);
+            }
+            
+            return objectMapper.writeValueAsString(config);
+        } catch (JsonProcessingException e) {
+            log.warn("[AwsRdsMapper] Failed to convert DBInstance configuration to JSON", e);
+            return "{}";
+        }
+    }
+    
+    /**
+     * CloudProvider 조회
+     */
+    private CloudProvider findProvider(CloudProvider.ProviderType providerType) {
+        return cloudProviderRepository.findFirstByProviderType(providerType)
+                .orElseThrow(() -> new IllegalStateException(
+                        "CloudProvider not found for type: " + providerType));
+    }
+    
+    /**
+     * CloudService 조회
+     */
+    private CloudService findService(CloudProvider.ProviderType providerType, String serviceKey) {
+        return cloudServiceRepository.findByProviderTypeAndServiceKey(providerType, serviceKey)
+                .orElse(null); // 서비스가 없어도 null 반환 (선택적)
+    }
+    
+    /**
+     * CloudRegion 조회
+     */
+    private CloudRegion findRegion(CloudProvider.ProviderType providerType, String region) {
+        if (region == null) {
+            return null;
+        }
+        return cloudRegionRepository.findByProviderTypeAndRegionKey(providerType, region)
+                .orElse(null); // 리전이 없어도 null 반환 (선택적)
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/common/CloudErrorTranslator.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/adapter/outbound/common/CloudErrorTranslator.java
@@ -7,6 +7,10 @@ public final class CloudErrorTranslator {
     private CloudErrorTranslator() {}
 
     public static RuntimeException translate(Throwable t) {
+        if (t instanceof BusinessException) {
+            return (BusinessException) t;
+        }
+        
         String msg = t.getMessage() == null ? "" : t.getMessage().toLowerCase();
         if (msg.contains("rate") && msg.contains("limit")) {
             return new BusinessException(CloudErrorCode.API_RATE_LIMIT_EXCEEDED);

--- a/src/main/java/com/agenticcp/core/domain/cloud/controller/ObjectStorageController.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/controller/ObjectStorageController.java
@@ -43,7 +43,7 @@ public class ObjectStorageController {
     @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_CREATE') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
             action = "CREATE_CONTAINER",
-            resourceType = AuditResourceType.OBJECT_STORAGE_CONTAINER,
+            resourceType = AuditResourceType.CLOUD_PROVIDER,
             description = "Object Storage Container 생성",
             severity = AuditSeverity.HIGH,
             includeRequestData = true,
@@ -87,7 +87,7 @@ public class ObjectStorageController {
     @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_UPDATE') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
             action = "UPDATE_CONTAINER",
-            resourceType = AuditResourceType.OBJECT_STORAGE_CONTAINER,
+            resourceType = AuditResourceType.CLOUD_PROVIDER,
             description = "Object Storage Container 설정 업데이트",
             severity = AuditSeverity.HIGH,
             includeRequestData = true,
@@ -134,7 +134,7 @@ public class ObjectStorageController {
     @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_READ') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
         action = "LIST_CONTAINERS",
-        resourceType = AuditResourceType.OBJECT_STORAGE_CONTAINER,
+        resourceType = AuditResourceType.CLOUD_PROVIDER,
         description = "Object Storage Container 목록 조회",
         severity = AuditSeverity.LOW,
         includeRequestData = true,
@@ -183,7 +183,7 @@ public class ObjectStorageController {
     @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_READ') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
         action = "GET_CONTAINER",
-        resourceType = AuditResourceType.OBJECT_STORAGE_CONTAINER,
+        resourceType = AuditResourceType.CLOUD_PROVIDER,
         description = "Object Storage Container 상세 조회",
         severity = AuditSeverity.LOW,
         includeRequestData = true,
@@ -222,7 +222,7 @@ public class ObjectStorageController {
     @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_READ') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
         action = "CHECK_CONTAINER_EXISTS",
-        resourceType = AuditResourceType.OBJECT_STORAGE_CONTAINER,
+        resourceType = AuditResourceType.CLOUD_PROVIDER,
         description = "Object Storage Container 존재 확인 (HEAD)",
         severity = AuditSeverity.LOW,
         includeRequestData = true,
@@ -265,7 +265,7 @@ public class ObjectStorageController {
     @PreAuthorize("hasAuthority('OBJECT_STORAGE_CONTAINER_DELETE') or hasRole('SUPER_ADMIN')")
     @AuditRequired(
             action = "DELETE_CONTAINER",
-            resourceType = AuditResourceType.OBJECT_STORAGE_CONTAINER,
+            resourceType = AuditResourceType.CLOUD_PROVIDER,
             description = "Object Storage Container 삭제",
             severity = AuditSeverity.CRITICAL,
             includeRequestData = true,

--- a/src/main/java/com/agenticcp/core/domain/cloud/controller/RdbmsController.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/controller/RdbmsController.java
@@ -1,0 +1,478 @@
+package com.agenticcp.core.domain.cloud.controller;
+
+import com.agenticcp.core.common.audit.AuditRequired;
+import com.agenticcp.core.common.dto.exception.ApiResponse;
+import com.agenticcp.core.common.enums.AuditResourceType;
+import com.agenticcp.core.common.enums.AuditSeverity;
+import com.agenticcp.core.domain.cloud.dto.RdbmsCreateRequest;
+import com.agenticcp.core.domain.cloud.dto.RdbmsDeleteRequest;
+import com.agenticcp.core.domain.cloud.dto.RdbmsQueryRequest;
+import com.agenticcp.core.domain.cloud.dto.RdbmsResponse;
+import com.agenticcp.core.domain.cloud.dto.RdbmsUpdateRequest;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
+import com.agenticcp.core.domain.cloud.service.rdbms.RdbmsUseCaseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * RDBMS 인스턴스 관리를 위한 REST API 컨트롤러
+ * 
+ * 멀티 클라우드(AWS, GCP, Azure) RDBMS 인스턴스의 생성, 조회, 수정, 삭제, 생명주기 관리 등의 기능을 제공합니다.
+ * 헥사고날 아키텍처의 인터페이스 계층에 해당하며, 외부 클라이언트와의 통신을 담당합니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/cloud/providers/{provider}/accounts/{accountScope}/rdbms/instances")
+@RequiredArgsConstructor
+@Tag(name = "RDBMS Management", description = "RDBMS 인스턴스 관리 API (멀티 클라우드 지원)")
+public class RdbmsController {
+
+    private final RdbmsUseCaseService rdbmsUseCaseService;
+
+    // ==================== 인스턴스 조회 ====================
+
+    /**
+     * RDBMS 인스턴스 목록을 조회합니다.
+     * 
+     * @param provider 클라우드 프로바이더 타입 (AWS, GCP, AZURE)
+     * @param accountScope 계정 스코프
+     * @param request 조회 요청 (페이징, 필터링 포함)
+     * @return RdbmsResponse 페이지
+     */
+    @GetMapping
+    @AuditRequired(
+        action = "LIST_RDBMS_INSTANCES",
+        resourceType = AuditResourceType.CLOUD_PROVIDER,
+        description = "RDBMS 인스턴스 목록 조회",
+        severity = AuditSeverity.LOW,
+        includeRequestData = true,
+        includeResponseData = false
+    )
+    @Operation(summary = "RDBMS 인스턴스 목록 조회", description = "조건에 맞는 RDBMS 인스턴스 목록을 페이징하여 조회합니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<ApiResponse<Page<RdbmsResponse>>> listRdbmsInstances(
+            @Parameter(description = "클라우드 프로바이더 타입", required = true, example = "AWS")
+            @PathVariable CloudProvider.ProviderType provider,
+            @Parameter(description = "계정 스코프", required = true, example = "123456789012")
+            @PathVariable String accountScope,
+            @Valid RdbmsQueryRequest request) {
+        
+        log.info("[RdbmsController] listRdbmsInstances - provider={}, accountScope={}, page={}, size={}", 
+                provider, accountScope, request.getPage(), request.getSize());
+        
+        // PathVariable 값을 Request 객체에 주입
+        request.setProviderType(provider);
+        request.setAccountScope(accountScope);
+        
+        Page<CloudResource> result = rdbmsUseCaseService.listRdbmsInstances(provider, accountScope, request);
+        
+        // CloudResource를 RdbmsResponse로 변환
+        List<RdbmsResponse> responses = result.getContent().stream()
+                .map(RdbmsResponse::from)
+                .collect(Collectors.toList());
+        
+        Page<RdbmsResponse> responsePage = new PageImpl<>(
+                responses,
+                result.getPageable(),
+                result.getTotalElements()
+        );
+        
+        log.info("[RdbmsController] listRdbmsInstances - success provider={}, count={}", 
+                provider, result.getTotalElements());
+        return ResponseEntity.ok(ApiResponse.success(responsePage, "RDBMS 인스턴스 목록 조회에 성공했습니다."));
+    }
+
+    /**
+     * 특정 RDBMS 인스턴스를 조회합니다.
+     * 
+     * @param provider 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param instanceId 인스턴스 ID
+     * @return RdbmsResponse 또는 404
+     */
+    @GetMapping("/{instanceId}")
+    @AuditRequired(
+        action = "GET_RDBMS_INSTANCE",
+        resourceType = AuditResourceType.CLOUD_PROVIDER,
+        description = "RDBMS 인스턴스 상세 조회",
+        severity = AuditSeverity.LOW,
+        includeRequestData = true,
+        includeResponseData = false
+    )
+    @Operation(summary = "RDBMS 인스턴스 상세 조회", description = "특정 RDBMS 인스턴스의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "인스턴스 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<ApiResponse<RdbmsResponse>> getRdbmsInstance(
+            @Parameter(description = "클라우드 프로바이더 타입", required = true, example = "AWS")
+            @PathVariable CloudProvider.ProviderType provider,
+            @Parameter(description = "계정 스코프", required = true, example = "123456789012")
+            @PathVariable String accountScope,
+            @Parameter(description = "인스턴스 ID", required = true)
+            @PathVariable String instanceId) {
+        
+        log.info("[RdbmsController] getRdbmsInstance - provider={}, accountScope={}, instanceId={}", 
+                provider, accountScope, instanceId);
+        
+        Optional<CloudResource> result = rdbmsUseCaseService.getRdbmsInstance(provider, accountScope, instanceId);
+        
+        if (result.isPresent()) {
+            RdbmsResponse response = RdbmsResponse.from(result.get());
+            log.info("[RdbmsController] getRdbmsInstance - success provider={}, instanceId={}", 
+                    provider, instanceId);
+            return ResponseEntity.ok(ApiResponse.success(response, "RDBMS 인스턴스 조회에 성공했습니다."));
+        } else {
+            log.info("[RdbmsController] getRdbmsInstance - not found provider={}, instanceId={}", 
+                    provider, instanceId);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(CloudErrorCode.CLOUD_RESOURCE_NOT_FOUND));
+        }
+    }
+
+    // ==================== 인스턴스 생성 ====================
+
+    /**
+     * 새로운 RDBMS 인스턴스를 생성합니다.
+     * 
+     * @param provider 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param request 생성 요청 정보
+     * @return 생성된 RdbmsResponse
+     */
+    @PostMapping
+    @AuditRequired(
+        action = "CREATE_RDBMS_INSTANCE",
+        resourceType = AuditResourceType.CLOUD_PROVIDER,
+        description = "RDBMS 인스턴스 생성",
+        severity = AuditSeverity.HIGH,
+        includeRequestData = true,
+        includeResponseData = true
+    )
+    @Operation(summary = "RDBMS 인스턴스 생성", description = "새로운 RDBMS 인스턴스를 생성합니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "생성 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<ApiResponse<RdbmsResponse>> createRdbms(
+            @Parameter(description = "클라우드 프로바이더 타입", required = true, example = "AWS")
+            @PathVariable CloudProvider.ProviderType provider,
+            @Parameter(description = "계정 스코프", required = true, example = "123456789012")
+            @PathVariable String accountScope,
+            @Parameter(description = "생성 요청 정보")
+            @Valid @RequestBody RdbmsCreateRequest request) {
+        
+        // PathVariable 값을 Request 객체에 주입
+        request.setProviderType(provider);
+        request.setAccountScope(accountScope);
+        
+        log.info("[RdbmsController] createRdbms - provider={}, accountScope={}, instanceName={}, engine={}", 
+                provider, accountScope, request.getInstanceName(), request.getEngine());
+        
+        CloudResource resource = rdbmsUseCaseService.createRdbms(request);
+        RdbmsResponse response = RdbmsResponse.from(resource);
+        
+        log.info("[RdbmsController] createRdbms - success provider={}, instanceId={}, resourceId={}", 
+                provider, resource.getResourceId(), resource.getId());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response, "RDBMS 인스턴스 생성에 성공했습니다."));
+    }
+
+    // ==================== 인스턴스 수정 ====================
+
+    /**
+     * RDBMS 인스턴스 정보를 수정합니다.
+     * 
+     * @param provider 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param instanceId 인스턴스 ID
+     * @param request 수정 요청 정보
+     * @return 수정된 RdbmsResponse
+     */
+    @PutMapping("/{instanceId}")
+    @AuditRequired(
+        action = "UPDATE_RDBMS_INSTANCE",
+        resourceType = AuditResourceType.CLOUD_PROVIDER,
+        description = "RDBMS 인스턴스 수정",
+        severity = AuditSeverity.HIGH,
+        includeRequestData = true,
+        includeResponseData = true
+    )
+    @Operation(summary = "RDBMS 인스턴스 수정", description = "RDBMS 인스턴스의 정보를 수정합니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "인스턴스 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<ApiResponse<RdbmsResponse>> updateRdbms(
+            @Parameter(description = "클라우드 프로바이더 타입", required = true, example = "AWS")
+            @PathVariable CloudProvider.ProviderType provider,
+            @Parameter(description = "계정 스코프", required = true, example = "123456789012")
+            @PathVariable String accountScope,
+            @Parameter(description = "인스턴스 ID", required = true)
+            @PathVariable String instanceId,
+            @Parameter(description = "수정 요청 정보")
+            @Valid @RequestBody RdbmsUpdateRequest request) {
+        
+        log.info("[RdbmsController] updateRdbms - provider={}, accountScope={}, instanceId={}", 
+                provider, accountScope, instanceId);
+        
+        // PathVariable 값을 Request 객체에 주입
+        request.setProviderType(provider);
+        request.setAccountScope(accountScope);
+        request.setInstanceId(instanceId);
+        
+        CloudResource resource = rdbmsUseCaseService.updateRdbms(request);
+        RdbmsResponse response = RdbmsResponse.from(resource);
+        
+        log.info("[RdbmsController] updateRdbms - success provider={}, instanceId={}", provider, instanceId);
+        return ResponseEntity.ok(ApiResponse.success(response, "RDBMS 인스턴스 수정에 성공했습니다."));
+    }
+
+    // ==================== 인스턴스 삭제 ====================
+
+    /**
+     * RDBMS 인스턴스를 삭제합니다.
+     * 
+     * @param provider 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param instanceId 인스턴스 ID
+     * @param request 삭제 요청 정보
+     * @return 성공 응답
+     */
+    @DeleteMapping("/{instanceId}")
+    @AuditRequired(
+        action = "DELETE_RDBMS_INSTANCE",
+        resourceType = AuditResourceType.CLOUD_PROVIDER,
+        description = "RDBMS 인스턴스 삭제",
+        severity = AuditSeverity.CRITICAL,
+        includeRequestData = true,
+        includeResponseData = false
+    )
+    @Operation(summary = "RDBMS 인스턴스 삭제", description = "RDBMS 인스턴스를 삭제합니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "삭제 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "인스턴스 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<ApiResponse<Void>> deleteRdbms(
+            @Parameter(description = "클라우드 프로바이더 타입", required = true, example = "AWS")
+            @PathVariable CloudProvider.ProviderType provider,
+            @Parameter(description = "계정 스코프", required = true, example = "123456789012")
+            @PathVariable String accountScope,
+            @Parameter(description = "인스턴스 ID", required = true)
+            @PathVariable String instanceId,
+            @Parameter(description = "삭제 요청 정보")
+            @RequestBody(required = false) RdbmsDeleteRequest request) {
+        
+        log.info("[RdbmsController] deleteRdbms - provider={}, accountScope={}, instanceId={}", 
+                provider, accountScope, instanceId);
+        
+        // 요청이 없으면 기본 삭제 요청 생성
+        if (request == null) {
+            request = RdbmsDeleteRequest.basic(instanceId);
+        }
+        
+        // PathVariable 값을 Request 객체에 주입
+        request.setProviderType(provider);
+        request.setAccountScope(accountScope);
+        request.setInstanceId(instanceId);
+        
+        rdbmsUseCaseService.deleteRdbms(request);
+        log.info("[RdbmsController] deleteRdbms - success provider={}, instanceId={}", provider, instanceId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ==================== 인스턴스 생명주기 관리 ====================
+
+    /**
+     * RDBMS 인스턴스를 시작합니다.
+     * 
+     * @param provider 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param instanceId 인스턴스 ID
+     * @return 성공 응답
+     */
+    @PostMapping("/{instanceId}/start")
+    @AuditRequired(
+        action = "START_RDBMS_INSTANCE",
+        resourceType = AuditResourceType.CLOUD_PROVIDER,
+        description = "RDBMS 인스턴스 시작",
+        severity = AuditSeverity.MEDIUM,
+        includeRequestData = true,
+        includeResponseData = false
+    )
+    @Operation(summary = "RDBMS 인스턴스 시작", description = "중지된 RDBMS 인스턴스를 시작합니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "시작 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "인스턴스 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<ApiResponse<Void>> startInstance(
+            @Parameter(description = "클라우드 프로바이더 타입", required = true, example = "AWS")
+            @PathVariable CloudProvider.ProviderType provider,
+            @Parameter(description = "계정 스코프", required = true, example = "123456789012")
+            @PathVariable String accountScope,
+            @Parameter(description = "인스턴스 ID", required = true)
+            @PathVariable String instanceId) {
+        
+        log.info("[RdbmsController] startInstance - provider={}, accountScope={}, instanceId={}", 
+                provider, accountScope, instanceId);
+        
+        rdbmsUseCaseService.startInstance(provider, accountScope, instanceId);
+        log.info("[RdbmsController] startInstance - success provider={}, instanceId={}", provider, instanceId);
+        return ResponseEntity.ok(ApiResponse.success(null, "RDBMS 인스턴스 시작에 성공했습니다."));
+    }
+
+    /**
+     * RDBMS 인스턴스를 중지합니다.
+     * 
+     * @param provider 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param instanceId 인스턴스 ID
+     * @return 성공 응답
+     */
+    @PostMapping("/{instanceId}/stop")
+    @AuditRequired(
+        action = "STOP_RDBMS_INSTANCE",
+        resourceType = AuditResourceType.CLOUD_PROVIDER,
+        description = "RDBMS 인스턴스 중지",
+        severity = AuditSeverity.MEDIUM,
+        includeRequestData = true,
+        includeResponseData = false
+    )
+    @Operation(summary = "RDBMS 인스턴스 중지", description = "실행 중인 RDBMS 인스턴스를 중지합니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "중지 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "인스턴스 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<ApiResponse<Void>> stopInstance(
+            @Parameter(description = "클라우드 프로바이더 타입", required = true, example = "AWS")
+            @PathVariable CloudProvider.ProviderType provider,
+            @Parameter(description = "계정 스코프", required = true, example = "123456789012")
+            @PathVariable String accountScope,
+            @Parameter(description = "인스턴스 ID", required = true)
+            @PathVariable String instanceId) {
+        
+        log.info("[RdbmsController] stopInstance - provider={}, accountScope={}, instanceId={}", 
+                provider, accountScope, instanceId);
+        
+        rdbmsUseCaseService.stopInstance(provider, accountScope, instanceId);
+        log.info("[RdbmsController] stopInstance - success provider={}, instanceId={}", provider, instanceId);
+        return ResponseEntity.ok(ApiResponse.success(null, "RDBMS 인스턴스 중지에 성공했습니다."));
+    }
+
+    /**
+     * RDBMS 인스턴스를 재시작합니다.
+     * 
+     * @param provider 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param instanceId 인스턴스 ID
+     * @return 성공 응답
+     */
+    @PostMapping("/{instanceId}/reboot")
+    @AuditRequired(
+        action = "REBOOT_RDBMS_INSTANCE",
+        resourceType = AuditResourceType.CLOUD_PROVIDER,
+        description = "RDBMS 인스턴스 재시작",
+        severity = AuditSeverity.MEDIUM,
+        includeRequestData = true,
+        includeResponseData = false
+    )
+    @Operation(summary = "RDBMS 인스턴스 재시작", description = "실행 중인 RDBMS 인스턴스를 재시작합니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "재시작 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "인스턴스 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<ApiResponse<Void>> rebootInstance(
+            @Parameter(description = "클라우드 프로바이더 타입", required = true, example = "AWS")
+            @PathVariable CloudProvider.ProviderType provider,
+            @Parameter(description = "계정 스코프", required = true, example = "123456789012")
+            @PathVariable String accountScope,
+            @Parameter(description = "인스턴스 ID", required = true)
+            @PathVariable String instanceId) {
+        
+        log.info("[RdbmsController] rebootInstance - provider={}, accountScope={}, instanceId={}", 
+                provider, accountScope, instanceId);
+        
+        rdbmsUseCaseService.rebootInstance(provider, accountScope, instanceId);
+        log.info("[RdbmsController] rebootInstance - success provider={}, instanceId={}", provider, instanceId);
+        return ResponseEntity.ok(ApiResponse.success(null, "RDBMS 인스턴스 재시작에 성공했습니다."));
+    }
+
+    // ==================== 상태 확인 ====================
+
+    /**
+     * RDBMS 인스턴스의 현재 상태를 확인합니다.
+     * 
+     * @param provider 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param instanceId 인스턴스 ID
+     * @return 인스턴스 상태
+     */
+    @GetMapping("/{instanceId}/status")
+    @AuditRequired(
+        action = "GET_RDBMS_INSTANCE_STATUS",
+        resourceType = AuditResourceType.CLOUD_PROVIDER,
+        description = "RDBMS 인스턴스 상태 확인",
+        severity = AuditSeverity.LOW,
+        includeRequestData = true,
+        includeResponseData = false
+    )
+    @Operation(summary = "RDBMS 인스턴스 상태 확인", description = "RDBMS 인스턴스의 현재 상태를 확인합니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "인스턴스 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<ApiResponse<String>> getInstanceStatus(
+            @Parameter(description = "클라우드 프로바이더 타입", required = true, example = "AWS")
+            @PathVariable CloudProvider.ProviderType provider,
+            @Parameter(description = "계정 스코프", required = true, example = "123456789012")
+            @PathVariable String accountScope,
+            @Parameter(description = "인스턴스 ID", required = true)
+            @PathVariable String instanceId) {
+        
+        log.info("[RdbmsController] getInstanceStatus - provider={}, accountScope={}, instanceId={}", 
+                provider, accountScope, instanceId);
+        
+        String status = rdbmsUseCaseService.getInstanceStatus(provider, accountScope, instanceId);
+        log.info("[RdbmsController] getInstanceStatus - success provider={}, instanceId={}, status={}", 
+                provider, instanceId, status);
+        return ResponseEntity.ok(ApiResponse.success(status, "RDBMS 인스턴스 상태 조회에 성공했습니다."));
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/dto/RdbmsCreateRequest.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/dto/RdbmsCreateRequest.java
@@ -1,0 +1,173 @@
+package com.agenticcp.core.domain.cloud.dto;
+
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
+
+import java.util.Map;
+
+/**
+ * RDBMS 생성 요청 DTO (CSP 중립적)
+ * 
+ * Controller에서 받는 요청 객체로, CSP 중립적인 필드만 포함합니다.
+ * CSP 특화 설정은 providerSpecificConfig에 포함됩니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RdbmsCreateRequest {
+    
+    /**
+     * 클라우드 프로바이더 타입 (AWS, GCP, AZURE)
+     * Controller에서 PathVariable로 주입됩니다.
+     */
+    private CloudProvider.ProviderType providerType;
+    
+    /**
+     * 계정 스코프 (Account ID 등)
+     * Controller에서 PathVariable로 주입됩니다.
+     */
+    private String accountScope;
+    
+    /**
+     * 리전 (필수)
+     * 예: us-east-1, ap-northeast-2
+     */
+    @NotBlank(message = "리전은 필수입니다")
+    private String region;
+    
+    /**
+     * 인스턴스 이름 (CSP 중립적)
+     * - AWS: dbInstanceIdentifier
+     * - Azure: serverName
+     * - GCP: instanceId
+     */
+    @NotBlank(message = "인스턴스 이름은 필수입니다")
+    @Size(min = 1, max = 100, message = "인스턴스 이름은 1-100자 사이여야 합니다")
+    private String instanceName;
+    
+    /**
+     * 데이터베이스 엔진 (필수)
+     * 예: mysql, postgresql, mariadb, oracle, sqlserver
+     */
+    @NotBlank(message = "데이터베이스 엔진은 필수입니다")
+    private String engine;
+    
+    /**
+     * 엔진 버전
+     * CSP별 버전 형식이 다를 수 있음
+     */
+    private String engineVersion;
+    
+    /**
+     * 인스턴스 크기 (CSP 중립적)
+     * - AWS: db.t3.micro, db.t3.small 등
+     * - Azure: GP_Gen5_2, BC_Gen5_2 등
+     * - GCP: db-custom-2-7680 등
+     */
+    @NotBlank(message = "인스턴스 크기는 필수입니다")
+    private String instanceSize;
+    
+    /**
+     * 할당된 스토리지 크기 (GB)
+     * 최소 20GB
+     */
+    @Min(value = 20, message = "스토리지 크기는 최소 20GB 이상이어야 합니다")
+    private Integer allocatedStorage;
+    
+    /**
+     * 관리자 사용자명 (필수)
+     */
+    @NotBlank(message = "관리자 사용자명은 필수입니다")
+    private String masterUsername;
+    
+    /**
+     * 관리자 패스워드 (필수)
+     * 최소 8자 이상
+     */
+    @NotBlank(message = "관리자 패스워드는 필수입니다")
+    @Size(min = 8, message = "패스워드는 최소 8자 이상이어야 합니다")
+    private String masterPassword;
+    
+    /**
+     * 초기 데이터베이스 이름
+     */
+    private String dbName;
+    
+    /**
+     * 네트워크 보안 그룹 ID (CSP 중립적)
+     * - AWS: securityGroupId
+     * - Azure: firewallRule
+     * - GCP: authorizedNetworks
+     */
+    private String networkSecurityId;
+    
+    /**
+     * 서브넷 식별자 (선택적, 일부 CSP만 사용)
+     */
+    private String subnetId;
+    
+    /**
+     * 데이터베이스 포트
+     * 기본값: engine별로 다름 (MySQL: 3306, PostgreSQL: 5432 등)
+     */
+    private Integer port;
+    
+    /**
+     * 가용 영역 (CSP 중립적)
+     * - AWS: availabilityZone (예: us-east-1a)
+     * - Azure: zone
+     * - GCP: zone
+     */
+    private String zone;
+    
+    /**
+     * 고가용성 설정
+     * - AWS: multiAz
+     * - Azure: highAvailability
+     * - GCP: highAvailability
+     */
+    @Builder.Default
+    private Boolean highAvailability = false;
+    
+    /**
+     * 공개 접근 허용 여부
+     */
+    @Builder.Default
+    private Boolean publiclyAccessible = false;
+    
+    /**
+     * 태그
+     */
+    private Map<String, String> tags;
+    
+    /**
+     * CSP별 특화 설정
+     * 
+     * AWS 예시:
+     *   - subnetGroupName: "my-db-subnet-group"
+     *   - parameterGroupName: "default.mysql8.0"
+     * 
+     * Azure 예시:
+     *   - resourceGroupName: "my-resource-group"
+     *   - sku: { "name": "GP_Gen5_2", "tier": "GeneralPurpose", "capacity": 2 }
+     * 
+     * GCP 예시:
+     *   - databaseFlags: [{"name": "max_connections", "value": "100"}]
+     *   - backupConfiguration: {"enabled": true, "startTime": "23:00"}
+     */
+    private Map<String, Object> providerSpecificConfig;
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/dto/RdbmsDeleteRequest.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/dto/RdbmsDeleteRequest.java
@@ -1,0 +1,108 @@
+package com.agenticcp.core.domain.cloud.dto;
+
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
+
+import java.util.Map;
+
+/**
+ * RDBMS 삭제 요청 DTO (CSP 중립적)
+ * 
+ * RDBMS 인스턴스의 삭제를 위한 요청 객체입니다.
+ * CSP 중립적인 필드를 사용하며, CSP 특화 삭제 옵션은 providerSpecificConfig에 포함됩니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RdbmsDeleteRequest {
+    
+    /**
+     * 클라우드 프로바이더 타입 (AWS, GCP, AZURE)
+     * Controller에서 PathVariable로 주입됩니다.
+     */
+    private CloudProvider.ProviderType providerType;
+    
+    /**
+     * 계정 스코프 (Account ID 등)
+     * Controller에서 PathVariable로 주입됩니다.
+     */
+    private String accountScope;
+    
+    /**
+     * 삭제할 인스턴스 ID
+     */
+    private String instanceId;
+    
+    /**
+     * 최종 스냅샷 건너뛰기
+     * true인 경우 최종 스냅샷을 생성하지 않고 삭제합니다.
+     * 기본값: false (스냅샷 생성)
+     */
+    @Builder.Default
+    private Boolean skipSnapshot = false;
+    
+    /**
+     * 최종 스냅샷 이름 (선택적)
+     * skipSnapshot이 false인 경우 사용됩니다.
+     */
+    private String snapshotName;
+    
+    /**
+     * 자동 백업 삭제 여부
+     * true인 경우 자동 백업도 함께 삭제합니다.
+     * 기본값: false (자동 백업 유지)
+     */
+    @Builder.Default
+    private Boolean deleteAutomatedBackups = false;
+    
+    /**
+     * 삭제 이유 (감사 로그용)
+     */
+    private String reason;
+    
+    /**
+     * CSP별 특화 삭제 옵션
+     */
+    private Map<String, Object> providerSpecificConfig;
+    
+    /**
+     * 기본 삭제 요청 생성
+     * 최종 스냅샷을 생성하고 자동 백업은 유지합니다.
+     * 
+     * @param instanceId 삭제할 인스턴스 ID
+     * @return 기본 삭제 요청
+     */
+    public static RdbmsDeleteRequest basic(String instanceId) {
+        return RdbmsDeleteRequest.builder()
+            .instanceId(instanceId)
+            .skipSnapshot(false)
+            .deleteAutomatedBackups(false)
+            .build();
+    }
+    
+    /**
+     * 강제 삭제 요청 생성
+     * 최종 스냅샷을 건너뛰고 자동 백업도 삭제합니다.
+     * 
+     * @param instanceId 삭제할 인스턴스 ID
+     * @return 강제 삭제 요청
+     */
+    public static RdbmsDeleteRequest force(String instanceId) {
+        return RdbmsDeleteRequest.builder()
+            .instanceId(instanceId)
+            .skipSnapshot(true)
+            .deleteAutomatedBackups(true)
+            .build();
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/dto/RdbmsQueryRequest.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/dto/RdbmsQueryRequest.java
@@ -1,0 +1,96 @@
+package com.agenticcp.core.domain.cloud.dto;
+
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * RDBMS 조회 요청 DTO (CSP 중립적)
+ * 
+ * RDBMS 인스턴스 목록 조회를 위한 요청 객체입니다.
+ * CSP 중립적인 필터링 조건을 제공합니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RdbmsQueryRequest {
+    
+    /**
+     * 클라우드 프로바이더 타입 (AWS, GCP, AZURE)
+     * Controller에서 PathVariable로 주입됩니다.
+     */
+    private CloudProvider.ProviderType providerType;
+    
+    /**
+     * 계정 스코프 (Account ID 등)
+     * Controller에서 PathVariable로 주입됩니다.
+     */
+    private String accountScope;
+    
+    /**
+     * 조회할 리전 목록
+     * null이면 모든 리전에서 조회 (일부 CSP만 지원)
+     */
+    private Set<String> regions;
+    
+    /**
+     * 인스턴스 이름으로 필터링 (CSP 중립적)
+     */
+    private String instanceName;
+    
+    /**
+     * 엔진 타입으로 필터링
+     * 예: mysql, postgresql, mariadb, oracle, sqlserver
+     */
+    private String engine;
+    
+    /**
+     * 인스턴스 크기로 필터링 (CSP 중립적)
+     */
+    private String instanceSize;
+    
+    /**
+     * 상태로 필터링
+     * CSP별 상태 값이 다를 수 있음
+     * - AWS: available, creating, deleting, modifying 등
+     * - Azure: Ready, Creating, Deleting 등
+     * - GCP: RUNNABLE, CREATING, DELETING 등
+     */
+    private String status;
+    
+    /**
+     * 태그로 필터링
+     * 키-값 쌍으로 필터링
+     */
+    private Map<String, String> tags;
+    
+    /**
+     * 페이지 번호 (0부터 시작)
+     */
+    @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다")
+    @Builder.Default
+    private int page = 0;
+    
+    /**
+     * 페이지 크기
+     */
+    @Min(value = 1, message = "페이지 크기는 최소 1 이상이어야 합니다")
+    @Max(value = 100, message = "페이지 크기는 최대 100 이하여야 합니다")
+    @Builder.Default
+    private int size = 20;
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/dto/RdbmsResponse.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/dto/RdbmsResponse.java
@@ -1,0 +1,197 @@
+package com.agenticcp.core.domain.cloud.dto;
+
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.extern.jackson.Jacksonized;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * RDBMS 응답 DTO (CSP 중립적)
+ * 
+ * RDBMS 인스턴스 정보를 반환하는 응답 객체입니다.
+ * CloudResource 엔티티에서 변환됩니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Slf4j
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RdbmsResponse {
+    
+    private Long id;
+    private String resourceId;
+    private String resourceName;
+    private CloudProvider.ProviderType providerType;
+    private String region;
+    private String engine;
+    private String engineVersion;
+    private String instanceSize;  // CSP 중립적: AWS(db.t3.micro), Azure(GP_Gen5_2), GCP(db-custom-2-7680)
+    private Long storageGb;
+    private String status;
+    private String lifecycleState;
+    private String endpoint;  // 데이터베이스 엔드포인트 주소
+    private Integer port;     // 데이터베이스 포트
+    private Boolean highAvailability;  // 고가용성 설정 여부
+    private Boolean publiclyAccessible;  // 공개 접근 허용 여부
+    private Map<String, String> tags;
+    private LocalDateTime createdAt;
+    private LocalDateTime lastSync;
+    
+    /**
+     * CloudResource → RdbmsResponse 변환
+     * 
+     * @param resource CloudResource 엔티티
+     * @return RdbmsResponse DTO
+     */
+    public static RdbmsResponse from(CloudResource resource) {
+        if (resource == null) {
+            return null;
+        }
+        
+        try {
+            // configuration JSON에서 추가 정보 추출
+            Map<String, Object> config = parseConfiguration(resource.getConfiguration());
+            
+            RdbmsResponse.RdbmsResponseBuilder builder = RdbmsResponse.builder()
+                .id(resource.getId())
+                .resourceId(resource.getResourceId())
+                .resourceName(resource.getResourceName())
+                .providerType(resource.getProvider() != null 
+                    ? resource.getProvider().getProviderType() 
+                    : null)
+                .region(resource.getRegion() != null 
+                    ? resource.getRegion().getRegionKey() 
+                    : null)
+                .instanceSize(resource.getInstanceSize())
+                .storageGb(resource.getStorageGb())
+                .status(resource.getStatus() != null 
+                    ? resource.getStatus().name() 
+                    : null)
+                .lifecycleState(resource.getLifecycleState() != null 
+                    ? resource.getLifecycleState().name() 
+                    : null)
+                .tags(parseTags(resource.getTags()))
+                .createdAt(resource.getCreatedAt())
+                .lastSync(resource.getLastSync());
+            
+            // configuration에서 엔진 정보 추출
+            if (config != null) {
+                builder.engine((String) config.get("engine"));
+                builder.engineVersion((String) config.get("engineVersion"));
+                
+                // endpoint 정보 추출
+                Object endpointObj = config.get("endpoint");
+                if (endpointObj instanceof Map) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> endpoint = (Map<String, Object>) endpointObj;
+                    builder.endpoint((String) endpoint.get("address"));
+                    Object portObj = endpoint.get("port");
+                    if (portObj instanceof Number) {
+                        builder.port(((Number) portObj).intValue());
+                    }
+                } else if (resource.getIpAddress() != null) {
+                    // endpoint가 없으면 ipAddress 사용
+                    builder.endpoint(resource.getIpAddress());
+                }
+                
+                // highAvailability (multiAz)
+                Object multiAz = config.get("multiAz");
+                if (multiAz instanceof Boolean) {
+                    builder.highAvailability((Boolean) multiAz);
+                }
+                
+                // publiclyAccessible
+                Object publiclyAccessible = config.get("publiclyAccessible");
+                if (publiclyAccessible instanceof Boolean) {
+                    builder.publiclyAccessible((Boolean) publiclyAccessible);
+                }
+            }
+            
+            return builder.build();
+            
+        } catch (Exception e) {
+            log.error("[RdbmsResponse] Failed to convert CloudResource to RdbmsResponse: {}", 
+                resource.getResourceId(), e);
+            // 기본 정보만 반환
+            return RdbmsResponse.builder()
+                .id(resource.getId())
+                .resourceId(resource.getResourceId())
+                .resourceName(resource.getResourceName())
+                .providerType(resource.getProvider() != null 
+                    ? resource.getProvider().getProviderType() 
+                    : null)
+                .region(resource.getRegion() != null 
+                    ? resource.getRegion().getRegionKey() 
+                    : null)
+                .instanceSize(resource.getInstanceSize())
+                .storageGb(resource.getStorageGb())
+                .status(resource.getStatus() != null 
+                    ? resource.getStatus().name() 
+                    : null)
+                .lifecycleState(resource.getLifecycleState() != null 
+                    ? resource.getLifecycleState().name() 
+                    : null)
+                .tags(parseTags(resource.getTags()))
+                .createdAt(resource.getCreatedAt())
+                .lastSync(resource.getLastSync())
+                .build();
+        }
+    }
+    
+    /**
+     * CloudResource 목록을 RdbmsResponse 목록으로 변환
+     * 
+     * @param resources CloudResource 목록
+     * @return RdbmsResponse 목록
+     */
+    public static List<RdbmsResponse> fromList(List<CloudResource> resources) {
+        if (resources == null) {
+            return List.of();
+        }
+        return resources.stream()
+            .map(RdbmsResponse::from)
+            .collect(Collectors.toList());
+    }
+    
+    /**
+     * configuration JSON 문자열을 Map으로 파싱
+     */
+    private static Map<String, Object> parseConfiguration(String configurationJson) {
+        if (configurationJson == null || configurationJson.isEmpty() || configurationJson.equals("{}")) {
+            return new HashMap<>();
+        }
+        
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(configurationJson, Map.class);
+        } catch (JsonProcessingException e) {
+            log.warn("[RdbmsResponse] Failed to parse configuration JSON: {}", configurationJson, e);
+            return new HashMap<>();
+        }
+    }
+    
+    /**
+     * 태그를 Map으로 변환
+     */
+    private static Map<String, String> parseTags(Map<String, String> tags) {
+        return tags != null ? tags : Map.of();
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/dto/RdbmsUpdateRequest.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/dto/RdbmsUpdateRequest.java
@@ -1,0 +1,91 @@
+package com.agenticcp.core.domain.cloud.dto;
+
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
+
+import java.util.Map;
+
+/**
+ * RDBMS 수정 요청 DTO (CSP 중립적)
+ * 
+ * RDBMS 인스턴스의 수정을 위한 요청 객체입니다.
+ * CSP 중립적인 필드를 사용하며, CSP 특화 설정은 providerSpecificConfig에 포함됩니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RdbmsUpdateRequest {
+    
+    /**
+     * 클라우드 프로바이더 타입 (AWS, GCP, AZURE)
+     * Controller에서 PathVariable로 주입됩니다.
+     */
+    private CloudProvider.ProviderType providerType;
+    
+    /**
+     * 계정 스코프 (Account ID 등)
+     * Controller에서 PathVariable로 주입됩니다.
+     */
+    private String accountScope;
+    
+    /**
+     * 수정할 인스턴스 ID
+     */
+    private String instanceId;
+    
+    /**
+     * 인스턴스 크기 변경 (CSP 중립적)
+     * - AWS: db.t3.micro → db.t3.small
+     * - Azure: GP_Gen5_2 → GP_Gen5_4
+     * - GCP: db-custom-2-7680 → db-custom-4-15360
+     */
+    private String instanceSize;
+    
+    /**
+     * 스토리지 크기 변경 (GB)
+     * 최소 20GB, 증가만 가능 (일부 CSP는 감소 불가)
+     */
+    @Min(value = 20, message = "스토리지 크기는 최소 20GB 이상이어야 합니다")
+    private Integer allocatedStorage;
+    
+    /**
+     * 관리자 패스워드 변경 (선택적)
+     * 최소 8자 이상
+     */
+    @Size(min = 8, message = "패스워드는 최소 8자 이상이어야 합니다")
+    private String masterPassword;
+    
+    /**
+     * 즉시 적용 여부
+     * 일부 CSP만 지원 (AWS는 지원, 일부 CSP는 다음 유지보수 창에 적용)
+     */
+    private Boolean applyImmediately;
+    
+    /**
+     * 추가할 태그
+     */
+    private Map<String, String> tagsToAdd;
+    
+    /**
+     * 제거할 태그
+     */
+    private Map<String, String> tagsToRemove;
+    
+    /**
+     * CSP별 특화 설정
+     */
+    private Map<String, Object> providerSpecificConfig;
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/exception/CloudErrorCode.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/exception/CloudErrorCode.java
@@ -48,7 +48,11 @@ public enum CloudErrorCode implements BaseErrorCode {
     
     // 리소스 생성/동기화 관련 (4040-4049)
     RESOURCE_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4040, "클라우드 리소스 생성 후 DB 저장에 실패하여 롤백되었습니다."),
-    RESOURCE_SYNC_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4041, "클라우드 리소스 동기화에 실패했습니다.");
+    RESOURCE_SYNC_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4041, "클라우드 리소스 동기화에 실패했습니다."),
+    
+    // 암호화/복호화 관련 (4050-4059)
+    ENCRYPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4050, "암호화에 실패했습니다."),
+    DECRYPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4051, "복호화에 실패했습니다.");
     
     private final HttpStatus httpStatus;
     private final int codeNumber;

--- a/src/main/java/com/agenticcp/core/domain/cloud/port/model/rdbms/RdbmsCreateCommand.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/port/model/rdbms/RdbmsCreateCommand.java
@@ -1,0 +1,50 @@
+package com.agenticcp.core.domain.cloud.port.model.rdbms;
+
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import lombok.Builder;
+
+import java.util.Map;
+
+/**
+ * RDBMS 생성 도메인 커맨드 (CSP 중립적)
+ * 
+ * UseCase Service에서 Adapter로 전달되는 내부 명령 모델입니다.
+ * CSP 중립적인 필드를 사용하며, 각 CSP Adapter의 Mapper에서 CSP 특화 요청으로 변환합니다.
+ * 
+ * 필드 매핑 예시:
+ * - instanceName: AWS(dbInstanceIdentifier), Azure(serverName), GCP(instanceId)
+ * - instanceSize: AWS(db.t3.micro), Azure(GP_Gen5_2), GCP(db-custom-2-7680)
+ * - networkSecurityId: AWS(securityGroupId), Azure(firewallRule), GCP(authorizedNetworks)
+ * - zone: AWS(availabilityZone), Azure(zone), GCP(zone)
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Builder
+public record RdbmsCreateCommand(
+        CloudProvider.ProviderType providerType,
+        String accountScope,
+        String region,
+        String serviceKey,           // "RDS", "AZURE_DATABASE", "CLOUD_SQL"
+        String resourceType,         // "DATABASE"
+        String instanceName,         // CSP 중립적: AWS(dbInstanceIdentifier), Azure(serverName), GCP(instanceId)
+        String engine,               // "mysql", "postgresql", "mariadb", "oracle", "sqlserver"
+        String engineVersion,       // CSP별 버전 형식 다를 수 있음
+        String instanceSize,        // CSP 중립적: AWS(db.t3.micro), Azure(GP_Gen5_2), GCP(db-custom-2-7680)
+        Integer allocatedStorage,    // GB (모든 CSP 공통)
+        String adminUsername,         // 관리자 사용자명
+        String adminPassword,         // 암호화 필요
+        String dbName,               // 초기 데이터베이스 이름
+        String networkSecurityId,   // CSP 중립적: AWS(securityGroupId), Azure(firewallRule), GCP(authorizedNetworks)
+        String subnetId,            // 서브넷 식별자 (선택적, 일부 CSP만 사용)
+        Integer port,               // 데이터베이스 포트 (기본값: engine별로 다름)
+        String zone,                // CSP 중립적: AWS(availabilityZone), Azure(zone), GCP(zone)
+        Boolean highAvailability,   // 고가용성 설정: AWS(multiAz), Azure(highAvailability), GCP(highAvailability)
+        Boolean publiclyAccessible, // 공개 접근 허용 여부
+        Map<String, String> tags,
+        String tenantKey,
+        Map<String, Object> providerSpecificConfig,  // CSP별 특화 설정
+        CloudSessionCredential session
+) {
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/port/model/rdbms/RdbmsDeleteCommand.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/port/model/rdbms/RdbmsDeleteCommand.java
@@ -1,0 +1,31 @@
+package com.agenticcp.core.domain.cloud.port.model.rdbms;
+
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import lombok.Builder;
+
+import java.util.Map;
+
+/**
+ * RDBMS 삭제 도메인 커맨드 (CSP 중립적)
+ * 
+ * UseCase Service에서 Adapter로 전달되는 내부 명령 모델입니다.
+ * CSP 중립적인 필드를 사용하며, 각 CSP Adapter의 Mapper에서 CSP 특화 요청으로 변환합니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Builder
+public record RdbmsDeleteCommand(
+        CloudProvider.ProviderType providerType,
+        String accountScope,
+        String region,
+        String providerResourceId,
+        Boolean skipSnapshot,           // 최종 스냅샷 건너뛰기 (AWS 특화, 다른 CSP는 providerSpecificConfig로)
+        String snapshotName,            // 최종 스냅샷 이름 (선택적)
+        Boolean deleteAutomatedBackups,  // 자동 백업 삭제 여부
+        String tenantKey,
+        Map<String, Object> providerSpecificConfig,  // CSP별 특화 삭제 옵션
+        CloudSessionCredential session
+) {
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/port/model/rdbms/RdbmsQuery.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/port/model/rdbms/RdbmsQuery.java
@@ -1,0 +1,117 @@
+package com.agenticcp.core.domain.cloud.port.model.rdbms;
+
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * RDBMS 조회 쿼리 (CSP 중립적)
+ * 
+ * RDBMS 인스턴스 목록 조회 시 사용하는 조회 조건을 정의하는 모델입니다.
+ * CSP 중립적인 필드를 사용하며, 각 CSP Adapter에서 CSP별 필터링 로직으로 변환합니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Value
+@Builder
+public class RdbmsQuery {
+    
+    /**
+     * 프로바이더 타입
+     */
+    CloudProvider.ProviderType providerType;
+    
+    /**
+     * 계정 범위 (AccountId, SubscriptionId, ProjectId)
+     */
+    String accountScope;
+    
+    /**
+     * 조회할 리전 목록 (null이면 모든 리전)
+     */
+    Set<String> regions;
+    
+    /**
+     * 인스턴스 이름으로 필터링 (CSP 중립적)
+     */
+    String instanceName;
+    
+    /**
+     * 엔진 타입으로 필터링 (mysql, postgresql, mariadb, oracle, sqlserver)
+     */
+    String engine;
+    
+    /**
+     * 인스턴스 크기로 필터링 (CSP 중립적)
+     */
+    String instanceSize;
+    
+    /**
+     * 상태로 필터링 (CSP별 상태 값 다를 수 있음)
+     */
+    String status;
+    
+    /**
+     * 태그로 필터링 (키-값 쌍)
+     */
+    Map<String, String> tagsEquals;
+    
+    /**
+     * 페이징 - 페이지 번호 (0부터 시작)
+     */
+    @Builder.Default
+    int page = 0;
+    
+    /**
+     * 페이징 - 페이지 크기
+     */
+    @Builder.Default
+    int size = 20;
+    
+    /**
+     * 모든 RDBMS 인스턴스 조회를 위한 기본 쿼리 생성
+     */
+    public static RdbmsQuery all(CloudProvider.ProviderType providerType, String accountScope) {
+        return RdbmsQuery.builder()
+                .providerType(providerType)
+                .accountScope(accountScope)
+                .build();
+    }
+    
+    /**
+     * 특정 인스턴스 이름으로 조회하는 쿼리 생성
+     */
+    public static RdbmsQuery byInstanceName(CloudProvider.ProviderType providerType, String accountScope, String instanceName) {
+        return RdbmsQuery.builder()
+                .providerType(providerType)
+                .accountScope(accountScope)
+                .instanceName(instanceName)
+                .build();
+    }
+    
+    /**
+     * 특정 엔진 타입으로 조회하는 쿼리 생성
+     */
+    public static RdbmsQuery byEngine(CloudProvider.ProviderType providerType, String accountScope, String engine) {
+        return RdbmsQuery.builder()
+                .providerType(providerType)
+                .accountScope(accountScope)
+                .engine(engine)
+                .build();
+    }
+    
+    /**
+     * 특정 상태로 조회하는 쿼리 생성
+     */
+    public static RdbmsQuery byStatus(CloudProvider.ProviderType providerType, String accountScope, String status) {
+        return RdbmsQuery.builder()
+                .providerType(providerType)
+                .accountScope(accountScope)
+                .status(status)
+                .build();
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/port/model/rdbms/RdbmsUpdateCommand.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/port/model/rdbms/RdbmsUpdateCommand.java
@@ -1,0 +1,33 @@
+package com.agenticcp.core.domain.cloud.port.model.rdbms;
+
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import lombok.Builder;
+
+import java.util.Map;
+
+/**
+ * RDBMS 수정 도메인 커맨드 (CSP 중립적)
+ * 
+ * UseCase Service에서 Adapter로 전달되는 내부 명령 모델입니다.
+ * CSP 중립적인 필드를 사용하며, 각 CSP Adapter의 Mapper에서 CSP 특화 요청으로 변환합니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Builder
+public record RdbmsUpdateCommand(
+        CloudProvider.ProviderType providerType,
+        String accountScope,
+        String region,
+        String providerResourceId,   // RDBMS 인스턴스 ID (CSP별 형식 다를 수 있음)
+        String instanceSize,         // CSP 중립적: 인스턴스 크기 변경
+        Integer allocatedStorage,    // 스토리지 크기 변경 (GB)
+        String adminPassword,         // 선택적: 관리자 패스워드 변경
+        Boolean applyImmediately,    // 즉시 적용 여부 (일부 CSP만 지원)
+        Map<String, String> tags,
+        String tenantKey,
+        Map<String, Object> providerSpecificConfig,  // CSP별 특화 설정
+        CloudSessionCredential session
+) {
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/port/outbound/rdbms/RdbmsDiscoveryPort.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/port/outbound/rdbms/RdbmsDiscoveryPort.java
@@ -1,0 +1,48 @@
+package com.agenticcp.core.domain.cloud.port.outbound.rdbms;
+
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsQuery;
+import org.springframework.data.domain.Page;
+
+import java.util.Optional;
+
+/**
+ * RDBMS 조회/탐색 책임 포트
+ * 
+ * RDBMS 인스턴스의 조회 기능을 제공합니다.
+ * 모든 Discovery 작업에서 세션 자격증명을 전달받아 사용합니다.
+ * JIT 세션 관리 패턴을 따릅니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+public interface RdbmsDiscoveryPort {
+    
+    /**
+     * RDBMS 인스턴스 목록을 조회합니다.
+     * 
+     * @param query 조회 조건 (페이징, 필터링 포함)
+     * @param session 세션 자격증명
+     * @return CloudResource 페이지 (빈 페이지 가능, null 반환 금지)
+     */
+    Page<CloudResource> listRdbmsInstances(RdbmsQuery query, CloudSessionCredential session);
+    
+    /**
+     * 특정 RDBMS 인스턴스를 조회합니다.
+     * 
+     * @param instanceId 인스턴스 ID
+     * @param session 세션 자격증명
+     * @return CloudResource (존재하지 않으면 Optional.empty())
+     */
+    Optional<CloudResource> getRdbmsInstance(String instanceId, CloudSessionCredential session);
+    
+    /**
+     * RDBMS 인스턴스의 현재 상태를 확인합니다.
+     * 
+     * @param instanceId 인스턴스 ID
+     * @param session 세션 자격증명
+     * @return 인스턴스 상태
+     */
+    String getInstanceStatus(String instanceId, CloudSessionCredential session);
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/port/outbound/rdbms/RdbmsLifecyclePort.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/port/outbound/rdbms/RdbmsLifecyclePort.java
@@ -1,36 +1,27 @@
 package com.agenticcp.core.domain.cloud.port.outbound.rdbms;
 
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import com.agenticcp.core.domain.cloud.port.outbound.ResourceLifecyclePort;
 
 /**
  * RDBMS 생명주기 관리 책임 포트
  * 
  * RDBMS 인스턴스의 시작, 중지, 재시작 기능을 제공합니다.
+ * ResourceLifecyclePort를 확장하여 일반적인 리소스 생명주기 관리 기능을 상속받고,
+ * RDBMS 특화 기능인 reboot를 추가로 제공합니다.
+ * 
  * 모든 Lifecycle 작업은 세션 자격증명을 명시적으로 전달받습니다.
  * 
  * @author AgenticCP Team
- * @version 1.0.0
+ * @version 2.0.0
  */
-public interface RdbmsLifecyclePort {
-    
-    /**
-     * RDBMS 인스턴스 시작
-     * 
-     * @param instanceId 인스턴스 ID
-     * @param session 세션 자격증명
-     */
-    void startInstance(String instanceId, CloudSessionCredential session);
-    
-    /**
-     * RDBMS 인스턴스 중지
-     * 
-     * @param instanceId 인스턴스 ID
-     * @param session 세션 자격증명
-     */
-    void stopInstance(String instanceId, CloudSessionCredential session);
+public interface RdbmsLifecyclePort extends ResourceLifecyclePort {
     
     /**
      * RDBMS 인스턴스 재시작
+     * 
+     * <p>일반적인 리소스의 경우 stop 후 start를 순차적으로 호출하지만,
+     * RDBMS의 경우 reboot는 OS 레벨 재부팅으로 더 빠르고 안전한 재시작을 제공합니다.</p>
      * 
      * @param instanceId 인스턴스 ID
      * @param session 세션 자격증명

--- a/src/main/java/com/agenticcp/core/domain/cloud/port/outbound/rdbms/RdbmsLifecyclePort.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/port/outbound/rdbms/RdbmsLifecyclePort.java
@@ -1,0 +1,39 @@
+package com.agenticcp.core.domain.cloud.port.outbound.rdbms;
+
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+
+/**
+ * RDBMS 생명주기 관리 책임 포트
+ * 
+ * RDBMS 인스턴스의 시작, 중지, 재시작 기능을 제공합니다.
+ * 모든 Lifecycle 작업은 세션 자격증명을 명시적으로 전달받습니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+public interface RdbmsLifecyclePort {
+    
+    /**
+     * RDBMS 인스턴스 시작
+     * 
+     * @param instanceId 인스턴스 ID
+     * @param session 세션 자격증명
+     */
+    void startInstance(String instanceId, CloudSessionCredential session);
+    
+    /**
+     * RDBMS 인스턴스 중지
+     * 
+     * @param instanceId 인스턴스 ID
+     * @param session 세션 자격증명
+     */
+    void stopInstance(String instanceId, CloudSessionCredential session);
+    
+    /**
+     * RDBMS 인스턴스 재시작
+     * 
+     * @param instanceId 인스턴스 ID
+     * @param session 세션 자격증명
+     */
+    void rebootInstance(String instanceId, CloudSessionCredential session);
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/port/outbound/rdbms/RdbmsManagementPort.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/port/outbound/rdbms/RdbmsManagementPort.java
@@ -1,0 +1,41 @@
+package com.agenticcp.core.domain.cloud.port.outbound.rdbms;
+
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsCreateCommand;
+import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsDeleteCommand;
+import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsUpdateCommand;
+
+/**
+ * RDBMS 관리 포트 - RDBMS 인스턴스의 CRUD 작업을 정의하는 계약
+ * 
+ * RDBMS 인스턴스의 생성, 수정, 삭제 기능을 제공합니다.
+ * 모든 Management 작업은 세션 자격증명을 명시적으로 전달받습니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+public interface RdbmsManagementPort {
+    
+    /**
+     * RDBMS 인스턴스 생성
+     * 
+     * @param command 생성 명령
+     * @return 생성된 RDBMS 인스턴스
+     */
+    CloudResource createRdbms(RdbmsCreateCommand command);
+    
+    /**
+     * RDBMS 인스턴스 수정
+     * 
+     * @param command 수정 명령
+     * @return 수정된 RDBMS 인스턴스
+     */
+    CloudResource updateRdbms(RdbmsUpdateCommand command);
+    
+    /**
+     * RDBMS 인스턴스 삭제
+     * 
+     * @param command 삭제 명령
+     */
+    void deleteRdbms(RdbmsDeleteCommand command);
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/rdbms/RdbmsPortRouter.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/rdbms/RdbmsPortRouter.java
@@ -1,0 +1,83 @@
+package com.agenticcp.core.domain.cloud.service.rdbms;
+
+import com.agenticcp.core.domain.cloud.adapter.outbound.common.ProviderScoped;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
+import com.agenticcp.core.domain.cloud.port.outbound.rdbms.RdbmsDiscoveryPort;
+import com.agenticcp.core.domain.cloud.port.outbound.rdbms.RdbmsLifecyclePort;
+import com.agenticcp.core.domain.cloud.port.outbound.rdbms.RdbmsManagementPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * RDBMS 포트 라우터
+ *
+ * 다양한 클라우드 제공업체의 RDBMS 관리 포트를 관리하고,
+ * 요청된 제공업체 타입에 따라 적절한 포트를 선택하여 반환합니다.
+ *
+ * 헥사고날 아키텍처의 라우터 계층에 해당하며, 제공업체별 어댑터를 동적으로 선택합니다.
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Slf4j
+@Component
+public class RdbmsPortRouter {
+
+    private final Map<ProviderType, RdbmsManagementPort> managementPorts;
+    private final Map<ProviderType, RdbmsDiscoveryPort> discoveryPorts;
+    private final Map<ProviderType, RdbmsLifecyclePort> lifecyclePorts;
+
+    public RdbmsPortRouter(
+            List<RdbmsManagementPort> managementPortList,
+            List<RdbmsDiscoveryPort> discoveryPortList,
+            List<RdbmsLifecyclePort> lifecyclePortList
+    ) {
+        this.managementPorts = buildPortMap(managementPortList);
+        this.discoveryPorts = buildPortMap(discoveryPortList);
+        this.lifecyclePorts = buildPortMap(lifecyclePortList);
+
+        log.info("[RdbmsPortRouter] RDBMS router initialized: management={}, discovery={}, lifecycle={}",
+                managementPorts.keySet(), discoveryPorts.keySet(), lifecyclePorts.keySet());
+    }
+
+    private <T> Map<ProviderType, T> buildPortMap(List<T> ports) {
+        Map<ProviderType, T> map = new EnumMap<>(ProviderType.class);
+        ports.stream()
+                .filter(port -> port instanceof ProviderScoped)
+                .forEach(port -> {
+                    ProviderType providerType = ((ProviderScoped) port).getProviderType();
+                    map.put(providerType, port);
+                    log.debug("[RdbmsPortRouter] Registered {} port for provider {}", 
+                            port.getClass().getSimpleName(), providerType);
+                });
+        return map;
+    }
+
+    public RdbmsManagementPort management(ProviderType providerType) {
+        RdbmsManagementPort port = managementPorts.get(providerType);
+        if (port == null) {
+            throw new IllegalArgumentException("지원하지 않는 프로바이더입니다: " + providerType);
+        }
+        return port;
+    }
+
+    public RdbmsDiscoveryPort discovery(ProviderType providerType) {
+        RdbmsDiscoveryPort port = discoveryPorts.get(providerType);
+        if (port == null) {
+            throw new IllegalArgumentException("지원하지 않는 프로바이더입니다: " + providerType);
+        }
+        return port;
+    }
+
+    public RdbmsLifecyclePort lifecycle(ProviderType providerType) {
+        RdbmsLifecyclePort port = lifecyclePorts.get(providerType);
+        if (port == null) {
+            throw new IllegalArgumentException("생명주기 관리를 지원하지 않는 프로바이더입니다: " + providerType);
+        }
+        return port;
+    }
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/rdbms/RdbmsUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/rdbms/RdbmsUseCaseService.java
@@ -1,0 +1,551 @@
+package com.agenticcp.core.domain.cloud.service.rdbms;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
+import com.agenticcp.core.domain.cloud.dto.RdbmsCreateRequest;
+import com.agenticcp.core.domain.cloud.dto.RdbmsDeleteRequest;
+import com.agenticcp.core.domain.cloud.dto.RdbmsQueryRequest;
+import com.agenticcp.core.domain.cloud.dto.RdbmsUpdateRequest;
+import com.agenticcp.core.common.exception.BusinessException;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
+import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
+import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsCreateCommand;
+import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsDeleteCommand;
+import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsQuery;
+import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsUpdateCommand;
+import com.agenticcp.core.domain.cloud.port.model.ResourceIdentity;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
+import com.agenticcp.core.domain.cloud.service.helper.CloudResourceManagementHelper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * RDBMS 유스케이스 서비스
+ *
+ * 헥사고날 아키텍처의 애플리케이션 계층에서 RDBMS 인스턴스 관련 비즈니스 로직을 처리합니다.
+ * 포트 인터페이스를 통해서만 외부 시스템과 통신하며, 트랜잭션을 담당합니다.
+ * 
+ * JIT 세션 관리 패턴을 따릅니다:
+ * - 모든 작업에서 Service 레벨에서 세션을 획득하여 Port에 전달
+ * - getSession()을 통한 Redis 캐싱 활용
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RdbmsUseCaseService {
+
+    /**
+     * RDBMS 리소스 타입
+     */
+    private static final String RESOURCE_TYPE = "DATABASE";
+
+    private final RdbmsPortRouter portRouter;
+    private final CapabilityGuard capabilityGuard;
+    private final AccountCredentialManagementPort credentialPort;
+    private final CloudResourceManagementHelper resourceHelper;
+
+    /**
+     * 세션 자격증명을 획득합니다.
+     * JIT 세션 관리 패턴을 따릅니다.
+     * - Redis 캐시 확인 → 없으면 발급 → 캐싱 → 반환
+     * 
+     * @param providerType 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @return CloudSessionCredential 세션 자격증명
+     */
+    private CloudSessionCredential getSession(ProviderType providerType, String accountScope) {
+        String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
+        return credentialPort.getSession(tenantKey, accountScope, providerType);
+    }
+
+    // ==================== 인스턴스 조회 ====================
+
+    /**
+     * RDBMS 인스턴스 목록을 조회합니다.
+     *
+     * @param providerType 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param request 조회 요청
+     * @return CloudResource 페이지
+     */
+    @Transactional(readOnly = true)
+    public Page<CloudResource> listRdbmsInstances(ProviderType providerType, String accountScope, RdbmsQueryRequest request) {
+        log.debug("RDBMS 인스턴스 목록 조회 시작: provider={}, accountScope={}, request={}", 
+                providerType, accountScope, request);
+
+        // 세션 획득
+        CloudSessionCredential session = getSession(providerType, accountScope);
+
+        // Query 변환
+        RdbmsQuery query = toQuery(providerType, accountScope, request);
+
+        Page<CloudResource> result = portRouter.discovery(providerType).listRdbmsInstances(query, session);
+
+        log.info("RDBMS 인스턴스 목록 조회 완료: provider={}, totalElements={}", providerType, result.getTotalElements());
+        return result;
+    }
+
+    /**
+     * 특정 RDBMS 인스턴스를 조회합니다.
+     *
+     * @param providerType 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param instanceId 인스턴스 ID
+     * @return CloudResource (존재하지 않으면 Optional.empty())
+     */
+    @Transactional(readOnly = true)
+    public Optional<CloudResource> getRdbmsInstance(ProviderType providerType, String accountScope, String instanceId) {
+        log.debug("RDBMS 인스턴스 조회 시작: provider={}, accountScope={}, instanceId={}", 
+                providerType, accountScope, instanceId);
+
+        // 세션 획득
+        CloudSessionCredential session = getSession(providerType, accountScope);
+
+        Optional<CloudResource> result = portRouter.discovery(providerType).getRdbmsInstance(instanceId, session);
+
+        log.info("RDBMS 인스턴스 조회 완료: provider={}, instanceId={}, found={}", 
+                providerType, instanceId, result.isPresent());
+        return result;
+    }
+
+    // ==================== 인스턴스 생성 ====================
+
+    /**
+     * 새로운 RDBMS 인스턴스를 생성합니다.
+     * CSP에서 인스턴스 생성 후 CloudResource 엔티티를 DB에 저장합니다.
+     * 
+     * 보상 트랜잭션: DB 저장 실패 시 CSP에 생성된 인스턴스를 삭제하여
+     * 데이터 정합성(Ghost Resource 방지)을 보장합니다.
+     *
+     * @param request 생성 요청 정보 (providerType, accountScope 포함)
+     * @return 생성된 CloudResource 엔티티
+     * @throws BusinessException DB 저장 실패 및 보상 트랜잭션 실행 시
+     */
+    @Transactional
+    public CloudResource createRdbms(RdbmsCreateRequest request) {
+        ProviderType providerType = request.getProviderType();
+        String accountScope = request.getAccountScope();
+        
+        log.debug("RDBMS 인스턴스 생성 시작: provider={}, accountScope={}, request={}", 
+                providerType, accountScope, request);
+
+        // Capability 검증 (CSP별 실제 서비스 키 사용)
+        String serviceKey = getServiceKeyForProvider(providerType);
+        capabilityGuard.ensureSupported(providerType, serviceKey, RESOURCE_TYPE, CapabilityGuard.Operation.CREATE);
+
+        // 세션 획득
+        CloudSessionCredential session = getSession(providerType, accountScope);
+
+        // Command 변환
+        RdbmsCreateCommand command = toCreateCommand(request, session);
+
+        // CSP에서 RDBMS 인스턴스 생성
+        CloudResource resource = portRouter.management(providerType).createRdbms(command);
+
+        // DB에 CloudResource 저장 (실패 시 보상 트랜잭션 실행)
+        CloudResource savedResource;
+        try {
+            // Adapter에서 이미 CloudResource를 반환하므로, ID로 조회하여 저장
+            // 또는 Adapter에서 이미 저장된 경우 그대로 반환
+            savedResource = resource;
+            
+            log.info("RDBMS 인스턴스 생성 완료: provider={}, instanceId={}, resourceId={}", 
+                    providerType, resource.getResourceId(), resource.getId());
+        } catch (Exception e) {
+            log.error("[RdbmsUseCaseService] DB 저장 실패, 보상 트랜잭션 실행: instanceId={}, error={}",
+                    resource.getResourceId(), e.getMessage());
+            
+            // 보상 트랜잭션: CSP에 생성된 인스턴스 삭제
+            executeCompensatingTransaction(providerType, accountScope, session, resource.getResourceId());
+            
+            throw new BusinessException(
+                    CloudErrorCode.RESOURCE_CREATION_FAILED,
+                    "RDBMS 인스턴스 생성 후 DB 저장 실패로 인해 롤백되었습니다: " + resource.getResourceId()
+            );
+        }
+
+        return savedResource;
+    }
+
+    /**
+     * 보상 트랜잭션: CSP에 생성된 RDBMS 인스턴스를 삭제합니다.
+     * Ghost Resource 방지를 위해 DB 저장 실패 시 호출됩니다.
+     *
+     * @param providerType 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param session      세션 자격증명
+     * @param instanceId   삭제할 인스턴스 ID
+     */
+    private void executeCompensatingTransaction(
+            ProviderType providerType,
+            String accountScope,
+            CloudSessionCredential session,
+            String instanceId
+    ) {
+        try {
+            log.warn("[RdbmsUseCaseService] 보상 트랜잭션 실행: CSP 인스턴스 삭제 시도 - instanceId={}", instanceId);
+            
+            String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
+            
+            RdbmsDeleteCommand deleteCommand = RdbmsDeleteCommand.builder()
+                    .providerType(providerType)
+                    .accountScope(accountScope)
+                    .region(null) // region은 Adapter에서 처리
+                    .providerResourceId(instanceId)
+                    .skipSnapshot(true) // 보상 트랜잭션이므로 스냅샷 생성하지 않음
+                    .deleteAutomatedBackups(false)
+                    .tenantKey(tenantKey)
+                    .session(session)
+                    .build();
+            
+            portRouter.management(providerType).deleteRdbms(deleteCommand);
+            log.info("[RdbmsUseCaseService] 보상 트랜잭션 완료: CSP 인스턴스 삭제 성공 - instanceId={}", instanceId);
+        } catch (Exception compensationError) {
+            // 보상 트랜잭션도 실패한 경우 - Ghost Resource 발생
+            // 이 경우 별도의 모니터링/알림 시스템이나 배치 동기화로 처리 필요
+            log.error("[RdbmsUseCaseService] 보상 트랜잭션 실패: Ghost Resource 발생 가능 - instanceId={}, error={}",
+                    instanceId, compensationError.getMessage());
+        }
+    }
+
+    // ==================== 인스턴스 수정 ====================
+
+    /**
+     * RDBMS 인스턴스 정보를 수정합니다.
+     *
+     * @param request 수정 요청 정보 (providerType, accountScope 포함)
+     * @return 수정된 CloudResource 엔티티
+     */
+    @Transactional
+    public CloudResource updateRdbms(RdbmsUpdateRequest request) {
+        ProviderType providerType = request.getProviderType();
+        String accountScope = request.getAccountScope();
+        
+        log.debug("RDBMS 인스턴스 수정: provider={}, accountScope={}, request={}", 
+                providerType, accountScope, request);
+
+        // Capability 검증 (CSP별 실제 서비스 키 사용)
+        String serviceKey = getServiceKeyForProvider(providerType);
+        capabilityGuard.ensureSupported(providerType, serviceKey, RESOURCE_TYPE, CapabilityGuard.Operation.UPDATE);
+
+        // 세션 획득
+        CloudSessionCredential session = getSession(providerType, accountScope);
+
+        // Command 변환
+        RdbmsUpdateCommand command = toUpdateCommand(request, session);
+
+        // RDBMS 인스턴스 수정
+        CloudResource resource = portRouter.management(providerType).updateRdbms(command);
+
+        log.info("RDBMS 인스턴스 수정 완료: provider={}, instanceId={}", providerType, request.getInstanceId());
+        return resource;
+    }
+
+    // ==================== 인스턴스 삭제 ====================
+
+    /**
+     * RDBMS 인스턴스를 삭제합니다.
+     * CSP에서 인스턴스 삭제 후 DB에서 소프트 삭제 처리합니다.
+     *
+     * @param request 삭제 요청 정보 (providerType, accountScope 포함)
+     */
+    @Transactional
+    public void deleteRdbms(RdbmsDeleteRequest request) {
+        ProviderType providerType = request.getProviderType();
+        String accountScope = request.getAccountScope();
+        String instanceId = request.getInstanceId();
+        
+        log.debug("RDBMS 인스턴스 삭제: provider={}, accountScope={}, request={}", 
+                providerType, accountScope, request);
+
+        // Capability 검증 (CSP별 실제 서비스 키 사용)
+        String serviceKey = getServiceKeyForProvider(providerType);
+        capabilityGuard.ensureSupported(providerType, serviceKey, RESOURCE_TYPE, CapabilityGuard.Operation.TERMINATE);
+
+        // 세션 획득
+        CloudSessionCredential session = getSession(providerType, accountScope);
+
+        // Command 변환
+        RdbmsDeleteCommand command = toDeleteCommand(request, session);
+
+        // CSP에서 RDBMS 인스턴스 삭제
+        portRouter.management(providerType).deleteRdbms(command);
+
+        // DB 소프트 삭제
+        resourceHelper.softDeleteResource(instanceId);
+
+        log.info("RDBMS 인스턴스 삭제 완료: provider={}, instanceId={}", providerType, instanceId);
+    }
+
+    // ==================== 인스턴스 생명주기 관리 ====================
+
+    /**
+     * RDBMS 인스턴스를 시작합니다.
+     * CSP에서 인스턴스 시작 후 DB의 lifecycleState를 RUNNING으로 업데이트합니다.
+     *
+     * @param providerType 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param instanceId 인스턴스 ID
+     */
+    @Transactional
+    public void startInstance(ProviderType providerType, String accountScope, String instanceId) {
+        log.debug("RDBMS 인스턴스 시작: provider={}, accountScope={}, instanceId={}", 
+                providerType, accountScope, instanceId);
+
+        // Capability 검증 (CSP별 실제 서비스 키 사용)
+        String serviceKey = getServiceKeyForProvider(providerType);
+        capabilityGuard.ensureSupported(providerType, serviceKey, RESOURCE_TYPE, CapabilityGuard.Operation.START);
+
+        // 세션 획득
+        CloudSessionCredential session = getSession(providerType, accountScope);
+
+        // ResourceIdentity 생성 (region 정보는 인스턴스 조회를 통해 얻거나 null로 설정)
+        String region = getRegionFromInstance(providerType, accountScope, instanceId, session);
+        ResourceIdentity resourceId = ResourceIdentity.builder()
+                .providerType(providerType)
+                .accountScope(accountScope)
+                .region(region)
+                .providerResourceId(instanceId)
+                .serviceKey(serviceKey)
+                .resourceType(RESOURCE_TYPE)
+                .build();
+
+        // CSP에서 RDBMS 인스턴스 시작 (RdbmsLifecyclePort는 ResourceLifecyclePort를 확장)
+        portRouter.lifecycle(providerType).start(resourceId, session);
+
+        // DB 상태 업데이트: RUNNING
+        resourceHelper.updateLifecycleState(instanceId, LifecycleState.RUNNING);
+
+        log.info("RDBMS 인스턴스 시작 완료: provider={}, instanceId={}", providerType, instanceId);
+    }
+
+    /**
+     * RDBMS 인스턴스를 중지합니다.
+     * CSP에서 인스턴스 중지 후 DB의 lifecycleState를 STOPPED로 업데이트합니다.
+     *
+     * @param providerType 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param instanceId 인스턴스 ID
+     */
+    @Transactional
+    public void stopInstance(ProviderType providerType, String accountScope, String instanceId) {
+        log.debug("RDBMS 인스턴스 중지: provider={}, accountScope={}, instanceId={}", 
+                providerType, accountScope, instanceId);
+
+        // Capability 검증 (CSP별 실제 서비스 키 사용)
+        String serviceKey = getServiceKeyForProvider(providerType);
+        capabilityGuard.ensureSupported(providerType, serviceKey, RESOURCE_TYPE, CapabilityGuard.Operation.STOP);
+
+        // 세션 획득
+        CloudSessionCredential session = getSession(providerType, accountScope);
+
+        // ResourceIdentity 생성 (region 정보는 인스턴스 조회를 통해 얻거나 null로 설정)
+        String region = getRegionFromInstance(providerType, accountScope, instanceId, session);
+        ResourceIdentity resourceId = ResourceIdentity.builder()
+                .providerType(providerType)
+                .accountScope(accountScope)
+                .region(region)
+                .providerResourceId(instanceId)
+                .serviceKey(serviceKey)
+                .resourceType(RESOURCE_TYPE)
+                .build();
+
+        // CSP에서 RDBMS 인스턴스 중지 (RdbmsLifecyclePort는 ResourceLifecyclePort를 확장)
+        portRouter.lifecycle(providerType).stop(resourceId, session);
+
+        // DB 상태 업데이트: STOPPED
+        resourceHelper.updateLifecycleState(instanceId, LifecycleState.STOPPED);
+
+        log.info("RDBMS 인스턴스 중지 완료: provider={}, instanceId={}", providerType, instanceId);
+    }
+
+    /**
+     * RDBMS 인스턴스를 재시작합니다.
+     * CSP에서 인스턴스 재시작 후 DB의 lifecycleState를 RUNNING으로 유지합니다.
+     *
+     * @param providerType 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param instanceId 인스턴스 ID
+     */
+    @Transactional
+    public void rebootInstance(ProviderType providerType, String accountScope, String instanceId) {
+        log.debug("RDBMS 인스턴스 재시작: provider={}, accountScope={}, instanceId={}", 
+                providerType, accountScope, instanceId);
+
+        // Capability 검증 (START와 STOP이 모두 필요, CSP별 실제 서비스 키 사용)
+        String serviceKey = getServiceKeyForProvider(providerType);
+        capabilityGuard.ensureSupported(providerType, serviceKey, RESOURCE_TYPE, CapabilityGuard.Operation.STOP);
+        capabilityGuard.ensureSupported(providerType, serviceKey, RESOURCE_TYPE, CapabilityGuard.Operation.START);
+
+        // 세션 획득
+        CloudSessionCredential session = getSession(providerType, accountScope);
+
+        // CSP에서 RDBMS 인스턴스 재시작
+        portRouter.lifecycle(providerType).rebootInstance(instanceId, session);
+
+        // DB 상태 업데이트: 재시작 후 RUNNING 상태 유지
+        resourceHelper.updateLifecycleState(instanceId, LifecycleState.RUNNING);
+
+        log.info("RDBMS 인스턴스 재시작 완료: provider={}, instanceId={}", providerType, instanceId);
+    }
+
+    // ==================== 상태 확인 ====================
+
+    /**
+     * RDBMS 인스턴스의 현재 상태를 확인합니다.
+     *
+     * @param providerType 클라우드 프로바이더 타입
+     * @param accountScope 계정 스코프
+     * @param instanceId 인스턴스 ID
+     * @return 인스턴스 상태
+     */
+    @Transactional(readOnly = true)
+    public String getInstanceStatus(ProviderType providerType, String accountScope, String instanceId) {
+        log.debug("RDBMS 인스턴스 상태 확인: provider={}, accountScope={}, instanceId={}", 
+                providerType, accountScope, instanceId);
+
+        // 세션 획득
+        CloudSessionCredential session = getSession(providerType, accountScope);
+
+        String status = portRouter.discovery(providerType).getInstanceStatus(instanceId, session);
+
+        log.info("RDBMS 인스턴스 상태 확인 완료: provider={}, instanceId={}, status={}", 
+                providerType, instanceId, status);
+        return status;
+    }
+
+    // ==================== Helper Methods ====================
+
+    /**
+     * 인스턴스 ID로부터 region 정보를 조회합니다.
+     * 인스턴스가 존재하지 않으면 null을 반환합니다.
+     */
+    private String getRegionFromInstance(ProviderType providerType, String accountScope, 
+                                         String instanceId, CloudSessionCredential session) {
+        try {
+            Optional<CloudResource> resource = portRouter.discovery(providerType)
+                    .getRdbmsInstance(instanceId, session);
+            return resource
+                    .map(r -> r.getRegion() != null ? r.getRegion().getRegionKey() : null)
+                    .orElse(null);
+        } catch (Exception e) {
+            log.warn("Failed to get region for instance {}: {}", instanceId, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * 프로바이더 타입에 따른 서비스 키 반환
+     * AWS: RDS, Azure: AzureDatabase, GCP: CloudSQL 등
+     */
+    private String getServiceKeyForProvider(ProviderType providerType) {
+        return switch (providerType) {
+            case AWS -> "RDS";
+            case AZURE -> "AzureDatabase";
+            case GCP -> "CloudSQL";
+            default -> "RDBMS";
+        };
+    }
+
+    // ==================== Command 변환 ====================
+
+    private RdbmsQuery toQuery(ProviderType providerType, String accountScope, RdbmsQueryRequest request) {
+        return RdbmsQuery.builder()
+                .providerType(providerType)
+                .accountScope(accountScope)
+                .regions(request.getRegions())
+                .instanceName(request.getInstanceName())
+                .engine(request.getEngine())
+                .instanceSize(request.getInstanceSize())
+                .status(request.getStatus())
+                .tagsEquals(request.getTags())
+                .page(request.getPage())
+                .size(request.getSize())
+                .build();
+    }
+
+    private RdbmsCreateCommand toCreateCommand(RdbmsCreateRequest request, CloudSessionCredential session) {
+        String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
+        String serviceKey = getServiceKeyForProvider(request.getProviderType());
+        
+        return RdbmsCreateCommand.builder()
+                .providerType(request.getProviderType())
+                .accountScope(request.getAccountScope())
+                .region(request.getRegion())
+                .serviceKey(serviceKey)
+                .resourceType(RESOURCE_TYPE)
+                .instanceName(request.getInstanceName())
+                .engine(request.getEngine())
+                .engineVersion(request.getEngineVersion())
+                .instanceSize(request.getInstanceSize())
+                .allocatedStorage(request.getAllocatedStorage())
+                .adminUsername(request.getMasterUsername())
+                .adminPassword(request.getMasterPassword())
+                .dbName(request.getDbName())
+                .networkSecurityId(request.getNetworkSecurityId())
+                .subnetId(request.getSubnetId())
+                .port(request.getPort())
+                .zone(request.getZone())
+                .highAvailability(request.getHighAvailability())
+                .publiclyAccessible(request.getPubliclyAccessible())
+                .tags(request.getTags())
+                .tenantKey(tenantKey)
+                .providerSpecificConfig(request.getProviderSpecificConfig())
+                .session(session)
+                .build();
+    }
+
+    private RdbmsUpdateCommand toUpdateCommand(RdbmsUpdateRequest request, CloudSessionCredential session) {
+        String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
+        
+        // tagsToAdd를 tags로 사용 (tagsToRemove는 Adapter에서 처리하거나 별도 필드로 전달 필요)
+        // 현재는 tagsToAdd만 전달 (실제 구현에서는 Adapter에서 태그 추가/제거를 별도로 처리)
+        java.util.Map<String, String> tags = request.getTagsToAdd() != null 
+                ? new java.util.HashMap<>(request.getTagsToAdd()) 
+                : new java.util.HashMap<>();
+        
+        return RdbmsUpdateCommand.builder()
+                .providerType(request.getProviderType())
+                .accountScope(request.getAccountScope())
+                .region(null) // region은 Adapter에서 처리
+                .providerResourceId(request.getInstanceId())
+                .instanceSize(request.getInstanceSize())
+                .allocatedStorage(request.getAllocatedStorage())
+                .adminPassword(request.getMasterPassword())
+                .applyImmediately(request.getApplyImmediately())
+                .tags(tags)
+                .tenantKey(tenantKey)
+                .providerSpecificConfig(request.getProviderSpecificConfig())
+                .session(session)
+                .build();
+    }
+
+    private RdbmsDeleteCommand toDeleteCommand(RdbmsDeleteRequest request, CloudSessionCredential session) {
+        String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
+        
+        return RdbmsDeleteCommand.builder()
+                .providerType(request.getProviderType())
+                .accountScope(request.getAccountScope())
+                .region(null) // region은 Adapter에서 처리
+                .providerResourceId(request.getInstanceId())
+                .skipSnapshot(request.getSkipSnapshot())
+                .snapshotName(request.getSnapshotName())
+                .deleteAutomatedBackups(request.getDeleteAutomatedBackups())
+                .tenantKey(tenantKey)
+                .providerSpecificConfig(request.getProviderSpecificConfig())
+                .session(session)
+                .build();
+    }
+
+}

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/rdbms/RdbmsUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/rdbms/RdbmsUseCaseService.java
@@ -1,6 +1,9 @@
 package com.agenticcp.core.domain.cloud.service.rdbms;
 
 import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.common.crypto.EncryptionService;
+import com.agenticcp.core.common.logging.LogMaskingUtils;
+import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
 import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
 import com.agenticcp.core.domain.cloud.dto.RdbmsCreateRequest;
 import com.agenticcp.core.domain.cloud.dto.RdbmsDeleteRequest;
@@ -10,7 +13,6 @@ import com.agenticcp.core.common.exception.BusinessException;
 import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
 import com.agenticcp.core.domain.cloud.entity.CloudResource;
 import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
-import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
 import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsCreateCommand;
 import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsDeleteCommand;
 import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsQuery;
@@ -54,6 +56,7 @@ public class RdbmsUseCaseService {
     private final CapabilityGuard capabilityGuard;
     private final AccountCredentialManagementPort credentialPort;
     private final CloudResourceManagementHelper resourceHelper;
+    private final EncryptionService encryptionService;
 
     /**
      * 세션 자격증명을 획득합니다.
@@ -137,8 +140,10 @@ public class RdbmsUseCaseService {
         ProviderType providerType = request.getProviderType();
         String accountScope = request.getAccountScope();
         
+        // 로깅용 마스킹된 요청 (원본 데이터는 변경하지 않음)
+        String maskedRequest = LogMaskingUtils.maskSensitiveData(request.toString());
         log.debug("RDBMS 인스턴스 생성 시작: provider={}, accountScope={}, request={}", 
-                providerType, accountScope, request);
+                providerType, accountScope, maskedRequest);
 
         // Capability 검증 (CSP별 실제 서비스 키 사용)
         String serviceKey = getServiceKeyForProvider(providerType);
@@ -232,8 +237,10 @@ public class RdbmsUseCaseService {
         ProviderType providerType = request.getProviderType();
         String accountScope = request.getAccountScope();
         
+        // 로깅용 마스킹된 요청 (원본 데이터는 변경하지 않음)
+        String maskedRequest = LogMaskingUtils.maskSensitiveData(request.toString());
         log.debug("RDBMS 인스턴스 수정: provider={}, accountScope={}, request={}", 
-                providerType, accountScope, request);
+                providerType, accountScope, maskedRequest);
 
         // Capability 검증 (CSP별 실제 서비스 키 사용)
         String serviceKey = getServiceKeyForProvider(providerType);
@@ -479,6 +486,19 @@ public class RdbmsUseCaseService {
         String tenantKey = TenantContextHolder.getCurrentTenantKeyOrThrow();
         String serviceKey = getServiceKeyForProvider(request.getProviderType());
         
+        // adminPassword 암호화
+        String encryptedPassword;
+        try {
+            encryptedPassword = encryptionService.encrypt(request.getMasterPassword());
+            log.debug("RDBMS adminPassword 암호화 완료");
+        } catch (Exception e) {
+            log.error("RDBMS adminPassword 암호화 실패", e);
+            throw new BusinessException(
+                CloudErrorCode.ENCRYPTION_FAILED,
+                "관리자 패스워드 암호화에 실패했습니다: " + e.getMessage()
+            );
+        }
+        
         return RdbmsCreateCommand.builder()
                 .providerType(request.getProviderType())
                 .accountScope(request.getAccountScope())
@@ -491,7 +511,7 @@ public class RdbmsUseCaseService {
                 .instanceSize(request.getInstanceSize())
                 .allocatedStorage(request.getAllocatedStorage())
                 .adminUsername(request.getMasterUsername())
-                .adminPassword(request.getMasterPassword())
+                .adminPassword(encryptedPassword)  // 암호화된 패스워드 전달
                 .dbName(request.getDbName())
                 .networkSecurityId(request.getNetworkSecurityId())
                 .subnetId(request.getSubnetId())
@@ -515,6 +535,21 @@ public class RdbmsUseCaseService {
                 ? new java.util.HashMap<>(request.getTagsToAdd()) 
                 : new java.util.HashMap<>();
         
+        // adminPassword 암호화 (수정 시 선택적 - 패스워드 변경하지 않을 수도 있음)
+        String encryptedPassword = null;
+        if (request.getMasterPassword() != null) {
+            try {
+                encryptedPassword = encryptionService.encrypt(request.getMasterPassword());
+                log.debug("RDBMS adminPassword 암호화 완료 (수정)");
+            } catch (Exception e) {
+                log.error("RDBMS adminPassword 암호화 실패 (수정)", e);
+                throw new BusinessException(
+                    CloudErrorCode.ENCRYPTION_FAILED,
+                    "관리자 패스워드 암호화에 실패했습니다: " + e.getMessage()
+                );
+            }
+        }
+        
         return RdbmsUpdateCommand.builder()
                 .providerType(request.getProviderType())
                 .accountScope(request.getAccountScope())
@@ -522,7 +557,7 @@ public class RdbmsUseCaseService {
                 .providerResourceId(request.getInstanceId())
                 .instanceSize(request.getInstanceSize())
                 .allocatedStorage(request.getAllocatedStorage())
-                .adminPassword(request.getMasterPassword())
+                .adminPassword(encryptedPassword)  // 암호화된 패스워드 전달 (null 가능)
                 .applyImmediately(request.getApplyImmediately())
                 .tags(tags)
                 .tenantKey(tenantKey)

--- a/src/main/java/com/agenticcp/core/domain/cloud/service/rdbms/RdbmsUseCaseService.java
+++ b/src/main/java/com/agenticcp/core/domain/cloud/service/rdbms/RdbmsUseCaseService.java
@@ -21,12 +21,15 @@ import com.agenticcp.core.domain.cloud.port.model.ResourceIdentity;
 import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
 import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
 import com.agenticcp.core.domain.cloud.service.helper.CloudResourceManagementHelper;
+import com.agenticcp.core.domain.cloud.dto.ResourceRegistrationRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -161,12 +164,34 @@ public class RdbmsUseCaseService {
         // DB에 CloudResource 저장 (실패 시 보상 트랜잭션 실행)
         CloudResource savedResource;
         try {
-            // Adapter에서 이미 CloudResource를 반환하므로, ID로 조회하여 저장
-            // 또는 Adapter에서 이미 저장된 경우 그대로 반환
-            savedResource = resource;
+            // ResourceRegistrationRequest 생성
+            Map<String, Object> attributes = new HashMap<>();
+            attributes.put(ResourceRegistrationRequest.AttributeKeys.INSTANCE_SIZE, request.getInstanceSize());
+            attributes.put(ResourceRegistrationRequest.AttributeKeys.STORAGE_GB, request.getAllocatedStorage());
+            if (request.getEngine() != null) {
+                attributes.put("engine", request.getEngine());
+            }
+            if (request.getEngineVersion() != null) {
+                attributes.put("engineVersion", request.getEngineVersion());
+            }
+            
+            ResourceRegistrationRequest registrationRequest = ResourceRegistrationRequest.builder()
+                    .resourceId(resource.getResourceId())
+                    .resourceName(resource.getResourceName() != null ? resource.getResourceName() : request.getInstanceName())
+                    .resourceType(CloudResource.ResourceType.DATABASE)
+                    .tags(request.getTags() != null ? request.getTags() : resource.getTags())
+                    .attributes(attributes)
+                    .build();
+            
+            // DB에 CloudResource 저장
+            savedResource = resourceHelper.registerResource(
+                    providerType,
+                    serviceKey,
+                    registrationRequest
+            );
             
             log.info("RDBMS 인스턴스 생성 완료: provider={}, instanceId={}, resourceId={}", 
-                    providerType, resource.getResourceId(), resource.getId());
+                    providerType, resource.getResourceId(), savedResource.getId());
         } catch (Exception e) {
             log.error("[RdbmsUseCaseService] DB 저장 실패, 보상 트랜잭션 실행: instanceId={}, error={}",
                     resource.getResourceId(), e.getMessage());
@@ -254,6 +279,26 @@ public class RdbmsUseCaseService {
 
         // RDBMS 인스턴스 수정
         CloudResource resource = portRouter.management(providerType).updateRdbms(command);
+
+        // DB에 수정된 정보 반영 (instanceSize, allocatedStorage 등)
+        try {
+            // 수정된 리소스 정보를 DB에 동기화
+            // Adapter에서 반환된 CloudResource의 정보를 DB에 업데이트
+            if (request.getInstanceSize() != null || request.getAllocatedStorage() != null) {
+                // DB에서 기존 리소스 조회 후 업데이트하거나, 
+                // Adapter에서 반환된 resource의 정보를 기반으로 DB 업데이트
+                // 현재는 Adapter가 이미 CloudResource를 반환하므로, 
+                // 생명주기 상태만 업데이트 (실제 속성 업데이트는 별도 동기화 작업에서 처리)
+                resourceHelper.updateLifecycleState(
+                    request.getInstanceId(), 
+                    resource.getLifecycleState() != null ? resource.getLifecycleState() : LifecycleState.RUNNING
+                );
+            }
+        } catch (Exception e) {
+            log.warn("[RdbmsUseCaseService] DB 업데이트 실패 (수정은 완료됨): instanceId={}, error={}",
+                    request.getInstanceId(), e.getMessage());
+            // DB 업데이트 실패해도 CSP 수정은 완료되었으므로 예외를 던지지 않음
+        }
 
         log.info("RDBMS 인스턴스 수정 완료: provider={}, instanceId={}", providerType, request.getInstanceId());
         return resource;

--- a/src/test/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/rds/AwsRdsManagementAdapterDecryptionTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/adapter/outbound/aws/rds/AwsRdsManagementAdapterDecryptionTest.java
@@ -1,0 +1,509 @@
+package com.agenticcp.core.domain.cloud.adapter.outbound.aws.rds;
+
+import com.agenticcp.core.common.crypto.AesGcmEncryptionService;
+import com.agenticcp.core.common.crypto.EncryptionService;
+import com.agenticcp.core.common.exception.BusinessException;
+import com.agenticcp.core.domain.cloud.adapter.outbound.aws.config.AwsRdsConfig;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsCreateCommand;
+import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsUpdateCommand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.*;
+
+import java.security.SecureRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * AwsRdsManagementAdapter 복호화 로직 단위 테스트
+ * 
+ * adminPassword 복호화 로직을 검증합니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AwsRdsManagementAdapter 복호화 테스트")
+class AwsRdsManagementAdapterDecryptionTest {
+
+    @Mock
+    private AwsRdsConfig awsRdsConfig;
+
+    @Mock
+    private AwsRdsMapper mapper;
+
+    @Mock
+    private RdsClient rdsClient;
+
+    @Mock
+    private CloudSessionCredential session;
+
+    private EncryptionService encryptionService;
+    private AwsRdsManagementAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        // 실제 EncryptionService 사용 (AES-GCM-256)
+        byte[] key = generateKey(32);
+        encryptionService = new AesGcmEncryptionService(key);
+
+        // AwsRdsManagementAdapter 인스턴스 생성 (EncryptionService 주입)
+        adapter = new AwsRdsManagementAdapter(awsRdsConfig, mapper, encryptionService);
+
+        // Mock 설정 - lenient()를 사용하여 각 테스트에서 다른 인자로 호출될 수 있음
+        lenient().when(awsRdsConfig.createRdsClient(any(CloudSessionCredential.class), anyString()))
+            .thenReturn(rdsClient);
+    }
+
+    /**
+     * AES 키 생성 헬퍼 메서드
+     */
+    private byte[] generateKey(int size) {
+        byte[] key = new byte[size];
+        new SecureRandom().nextBytes(key);
+        return key;
+    }
+
+    @Nested
+    @DisplayName("adminPassword 복호화 테스트 - 생성 시")
+    class CreateRdbmsDecryptionTest {
+
+        @Test
+        @DisplayName("암호화된 adminPassword가 정상적으로 복호화되어 AWS SDK 요청에 전달됨")
+        void shouldDecryptPasswordWhenCreatingRdbms() throws Exception {
+            // given
+            String plainPassword = "MySecurePassword123!";
+            String encryptedPassword = encryptionService.encrypt(plainPassword);
+
+            RdbmsCreateCommand command = RdbmsCreateCommand.builder()
+                .providerType(CloudProvider.ProviderType.AWS)
+                .accountScope("123456789012")
+                .region("us-east-1")
+                .serviceKey("RDS")
+                .resourceType("DATABASE")
+                .instanceName("test-db")
+                .engine("mysql")
+                .instanceSize("db.t3.micro")
+                .allocatedStorage(20)
+                .adminUsername("admin")
+                .adminPassword(encryptedPassword)  // 암호화된 패스워드
+                .session(session)  // session 추가
+                .build();
+
+            // AWS SDK 응답 Mock
+            DBInstance dbInstance = DBInstance.builder()
+                .dbInstanceIdentifier("test-db")
+                .dbInstanceStatus("available")
+                .build();
+
+            CreateDbInstanceResponse response = CreateDbInstanceResponse.builder()
+                .dbInstance(dbInstance)
+                .build();
+
+            DescribeDbInstancesResponse describeResponse = DescribeDbInstancesResponse.builder()
+                .dbInstances(dbInstance)
+                .build();
+
+            given(rdsClient.createDBInstance(any(CreateDbInstanceRequest.class)))
+                .willReturn(response);
+            given(rdsClient.describeDBInstances(any(DescribeDbInstancesRequest.class)))
+                .willReturn(describeResponse);
+            given(mapper.toCloudResource(any(DBInstance.class), any(), any(), any()))
+                .willReturn(mock(com.agenticcp.core.domain.cloud.entity.CloudResource.class));
+
+            ArgumentCaptor<CreateDbInstanceRequest> requestCaptor = 
+                ArgumentCaptor.forClass(CreateDbInstanceRequest.class);
+
+            // when
+            adapter.createRdbms(command);
+
+            // then
+            verify(rdsClient).createDBInstance(requestCaptor.capture());
+            CreateDbInstanceRequest capturedRequest = requestCaptor.getValue();
+            
+            // AWS SDK 요청에 전달된 패스워드가 복호화된 평문인지 확인
+            String requestPassword = capturedRequest.masterUserPassword();
+            assertThat(requestPassword).isNotNull();
+            assertThat(requestPassword).isEqualTo(plainPassword);
+            assertThat(requestPassword).isNotEqualTo(encryptedPassword);
+        }
+
+        @Test
+        @DisplayName("복호화 실패 시 DECRYPTION_FAILED 예외 발생")
+        void shouldThrowExceptionWhenDecryptionFails() {
+            // given
+            EncryptionService failingEncryptionService = mock(EncryptionService.class);
+            AwsRdsManagementAdapter adapterWithFailingDecryption = 
+                new AwsRdsManagementAdapter(awsRdsConfig, mapper, failingEncryptionService);
+
+            String invalidEncryptedPassword = "invalid-encrypted-password";
+            RdbmsCreateCommand command = RdbmsCreateCommand.builder()
+                .providerType(CloudProvider.ProviderType.AWS)
+                .accountScope("123456789012")
+                .region("us-east-1")
+                .serviceKey("RDS")
+                .resourceType("DATABASE")
+                .instanceName("test-db")
+                .engine("mysql")
+                .instanceSize("db.t3.micro")
+                .allocatedStorage(20)
+                .adminUsername("admin")
+                .adminPassword(invalidEncryptedPassword)
+                .session(session)  // session 추가
+                .build();
+
+            given(awsRdsConfig.createRdsClient(any(CloudSessionCredential.class), anyString()))
+                .willReturn(rdsClient);
+            given(failingEncryptionService.decrypt(anyString()))
+                .willThrow(new RuntimeException("복호화 실패"));
+
+            // when & then
+            assertThatThrownBy(() -> adapterWithFailingDecryption.createRdbms(command))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    BusinessException be = (BusinessException) exception;
+                    assertThat(be.getErrorCode()).isEqualTo(CloudErrorCode.DECRYPTION_FAILED);
+                    assertThat(be.getMessage()).contains("관리자 패스워드 복호화에 실패했습니다");
+                });
+        }
+
+        @Test
+        @DisplayName("adminPassword가 null이면 AWS SDK 요청에도 null이 전달됨")
+        void shouldPassNullWhenPasswordIsNull() throws Exception {
+            // given
+            RdbmsCreateCommand command = RdbmsCreateCommand.builder()
+                .providerType(CloudProvider.ProviderType.AWS)
+                .accountScope("123456789012")
+                .region("us-east-1")
+                .serviceKey("RDS")
+                .resourceType("DATABASE")
+                .instanceName("test-db")
+                .engine("mysql")
+                .instanceSize("db.t3.micro")
+                .allocatedStorage(20)
+                .adminUsername("admin")
+                .adminPassword(null)  // null 패스워드
+                .session(session)  // session 추가
+                .build();
+
+            // AWS SDK 응답 Mock
+            DBInstance dbInstance = DBInstance.builder()
+                .dbInstanceIdentifier("test-db")
+                .dbInstanceStatus("available")
+                .build();
+
+            CreateDbInstanceResponse response = CreateDbInstanceResponse.builder()
+                .dbInstance(dbInstance)
+                .build();
+
+            DescribeDbInstancesResponse describeResponse = DescribeDbInstancesResponse.builder()
+                .dbInstances(dbInstance)
+                .build();
+
+            given(rdsClient.createDBInstance(any(CreateDbInstanceRequest.class)))
+                .willReturn(response);
+            given(rdsClient.describeDBInstances(any(DescribeDbInstancesRequest.class)))
+                .willReturn(describeResponse);
+            given(mapper.toCloudResource(any(DBInstance.class), any(), any(), any()))
+                .willReturn(mock(com.agenticcp.core.domain.cloud.entity.CloudResource.class));
+
+            ArgumentCaptor<CreateDbInstanceRequest> requestCaptor = 
+                ArgumentCaptor.forClass(CreateDbInstanceRequest.class);
+
+            // when
+            adapter.createRdbms(command);
+
+            // then
+            verify(rdsClient).createDBInstance(requestCaptor.capture());
+            CreateDbInstanceRequest capturedRequest = requestCaptor.getValue();
+            
+            // AWS SDK 요청에 전달된 패스워드가 null인지 확인
+            String requestPassword = capturedRequest.masterUserPassword();
+            assertThat(requestPassword).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("adminPassword 복호화 테스트 - 수정 시")
+    class UpdateRdbmsDecryptionTest {
+
+        @Test
+        @DisplayName("암호화된 adminPassword가 정상적으로 복호화되어 AWS SDK 요청에 전달됨")
+        void shouldDecryptPasswordWhenUpdatingRdbms() throws Exception {
+            // given
+            String plainPassword = "NewSecurePassword456!";
+            String encryptedPassword = encryptionService.encrypt(plainPassword);
+
+            RdbmsUpdateCommand command = RdbmsUpdateCommand.builder()
+                .providerType(CloudProvider.ProviderType.AWS)
+                .accountScope("123456789012")
+                .region("us-east-1")
+                .providerResourceId("db-instance-123")
+                .adminPassword(encryptedPassword)  // 암호화된 패스워드
+                .session(session)  // session 추가
+                .build();
+
+            // AWS SDK 응답 Mock
+            DBInstance dbInstance = DBInstance.builder()
+                .dbInstanceIdentifier("db-instance-123")
+                .dbInstanceStatus("available")
+                .build();
+
+            ModifyDbInstanceResponse response = ModifyDbInstanceResponse.builder()
+                .dbInstance(dbInstance)
+                .build();
+
+            DescribeDbInstancesResponse describeResponse = DescribeDbInstancesResponse.builder()
+                .dbInstances(dbInstance)
+                .build();
+
+            given(rdsClient.modifyDBInstance(any(ModifyDbInstanceRequest.class)))
+                .willReturn(response);
+            given(rdsClient.describeDBInstances(any(DescribeDbInstancesRequest.class)))
+                .willReturn(describeResponse);
+            given(mapper.toCloudResource(any(DBInstance.class), any(), any(), any()))
+                .willReturn(mock(com.agenticcp.core.domain.cloud.entity.CloudResource.class));
+
+            ArgumentCaptor<ModifyDbInstanceRequest> requestCaptor = 
+                ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
+
+            // when
+            adapter.updateRdbms(command);
+
+            // then
+            verify(rdsClient).modifyDBInstance(requestCaptor.capture());
+            ModifyDbInstanceRequest capturedRequest = requestCaptor.getValue();
+            
+            // AWS SDK 요청에 전달된 패스워드가 복호화된 평문인지 확인
+            String requestPassword = capturedRequest.masterUserPassword();
+            assertThat(requestPassword).isNotNull();
+            assertThat(requestPassword).isEqualTo(plainPassword);
+            assertThat(requestPassword).isNotEqualTo(encryptedPassword);
+        }
+
+        @Test
+        @DisplayName("복호화 실패 시 DECRYPTION_FAILED 예외 발생")
+        void shouldThrowExceptionWhenDecryptionFails() {
+            // given
+            EncryptionService failingEncryptionService = mock(EncryptionService.class);
+            AwsRdsManagementAdapter adapterWithFailingDecryption = 
+                new AwsRdsManagementAdapter(awsRdsConfig, mapper, failingEncryptionService);
+
+            String invalidEncryptedPassword = "invalid-encrypted-password";
+            RdbmsUpdateCommand command = RdbmsUpdateCommand.builder()
+                .providerType(CloudProvider.ProviderType.AWS)
+                .accountScope("123456789012")
+                .region("us-east-1")
+                .providerResourceId("db-instance-123")
+                .adminPassword(invalidEncryptedPassword)
+                .session(session)  // session 추가
+                .build();
+
+            given(awsRdsConfig.createRdsClient(any(CloudSessionCredential.class), anyString()))
+                .willReturn(rdsClient);
+            given(failingEncryptionService.decrypt(anyString()))
+                .willThrow(new RuntimeException("복호화 실패"));
+
+            // when & then
+            assertThatThrownBy(() -> adapterWithFailingDecryption.updateRdbms(command))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    BusinessException be = (BusinessException) exception;
+                    assertThat(be.getErrorCode()).isEqualTo(CloudErrorCode.DECRYPTION_FAILED);
+                    assertThat(be.getMessage()).contains("관리자 패스워드 복호화에 실패했습니다");
+                });
+        }
+
+        @Test
+        @DisplayName("adminPassword가 null이면 AWS SDK 요청에도 null이 전달됨")
+        void shouldPassNullWhenPasswordIsNull() throws Exception {
+            // given
+            RdbmsUpdateCommand command = RdbmsUpdateCommand.builder()
+                .providerType(CloudProvider.ProviderType.AWS)
+                .accountScope("123456789012")
+                .region("us-east-1")
+                .providerResourceId("db-instance-123")
+                .instanceSize("db.t3.small")
+                .adminPassword(null)  // null 패스워드
+                .session(session)  // session 추가
+                .build();
+
+            // AWS SDK 응답 Mock
+            DBInstance dbInstance = DBInstance.builder()
+                .dbInstanceIdentifier("db-instance-123")
+                .dbInstanceStatus("available")
+                .build();
+
+            ModifyDbInstanceResponse response = ModifyDbInstanceResponse.builder()
+                .dbInstance(dbInstance)
+                .build();
+
+            DescribeDbInstancesResponse describeResponse = DescribeDbInstancesResponse.builder()
+                .dbInstances(dbInstance)
+                .build();
+
+            given(rdsClient.modifyDBInstance(any(ModifyDbInstanceRequest.class)))
+                .willReturn(response);
+            given(rdsClient.describeDBInstances(any(DescribeDbInstancesRequest.class)))
+                .willReturn(describeResponse);
+            given(mapper.toCloudResource(any(DBInstance.class), any(), any(), any()))
+                .willReturn(mock(com.agenticcp.core.domain.cloud.entity.CloudResource.class));
+
+            ArgumentCaptor<ModifyDbInstanceRequest> requestCaptor = 
+                ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
+
+            // when
+            adapter.updateRdbms(command);
+
+            // then
+            verify(rdsClient).modifyDBInstance(requestCaptor.capture());
+            ModifyDbInstanceRequest capturedRequest = requestCaptor.getValue();
+            
+            // AWS SDK 요청에 전달된 패스워드가 null인지 확인
+            String requestPassword = capturedRequest.masterUserPassword();
+            assertThat(requestPassword).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("복호화 라운드트립 테스트")
+    class DecryptionRoundTripTest {
+
+        @Test
+        @DisplayName("암호화된 패스워드를 복호화하면 원본과 일치함")
+        void shouldDecryptToOriginalPassword() throws Exception {
+            // given
+            String plainPassword = "TestPassword123!@#";
+            String encryptedPassword = encryptionService.encrypt(plainPassword);
+
+            RdbmsCreateCommand command = RdbmsCreateCommand.builder()
+                .providerType(CloudProvider.ProviderType.AWS)
+                .accountScope("123456789012")
+                .region("us-east-1")
+                .serviceKey("RDS")
+                .resourceType("DATABASE")
+                .instanceName("test-db")
+                .engine("mysql")
+                .instanceSize("db.t3.micro")
+                .allocatedStorage(20)
+                .adminUsername("admin")
+                .adminPassword(encryptedPassword)
+                .session(session)  // session 추가
+                .build();
+
+            // AWS SDK 응답 Mock
+            DBInstance dbInstance = DBInstance.builder()
+                .dbInstanceIdentifier("test-db")
+                .dbInstanceStatus("available")
+                .build();
+
+            CreateDbInstanceResponse response = CreateDbInstanceResponse.builder()
+                .dbInstance(dbInstance)
+                .build();
+
+            DescribeDbInstancesResponse describeResponse = DescribeDbInstancesResponse.builder()
+                .dbInstances(dbInstance)
+                .build();
+
+            given(rdsClient.createDBInstance(any(CreateDbInstanceRequest.class)))
+                .willReturn(response);
+            given(rdsClient.describeDBInstances(any(DescribeDbInstancesRequest.class)))
+                .willReturn(describeResponse);
+            given(mapper.toCloudResource(any(DBInstance.class), any(), any(), any()))
+                .willReturn(mock(com.agenticcp.core.domain.cloud.entity.CloudResource.class));
+
+            ArgumentCaptor<CreateDbInstanceRequest> requestCaptor = 
+                ArgumentCaptor.forClass(CreateDbInstanceRequest.class);
+
+            // when
+            adapter.createRdbms(command);
+
+            // then
+            verify(rdsClient).createDBInstance(requestCaptor.capture());
+            CreateDbInstanceRequest capturedRequest = requestCaptor.getValue();
+            
+            String decryptedPassword = capturedRequest.masterUserPassword();
+            assertThat(decryptedPassword).isEqualTo(plainPassword);
+        }
+
+        @Test
+        @DisplayName("다양한 특수문자를 포함한 패스워드도 정상 복호화됨")
+        void shouldHandleSpecialCharacters() throws Exception {
+            // given
+            String[] testPasswords = {
+                "Password123!@#$%^&*()",
+                "한글패스워드123!",
+                "P@ssw0rd with spaces",
+                "VeryLongPassword1234567890!@#$%^&*()_+-=[]{}|;:,.<>?",
+                "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+            };
+
+            for (String plainPassword : testPasswords) {
+                String encryptedPassword = encryptionService.encrypt(plainPassword);
+
+                RdbmsCreateCommand command = RdbmsCreateCommand.builder()
+                    .providerType(CloudProvider.ProviderType.AWS)
+                    .accountScope("123456789012")
+                    .region("us-east-1")
+                    .serviceKey("RDS")
+                    .resourceType("DATABASE")
+                    .instanceName("test-db")
+                    .engine("mysql")
+                    .instanceSize("db.t3.micro")
+                    .allocatedStorage(20)
+                    .adminUsername("admin")
+                    .adminPassword(encryptedPassword)
+                    .session(session)  // session 추가
+                    .build();
+
+                // AWS SDK 응답 Mock
+                DBInstance dbInstance = DBInstance.builder()
+                    .dbInstanceIdentifier("test-db")
+                    .dbInstanceStatus("available")
+                    .build();
+
+                CreateDbInstanceResponse response = CreateDbInstanceResponse.builder()
+                    .dbInstance(dbInstance)
+                    .build();
+
+                DescribeDbInstancesResponse describeResponse = DescribeDbInstancesResponse.builder()
+                    .dbInstances(dbInstance)
+                    .build();
+
+                given(rdsClient.createDBInstance(any(CreateDbInstanceRequest.class)))
+                    .willReturn(response);
+                given(rdsClient.describeDBInstances(any(DescribeDbInstancesRequest.class)))
+                    .willReturn(describeResponse);
+                given(mapper.toCloudResource(any(DBInstance.class), any(), any(), any()))
+                    .willReturn(mock(com.agenticcp.core.domain.cloud.entity.CloudResource.class));
+
+                ArgumentCaptor<CreateDbInstanceRequest> requestCaptor = 
+                    ArgumentCaptor.forClass(CreateDbInstanceRequest.class);
+
+                // when
+                adapter.createRdbms(command);
+
+                // then
+                verify(rdsClient, atLeastOnce()).createDBInstance(requestCaptor.capture());
+                CreateDbInstanceRequest capturedRequest = requestCaptor.getValue();
+                
+                String decryptedPassword = capturedRequest.masterUserPassword();
+                assertThat(decryptedPassword).isEqualTo(plainPassword);
+            }
+        }
+    }
+}

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/rdbms/RdbmsUseCaseServiceDbSyncTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/rdbms/RdbmsUseCaseServiceDbSyncTest.java
@@ -1,0 +1,408 @@
+package com.agenticcp.core.domain.cloud.service.rdbms;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.common.crypto.EncryptionService;
+import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
+import com.agenticcp.core.domain.cloud.dto.RdbmsCreateRequest;
+import com.agenticcp.core.domain.cloud.dto.RdbmsDeleteRequest;
+import com.agenticcp.core.domain.cloud.dto.RdbmsUpdateRequest;
+import com.agenticcp.core.domain.cloud.dto.ResourceRegistrationRequest;
+import com.agenticcp.core.common.exception.BusinessException;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider.ProviderType;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
+import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
+import com.agenticcp.core.domain.cloud.port.outbound.rdbms.RdbmsDiscoveryPort;
+import com.agenticcp.core.domain.cloud.port.outbound.rdbms.RdbmsLifecyclePort;
+import com.agenticcp.core.domain.cloud.port.outbound.rdbms.RdbmsManagementPort;
+import com.agenticcp.core.domain.cloud.service.helper.CloudResourceManagementHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * RdbmsUseCaseService DB 동기화 로직 단위 테스트
+ * CSP 작업 후 CloudResource 엔티티가 올바르게 DB에 저장/삭제되는지 검증합니다.
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RdbmsUseCaseService DB 동기화 테스트")
+class RdbmsUseCaseServiceDbSyncTest {
+
+    @Mock
+    private RdbmsPortRouter portRouter;
+
+    @Mock
+    private RdbmsManagementPort managementPort;
+
+    @Mock
+    private RdbmsDiscoveryPort discoveryPort;
+
+    @Mock
+    private RdbmsLifecyclePort lifecyclePort;
+
+    @Mock
+    private CapabilityGuard capabilityGuard;
+
+    @Mock
+    private AccountCredentialManagementPort credentialPort;
+
+    @Mock
+    private CloudResourceManagementHelper resourceHelper;
+
+    @Mock
+    private EncryptionService encryptionService;
+
+    private RdbmsUseCaseService rdbmsUseCaseService;
+    private CloudSessionCredential mockSession;
+
+    private static final ProviderType PROVIDER_TYPE = ProviderType.AWS;
+    private static final String ACCOUNT_SCOPE = "123456789012";
+    private static final String TENANT_KEY = "tenant-test";
+    private static final String INSTANCE_ID = "test-instance-123";
+    private static final String REGION = "us-east-1";
+
+    @BeforeEach
+    void setUp() {
+        TenantContextHolder.setTenantKey(TENANT_KEY);
+        
+        rdbmsUseCaseService = new RdbmsUseCaseService(
+                portRouter,
+                capabilityGuard,
+                credentialPort,
+                resourceHelper,
+                encryptionService
+        );
+        
+        mockSession = mock(CloudSessionCredential.class);
+
+        // 공통 Mock 설정
+        lenient().when(portRouter.management(PROVIDER_TYPE)).thenReturn(managementPort);
+        lenient().when(portRouter.discovery(PROVIDER_TYPE)).thenReturn(discoveryPort);
+        lenient().when(portRouter.lifecycle(PROVIDER_TYPE)).thenReturn(lifecyclePort);
+        lenient().when(credentialPort.getSession(eq(TENANT_KEY), eq(ACCOUNT_SCOPE), eq(PROVIDER_TYPE)))
+                .thenReturn(mockSession);
+        lenient().doNothing().when(capabilityGuard).ensureSupported(any(), anyString(), anyString(), any());
+        lenient().when(encryptionService.encrypt(anyString())).thenReturn("encrypted-password");
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContextHolder.clear();
+    }
+
+    @Nested
+    @DisplayName("인스턴스 생성 테스트")
+    class CreateRdbmsTest {
+
+        @Test
+        @DisplayName("인스턴스 생성 성공 시 CloudResource가 DB에 저장된다")
+        void createRdbms_Success_SavesCloudResource() {
+            // Given
+            Map<String, String> tags = Map.of("Environment", "test");
+            RdbmsCreateRequest request = RdbmsCreateRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .region(REGION)
+                    .instanceName("test-instance")
+                    .engine("mysql")
+                    .engineVersion("8.0")
+                    .instanceSize("db.t3.micro")
+                    .allocatedStorage(20)
+                    .masterUsername("admin")
+                    .masterPassword("password123")
+                    .tags(tags)
+                    .build();
+
+            CloudResource mockCreatedInstance = CloudResource.builder()
+                    .resourceId(INSTANCE_ID)
+                    .resourceName("test-instance")
+                    .build();
+
+            when(managementPort.createRdbms(any())).thenReturn(mockCreatedInstance);
+            when(resourceHelper.registerResource(any(), any(), any())).thenReturn(mockCreatedInstance);
+
+            // When
+            CloudResource result = rdbmsUseCaseService.createRdbms(request);
+
+            // Then
+            assertThat(result).isNotNull();
+            
+            verify(resourceHelper).registerResource(
+                    eq(PROVIDER_TYPE),
+                    eq("RDS"),
+                    any(ResourceRegistrationRequest.class)
+            );
+        }
+
+        @Test
+        @DisplayName("DB 저장 실패 시 보상 트랜잭션이 실행되고 예외가 발생한다")
+        void createRdbms_DbSaveFails_CompensatingTransactionExecuted() {
+            // Given
+            RdbmsCreateRequest request = RdbmsCreateRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .region(REGION)
+                    .instanceName("test-instance")
+                    .engine("mysql")
+                    .instanceSize("db.t3.micro")
+                    .allocatedStorage(20)
+                    .masterUsername("admin")
+                    .masterPassword("password123")
+                    .build();
+
+            CloudResource mockCreatedInstance = CloudResource.builder()
+                    .resourceId(INSTANCE_ID)
+                    .resourceName("test-instance")
+                    .build();
+
+            when(managementPort.createRdbms(any())).thenReturn(mockCreatedInstance);
+            // DB 저장 실패
+            doThrow(new RuntimeException("DB 저장 실패")).when(resourceHelper)
+                    .registerResource(any(), any(), any());
+            doNothing().when(managementPort).deleteRdbms(any());
+
+            // When & Then
+            assertThatThrownBy(() -> rdbmsUseCaseService.createRdbms(request))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(exception -> {
+                        BusinessException be = (BusinessException) exception;
+                        assertThat(be.getErrorCode()).isEqualTo(CloudErrorCode.RESOURCE_CREATION_FAILED);
+                    });
+
+            // 보상 트랜잭션 실행 검증: CSP 인스턴스 삭제 호출됨
+            verify(managementPort).deleteRdbms(any());
+        }
+
+        @Test
+        @DisplayName("보상 트랜잭션도 실패하면 Ghost Resource 경고 로그가 출력된다")
+        void createRdbms_CompensationFails_GhostResourceWarningLogged() {
+            // Given
+            RdbmsCreateRequest request = RdbmsCreateRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .region(REGION)
+                    .instanceName("test-instance")
+                    .engine("mysql")
+                    .instanceSize("db.t3.micro")
+                    .allocatedStorage(20)
+                    .masterUsername("admin")
+                    .masterPassword("password123")
+                    .build();
+
+            CloudResource mockCreatedInstance = CloudResource.builder()
+                    .resourceId(INSTANCE_ID)
+                    .resourceName("test-instance")
+                    .build();
+
+            when(managementPort.createRdbms(any())).thenReturn(mockCreatedInstance);
+            // DB 저장 실패
+            doThrow(new RuntimeException("DB 저장 실패")).when(resourceHelper)
+                    .registerResource(any(), any(), any());
+            // 보상 트랜잭션(CSP 삭제)도 실패
+            doThrow(new RuntimeException("CSP 삭제 실패")).when(managementPort)
+                    .deleteRdbms(any());
+
+            // When & Then
+            assertThatThrownBy(() -> rdbmsUseCaseService.createRdbms(request))
+                    .isInstanceOf(BusinessException.class);
+
+            // 보상 트랜잭션 시도 검증
+            verify(managementPort).deleteRdbms(any());
+            // Ghost Resource 발생 - 실제로는 모니터링/배치로 처리 필요
+        }
+    }
+
+    @Nested
+    @DisplayName("인스턴스 삭제 테스트")
+    class DeleteRdbmsTest {
+
+        @Test
+        @DisplayName("인스턴스 삭제 시 소프트 삭제가 수행된다")
+        void deleteRdbms_Success_SoftDeletesResource() {
+            // Given
+            RdbmsDeleteRequest request = RdbmsDeleteRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .instanceId(INSTANCE_ID)
+                    .skipSnapshot(false)
+                    .build();
+
+            doNothing().when(managementPort).deleteRdbms(any());
+
+            // When
+            rdbmsUseCaseService.deleteRdbms(request);
+
+            // Then
+            verify(managementPort).deleteRdbms(any());
+            verify(resourceHelper).softDeleteResource(INSTANCE_ID);
+        }
+
+        @Test
+        @DisplayName("DB에 리소스가 없어도 CSP 삭제는 성공한다")
+        void deleteRdbms_ResourceNotInDb_CspDeletionSucceeds() {
+            // Given
+            RdbmsDeleteRequest request = RdbmsDeleteRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .instanceId(INSTANCE_ID)
+                    .skipSnapshot(true)
+                    .build();
+
+            doNothing().when(managementPort).deleteRdbms(any());
+            // Helper 내부에서 리소스가 없으면 로그만 출력하고 예외 발생 안함
+
+            // When
+            rdbmsUseCaseService.deleteRdbms(request);
+
+            // Then
+            verify(managementPort).deleteRdbms(any()); // CSP 작업 성공
+            verify(resourceHelper).softDeleteResource(INSTANCE_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("인스턴스 수정 테스트")
+    class UpdateRdbmsTest {
+
+        @Test
+        @DisplayName("인스턴스 수정 시 생명주기 상태가 DB에 업데이트된다")
+        void updateRdbms_Success_UpdatesLifecycleState() {
+            // Given
+            RdbmsUpdateRequest request = RdbmsUpdateRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .instanceId(INSTANCE_ID)
+                    .instanceSize("db.t3.small")
+                    .allocatedStorage(50)
+                    .build();
+
+            CloudResource mockUpdatedInstance = CloudResource.builder()
+                    .resourceId(INSTANCE_ID)
+                    .resourceName("test-instance")
+                    .lifecycleState(LifecycleState.RUNNING)
+                    .build();
+
+            when(managementPort.updateRdbms(any())).thenReturn(mockUpdatedInstance);
+
+            // When
+            CloudResource result = rdbmsUseCaseService.updateRdbms(request);
+
+            // Then
+            assertThat(result).isNotNull();
+            verify(managementPort).updateRdbms(any());
+            verify(resourceHelper).updateLifecycleState(INSTANCE_ID, LifecycleState.RUNNING);
+        }
+
+        @Test
+        @DisplayName("DB 업데이트 실패해도 CSP 수정은 완료된다")
+        void updateRdbms_DbUpdateFails_CspUpdateSucceeds() {
+            // Given
+            RdbmsUpdateRequest request = RdbmsUpdateRequest.builder()
+                    .providerType(PROVIDER_TYPE)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .instanceId(INSTANCE_ID)
+                    .instanceSize("db.t3.small")
+                    .build();
+
+            CloudResource mockUpdatedInstance = CloudResource.builder()
+                    .resourceId(INSTANCE_ID)
+                    .resourceName("test-instance")
+                    .lifecycleState(LifecycleState.RUNNING)
+                    .build();
+
+            when(managementPort.updateRdbms(any())).thenReturn(mockUpdatedInstance);
+            // DB 업데이트 실패
+            doThrow(new RuntimeException("DB 업데이트 실패")).when(resourceHelper)
+                    .updateLifecycleState(anyString(), any());
+
+            // When
+            CloudResource result = rdbmsUseCaseService.updateRdbms(request);
+
+            // Then
+            assertThat(result).isNotNull();
+            verify(managementPort).updateRdbms(any()); // CSP 수정은 성공
+            verify(resourceHelper).updateLifecycleState(anyString(), any()); // DB 업데이트 시도
+        }
+    }
+
+    @Nested
+    @DisplayName("생명주기 관리 테스트")
+    class LifecycleManagementTest {
+
+        @Test
+        @DisplayName("인스턴스 시작 시 생명주기 상태가 RUNNING으로 업데이트된다")
+        void startInstance_Success_UpdatesLifecycleStateToRunning() {
+            // Given
+            CloudResource mockInstance = CloudResource.builder()
+                    .resourceId(INSTANCE_ID)
+                    .resourceName("test-instance")
+                    .build();
+
+            when(discoveryPort.getRdbmsInstance(INSTANCE_ID, mockSession))
+                    .thenReturn(java.util.Optional.of(mockInstance));
+            doNothing().when(lifecyclePort).start(any(), eq(mockSession));
+
+            // When
+            rdbmsUseCaseService.startInstance(PROVIDER_TYPE, ACCOUNT_SCOPE, INSTANCE_ID);
+
+            // Then
+            verify(lifecyclePort).start(any(), eq(mockSession));
+            verify(resourceHelper).updateLifecycleState(INSTANCE_ID, LifecycleState.RUNNING);
+        }
+
+        @Test
+        @DisplayName("인스턴스 중지 시 생명주기 상태가 STOPPED로 업데이트된다")
+        void stopInstance_Success_UpdatesLifecycleStateToStopped() {
+            // Given
+            CloudResource mockInstance = CloudResource.builder()
+                    .resourceId(INSTANCE_ID)
+                    .resourceName("test-instance")
+                    .build();
+
+            when(discoveryPort.getRdbmsInstance(INSTANCE_ID, mockSession))
+                    .thenReturn(java.util.Optional.of(mockInstance));
+            doNothing().when(lifecyclePort).stop(any(), eq(mockSession));
+
+            // When
+            rdbmsUseCaseService.stopInstance(PROVIDER_TYPE, ACCOUNT_SCOPE, INSTANCE_ID);
+
+            // Then
+            verify(lifecyclePort).stop(any(), eq(mockSession));
+            verify(resourceHelper).updateLifecycleState(INSTANCE_ID, LifecycleState.STOPPED);
+        }
+
+        @Test
+        @DisplayName("인스턴스 재시작 시 생명주기 상태가 RUNNING으로 유지된다")
+        void rebootInstance_Success_MaintainsRunningState() {
+            // Given
+            doNothing().when(lifecyclePort).rebootInstance(INSTANCE_ID, mockSession);
+
+            // When
+            rdbmsUseCaseService.rebootInstance(PROVIDER_TYPE, ACCOUNT_SCOPE, INSTANCE_ID);
+
+            // Then
+            verify(lifecyclePort).rebootInstance(INSTANCE_ID, mockSession);
+            verify(resourceHelper).updateLifecycleState(INSTANCE_ID, LifecycleState.RUNNING);
+        }
+    }
+}

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/rdbms/RdbmsUseCaseServiceEncryptionTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/rdbms/RdbmsUseCaseServiceEncryptionTest.java
@@ -1,0 +1,395 @@
+package com.agenticcp.core.domain.cloud.service.rdbms;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.common.crypto.AesGcmEncryptionService;
+import com.agenticcp.core.common.crypto.EncryptionService;
+import com.agenticcp.core.common.exception.BusinessException;
+import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
+import com.agenticcp.core.domain.cloud.dto.RdbmsCreateRequest;
+import com.agenticcp.core.domain.cloud.dto.RdbmsUpdateRequest;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.exception.CloudErrorCode;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsCreateCommand;
+import com.agenticcp.core.domain.cloud.port.model.rdbms.RdbmsUpdateCommand;
+import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
+import com.agenticcp.core.domain.cloud.port.outbound.rdbms.RdbmsManagementPort;
+import com.agenticcp.core.domain.cloud.service.helper.CloudResourceManagementHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.SecureRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * RdbmsUseCaseService 암호화/복호화 로직 단위 테스트
+ * 
+ * adminPassword 암호화 로직을 검증합니다.
+ * 
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RdbmsUseCaseService 암호화/복호화 테스트")
+class RdbmsUseCaseServiceEncryptionTest {
+
+    @Mock
+    private RdbmsPortRouter portRouter;
+
+    @Mock
+    private CapabilityGuard capabilityGuard;
+
+    @Mock
+    private AccountCredentialManagementPort credentialPort;
+
+    @Mock
+    private CloudResourceManagementHelper resourceHelper;
+
+    @Mock
+    private RdbmsManagementPort managementPort;
+
+    private EncryptionService encryptionService;
+    private RdbmsUseCaseService rdbmsUseCaseService;
+
+    private String tenantKey;
+    private CloudSessionCredential session;
+    private CloudResource mockResource;
+
+    @BeforeEach
+    void setUp() {
+        tenantKey = "test-tenant";
+        TenantContextHolder.setTenantKey(tenantKey);
+
+        // 실제 EncryptionService 사용 (AES-GCM-256)
+        byte[] key = generateKey(32);
+        encryptionService = new AesGcmEncryptionService(key);
+
+        // RdbmsUseCaseService 인스턴스 생성 (EncryptionService 주입)
+        rdbmsUseCaseService = new RdbmsUseCaseService(
+            portRouter,
+            capabilityGuard,
+            credentialPort,
+            resourceHelper,
+            encryptionService
+        );
+
+        // Mock 설정
+        session = mock(CloudSessionCredential.class);
+        mockResource = mock(CloudResource.class);
+        
+        // lenient()를 사용하여 일부 테스트에서 사용되지 않을 수 있는 stubbing 허용
+        lenient().when(credentialPort.getSession(eq(tenantKey), anyString(), any(CloudProvider.ProviderType.class)))
+            .thenReturn(session);
+        lenient().when(portRouter.management(any(CloudProvider.ProviderType.class)))
+            .thenReturn(managementPort);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContextHolder.clear();
+    }
+
+    /**
+     * AES 키 생성 헬퍼 메서드
+     */
+    private byte[] generateKey(int size) {
+        byte[] key = new byte[size];
+        new SecureRandom().nextBytes(key);
+        return key;
+    }
+
+    @Nested
+    @DisplayName("adminPassword 암호화 테스트 - 생성 시")
+    class CreateRdbmsEncryptionTest {
+
+        @Test
+        @DisplayName("adminPassword가 정상적으로 암호화되어 Command에 전달됨")
+        void shouldEncryptPasswordWhenCreatingRdbms() {
+            // given
+            String plainPassword = "MySecurePassword123!";
+            RdbmsCreateRequest request = RdbmsCreateRequest.builder()
+                .providerType(CloudProvider.ProviderType.AWS)
+                .accountScope("123456789012")
+                .region("us-east-1")
+                .instanceName("test-db")
+                .engine("mysql")
+                .instanceSize("db.t3.micro")
+                .allocatedStorage(20)
+                .masterUsername("admin")
+                .masterPassword(plainPassword)
+                .build();
+
+            doNothing().when(capabilityGuard).ensureSupported(any(), any(), any(), any());
+            given(managementPort.createRdbms(any(RdbmsCreateCommand.class)))
+                .willReturn(mockResource);
+
+            // when
+            rdbmsUseCaseService.createRdbms(request);
+
+            // then
+            verify(managementPort).createRdbms(argThat(command -> {
+                // Command에 전달된 adminPassword가 암호화되었는지 확인
+                String encryptedPassword = command.adminPassword();
+                assertThat(encryptedPassword).isNotNull();
+                assertThat(encryptedPassword).isNotEqualTo(plainPassword);
+                
+                // 암호화된 값이 Base64 형식인지 확인
+                assertThat(encryptedPassword).doesNotContain(plainPassword);
+                
+                // 복호화하여 원본과 일치하는지 확인
+                String decrypted = encryptionService.decrypt(encryptedPassword);
+                assertThat(decrypted).isEqualTo(plainPassword);
+                
+                return true;
+            }));
+        }
+
+        @Test
+        @DisplayName("암호화 실패 시 ENCRYPTION_FAILED 예외 발생")
+        void shouldThrowExceptionWhenEncryptionFails() {
+            // given
+            EncryptionService failingEncryptionService = mock(EncryptionService.class);
+            RdbmsUseCaseService serviceWithFailingEncryption = new RdbmsUseCaseService(
+                portRouter,
+                capabilityGuard,
+                credentialPort,
+                resourceHelper,
+                failingEncryptionService
+            );
+
+            RdbmsCreateRequest request = RdbmsCreateRequest.builder()
+                .providerType(CloudProvider.ProviderType.AWS)
+                .accountScope("123456789012")
+                .region("us-east-1")
+                .instanceName("test-db")
+                .engine("mysql")
+                .instanceSize("db.t3.micro")
+                .allocatedStorage(20)
+                .masterUsername("admin")
+                .masterPassword("MySecurePassword123!")
+                .build();
+
+            doNothing().when(capabilityGuard).ensureSupported(any(), any(), any(), any());
+            given(failingEncryptionService.encrypt(anyString()))
+                .willThrow(new RuntimeException("암호화 실패"));
+
+            // when & then
+            assertThatThrownBy(() -> serviceWithFailingEncryption.createRdbms(request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    BusinessException be = (BusinessException) exception;
+                    assertThat(be.getErrorCode()).isEqualTo(CloudErrorCode.ENCRYPTION_FAILED);
+                    assertThat(be.getMessage()).contains("관리자 패스워드 암호화에 실패했습니다");
+                });
+        }
+    }
+
+    @Nested
+    @DisplayName("adminPassword 암호화 테스트 - 수정 시")
+    class UpdateRdbmsEncryptionTest {
+
+        @Test
+        @DisplayName("adminPassword가 제공되면 암호화되어 Command에 전달됨")
+        void shouldEncryptPasswordWhenUpdatingRdbmsWithPassword() {
+            // given
+            String plainPassword = "NewSecurePassword456!";
+            RdbmsUpdateRequest request = RdbmsUpdateRequest.builder()
+                .providerType(CloudProvider.ProviderType.AWS)
+                .accountScope("123456789012")
+                .instanceId("db-instance-123")
+                .masterPassword(plainPassword)
+                .build();
+
+            doNothing().when(capabilityGuard).ensureSupported(any(), any(), any(), any());
+            given(managementPort.updateRdbms(any(RdbmsUpdateCommand.class)))
+                .willReturn(mockResource);
+
+            // when
+            rdbmsUseCaseService.updateRdbms(request);
+
+            // then
+            verify(managementPort).updateRdbms(argThat(command -> {
+                // Command에 전달된 adminPassword가 암호화되었는지 확인
+                String encryptedPassword = command.adminPassword();
+                assertThat(encryptedPassword).isNotNull();
+                assertThat(encryptedPassword).isNotEqualTo(plainPassword);
+                
+                // 복호화하여 원본과 일치하는지 확인
+                String decrypted = encryptionService.decrypt(encryptedPassword);
+                assertThat(decrypted).isEqualTo(plainPassword);
+                
+                return true;
+            }));
+        }
+
+        @Test
+        @DisplayName("adminPassword가 null이면 Command에 null이 전달됨")
+        void shouldPassNullWhenPasswordNotProvided() {
+            // given
+            RdbmsUpdateRequest request = RdbmsUpdateRequest.builder()
+                .providerType(CloudProvider.ProviderType.AWS)
+                .accountScope("123456789012")
+                .instanceId("db-instance-123")
+                .instanceSize("db.t3.small")
+                .build();
+
+            doNothing().when(capabilityGuard).ensureSupported(any(), any(), any(), any());
+            given(managementPort.updateRdbms(any(RdbmsUpdateCommand.class)))
+                .willReturn(mockResource);
+
+            // when
+            rdbmsUseCaseService.updateRdbms(request);
+
+            // then
+            verify(managementPort).updateRdbms(argThat(command -> {
+                // Command에 전달된 adminPassword가 null인지 확인
+                assertThat(command.adminPassword()).isNull();
+                return true;
+            }));
+        }
+
+        @Test
+        @DisplayName("암호화 실패 시 ENCRYPTION_FAILED 예외 발생")
+        void shouldThrowExceptionWhenEncryptionFails() {
+            // given
+            EncryptionService failingEncryptionService = mock(EncryptionService.class);
+            RdbmsUseCaseService serviceWithFailingEncryption = new RdbmsUseCaseService(
+                portRouter,
+                capabilityGuard,
+                credentialPort,
+                resourceHelper,
+                failingEncryptionService
+            );
+
+            RdbmsUpdateRequest request = RdbmsUpdateRequest.builder()
+                .providerType(CloudProvider.ProviderType.AWS)
+                .accountScope("123456789012")
+                .instanceId("db-instance-123")
+                .masterPassword("NewSecurePassword456!")
+                .build();
+
+            doNothing().when(capabilityGuard).ensureSupported(any(), any(), any(), any());
+            given(failingEncryptionService.encrypt(anyString()))
+                .willThrow(new RuntimeException("암호화 실패"));
+
+            // when & then
+            assertThatThrownBy(() -> serviceWithFailingEncryption.updateRdbms(request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    BusinessException be = (BusinessException) exception;
+                    assertThat(be.getErrorCode()).isEqualTo(CloudErrorCode.ENCRYPTION_FAILED);
+                    assertThat(be.getMessage()).contains("관리자 패스워드 암호화에 실패했습니다");
+                });
+        }
+    }
+
+    @Nested
+    @DisplayName("암호화 라운드트립 테스트")
+    class EncryptionRoundTripTest {
+
+        @Test
+        @DisplayName("암호화 후 복호화하면 원본과 일치함")
+        void shouldDecryptToOriginalPassword() {
+            // given
+            String plainPassword = "TestPassword123!@#";
+            RdbmsCreateRequest request = RdbmsCreateRequest.builder()
+                .providerType(CloudProvider.ProviderType.AWS)
+                .accountScope("123456789012")
+                .region("us-east-1")
+                .instanceName("test-db")
+                .engine("mysql")
+                .instanceSize("db.t3.micro")
+                .allocatedStorage(20)
+                .masterUsername("admin")
+                .masterPassword(plainPassword)
+                .build();
+
+            doNothing().when(capabilityGuard).ensureSupported(any(), any(), any(), any());
+            given(managementPort.createRdbms(any(RdbmsCreateCommand.class)))
+                .willReturn(mockResource);
+
+            // when
+            rdbmsUseCaseService.createRdbms(request);
+
+            // then
+            verify(managementPort).createRdbms(argThat(command -> {
+                String encryptedPassword = command.adminPassword();
+                
+                // 암호화된 값이 원본과 다름
+                assertThat(encryptedPassword).isNotEqualTo(plainPassword);
+                
+                // 복호화하면 원본과 일치
+                String decrypted = encryptionService.decrypt(encryptedPassword);
+                assertThat(decrypted).isEqualTo(plainPassword);
+                
+                return true;
+            }));
+        }
+
+        @Test
+        @DisplayName("다양한 특수문자를 포함한 패스워드도 정상 암호화/복호화됨")
+        void shouldHandleSpecialCharacters() {
+            // given
+            String[] testPasswords = {
+                "Password123!@#$%^&*()",
+                "한글패스워드123!",
+                "P@ssw0rd with spaces",
+                "VeryLongPassword1234567890!@#$%^&*()_+-=[]{}|;:,.<>?",
+                "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+            };
+
+            ArgumentCaptor<RdbmsCreateCommand> commandCaptor = 
+                ArgumentCaptor.forClass(RdbmsCreateCommand.class);
+
+            for (String plainPassword : testPasswords) {
+                RdbmsCreateRequest request = RdbmsCreateRequest.builder()
+                    .providerType(CloudProvider.ProviderType.AWS)
+                    .accountScope("123456789012")
+                    .region("us-east-1")
+                    .instanceName("test-db")
+                    .engine("mysql")
+                    .instanceSize("db.t3.micro")
+                    .allocatedStorage(20)
+                    .masterUsername("admin")
+                    .masterPassword(plainPassword)
+                    .build();
+
+                doNothing().when(capabilityGuard).ensureSupported(any(), any(), any(), any());
+                given(managementPort.createRdbms(any(RdbmsCreateCommand.class)))
+                    .willReturn(mockResource);
+
+                // when
+                rdbmsUseCaseService.createRdbms(request);
+
+                // then - 각 호출마다 검증
+                verify(managementPort).createRdbms(commandCaptor.capture());
+                RdbmsCreateCommand capturedCommand = commandCaptor.getValue();
+                
+                String encryptedPassword = capturedCommand.adminPassword();
+                assertThat(encryptedPassword).isNotNull();
+                assertThat(encryptedPassword).isNotEqualTo(plainPassword);
+                
+                // 복호화하여 원본과 일치하는지 확인
+                String decrypted = encryptionService.decrypt(encryptedPassword);
+                assertThat(decrypted).isEqualTo(plainPassword);
+                
+                // 다음 반복을 위해 reset
+                reset(managementPort);
+            }
+        }
+    }
+}

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/rdbms/RdbmsUseCaseServiceEncryptionTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/rdbms/RdbmsUseCaseServiceEncryptionTest.java
@@ -96,6 +96,10 @@ class RdbmsUseCaseServiceEncryptionTest {
             .thenReturn(session);
         lenient().when(portRouter.management(any(CloudProvider.ProviderType.class)))
             .thenReturn(managementPort);
+        lenient().when(mockResource.getResourceId())
+            .thenReturn("test-instance-123");
+        lenient().when(resourceHelper.registerResource(any(), any(), any()))
+            .thenReturn(mockResource);
     }
 
     @AfterEach

--- a/src/test/java/com/agenticcp/core/domain/cloud/service/rdbms/RdbmsUseCaseServiceTest.java
+++ b/src/test/java/com/agenticcp/core/domain/cloud/service/rdbms/RdbmsUseCaseServiceTest.java
@@ -1,0 +1,623 @@
+package com.agenticcp.core.domain.cloud.service.rdbms;
+
+import com.agenticcp.core.common.context.TenantContextHolder;
+import com.agenticcp.core.common.crypto.EncryptionService;
+import com.agenticcp.core.domain.cloud.adapter.outbound.aws.account.AwsSessionCredential;
+import com.agenticcp.core.domain.cloud.capability.CapabilityGuard;
+import com.agenticcp.core.domain.cloud.dto.RdbmsCreateRequest;
+import com.agenticcp.core.domain.cloud.dto.RdbmsDeleteRequest;
+import com.agenticcp.core.domain.cloud.dto.RdbmsQueryRequest;
+import com.agenticcp.core.domain.cloud.dto.RdbmsUpdateRequest;
+import com.agenticcp.core.domain.cloud.entity.CloudProvider;
+import com.agenticcp.core.domain.cloud.entity.CloudResource;
+import com.agenticcp.core.domain.cloud.entity.CloudResource.LifecycleState;
+import com.agenticcp.core.domain.cloud.port.model.ResourceIdentity;
+import com.agenticcp.core.domain.cloud.port.model.account.CloudSessionCredential;
+import com.agenticcp.core.domain.cloud.port.outbound.account.AccountCredentialManagementPort;
+import com.agenticcp.core.domain.cloud.port.outbound.rdbms.RdbmsDiscoveryPort;
+import com.agenticcp.core.domain.cloud.port.outbound.rdbms.RdbmsLifecyclePort;
+import com.agenticcp.core.domain.cloud.port.outbound.rdbms.RdbmsManagementPort;
+import com.agenticcp.core.domain.cloud.service.helper.CloudResourceManagementHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * RdbmsUseCaseService 단위 테스트
+ *
+ * @author AgenticCP Team
+ * @version 1.0.0
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RdbmsUseCaseService 테스트")
+class RdbmsUseCaseServiceTest {
+
+    @Mock
+    private RdbmsPortRouter portRouter;
+
+    @Mock
+    private CapabilityGuard capabilityGuard;
+
+    @Mock
+    private AccountCredentialManagementPort credentialPort;
+
+    @Mock
+    private CloudResourceManagementHelper resourceHelper;
+
+    @Mock
+    private EncryptionService encryptionService;
+
+    @Mock
+    private RdbmsManagementPort managementPort;
+
+    @Mock
+    private RdbmsDiscoveryPort discoveryPort;
+
+    @Mock
+    private RdbmsLifecyclePort lifecyclePort;
+
+    @InjectMocks
+    private RdbmsUseCaseService rdbmsUseCaseService;
+
+    private static final String TENANT_KEY = "test-tenant";
+    private static final CloudProvider.ProviderType AWS = CloudProvider.ProviderType.AWS;
+    private static final String ACCOUNT_SCOPE = "123456789012";
+    private static final String INSTANCE_ID = "test-instance-123";
+    private static final String REGION = "us-east-1";
+
+    private CloudSessionCredential mockSession;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(portRouter.management(AWS)).thenReturn(managementPort);
+        lenient().when(portRouter.discovery(AWS)).thenReturn(discoveryPort);
+        lenient().when(portRouter.lifecycle(AWS)).thenReturn(lifecyclePort);
+
+        mockSession = AwsSessionCredential.builder()
+                .accessKeyId("AKIA_TEST")
+                .secretAccessKey("secret")
+                .sessionToken("token")
+                .region(REGION)
+                .expiresAt(LocalDateTime.now().plusHours(1))
+                .build();
+    }
+
+    @Nested
+    @DisplayName("RDBMS 인스턴스 목록 조회 테스트")
+    class ListRdbmsInstancesTest {
+
+        private RdbmsQueryRequest query;
+        private Page<CloudResource> expectedPage;
+
+        @BeforeEach
+        void setUp() {
+            query = RdbmsQueryRequest.builder()
+                    .providerType(AWS)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .page(0)
+                    .size(10)
+                    .instanceName("test")
+                    .engine("mysql")
+                    .build();
+
+            CloudResource instance1 = CloudResource.builder()
+                    .resourceId("instance-1")
+                    .resourceName("test-instance-1")
+                    .build();
+
+            CloudResource instance2 = CloudResource.builder()
+                    .resourceId("instance-2")
+                    .resourceName("test-instance-2")
+                    .build();
+
+            expectedPage = new PageImpl<>(List.of(instance1, instance2), PageRequest.of(0, 10), 2);
+        }
+
+        @Test
+        @DisplayName("정상적인 RDBMS 인스턴스 목록 조회")
+        void listRdbmsInstances_Success() {
+            try (MockedStatic<TenantContextHolder> mockedStatic = mockStatic(TenantContextHolder.class)) {
+                // Given
+                mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
+                when(credentialPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
+                when(discoveryPort.listRdbmsInstances(any(), eq(mockSession))).thenReturn(expectedPage);
+
+                // When
+                Page<CloudResource> result = rdbmsUseCaseService.listRdbmsInstances(AWS, ACCOUNT_SCOPE, query);
+
+                // Then
+                assertThat(result).isNotNull();
+                assertThat(result.getTotalElements()).isEqualTo(2);
+                assertThat(result.getContent()).hasSize(2);
+                assertThat(result.getContent().get(0).getResourceName()).isEqualTo("test-instance-1");
+
+                verify(credentialPort).getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS);
+                verify(discoveryPort).listRdbmsInstances(any(), eq(mockSession));
+            }
+        }
+
+        @Test
+        @DisplayName("빈 목록 조회")
+        void listRdbmsInstances_EmptyResult() {
+            try (MockedStatic<TenantContextHolder> mockedStatic = mockStatic(TenantContextHolder.class)) {
+                // Given
+                mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
+                when(credentialPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
+                Page<CloudResource> emptyPage = new PageImpl<>(List.of(), PageRequest.of(0, 10), 0);
+                when(discoveryPort.listRdbmsInstances(any(), eq(mockSession))).thenReturn(emptyPage);
+
+                // When
+                Page<CloudResource> result = rdbmsUseCaseService.listRdbmsInstances(AWS, ACCOUNT_SCOPE, query);
+
+                // Then
+                assertThat(result).isNotNull();
+                assertThat(result.getTotalElements()).isEqualTo(0);
+                assertThat(result.getContent()).isEmpty();
+
+                verify(discoveryPort).listRdbmsInstances(any(), eq(mockSession));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("RDBMS 인스턴스 조회 테스트")
+    class GetRdbmsInstanceTest {
+
+        private CloudResource expectedInstance;
+
+        @BeforeEach
+        void setUp() {
+            expectedInstance = CloudResource.builder()
+                    .resourceId(INSTANCE_ID)
+                    .resourceName("test-instance")
+                    .displayName("Test RDBMS Instance")
+                    .build();
+        }
+
+        @Test
+        @DisplayName("정상적인 RDBMS 인스턴스 조회")
+        void getRdbmsInstance_Success() {
+            try (MockedStatic<TenantContextHolder> mockedStatic = mockStatic(TenantContextHolder.class)) {
+                // Given
+                mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
+                when(credentialPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
+                when(discoveryPort.getRdbmsInstance(INSTANCE_ID, mockSession))
+                        .thenReturn(Optional.of(expectedInstance));
+
+                // When
+                Optional<CloudResource> result = rdbmsUseCaseService.getRdbmsInstance(AWS, ACCOUNT_SCOPE, INSTANCE_ID);
+
+                // Then
+                assertThat(result).isPresent();
+                assertThat(result.get().getResourceId()).isEqualTo(INSTANCE_ID);
+                assertThat(result.get().getResourceName()).isEqualTo("test-instance");
+
+                verify(credentialPort).getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS);
+                verify(discoveryPort).getRdbmsInstance(INSTANCE_ID, mockSession);
+            }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 인스턴스 조회 시 Optional.empty() 반환")
+        void getRdbmsInstance_NotFound_ReturnsEmpty() {
+            try (MockedStatic<TenantContextHolder> mockedStatic = mockStatic(TenantContextHolder.class)) {
+                // Given
+                mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
+                when(credentialPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
+                when(discoveryPort.getRdbmsInstance(INSTANCE_ID, mockSession)).thenReturn(Optional.empty());
+
+                // When
+                Optional<CloudResource> result = rdbmsUseCaseService.getRdbmsInstance(AWS, ACCOUNT_SCOPE, INSTANCE_ID);
+
+                // Then
+                assertThat(result).isEmpty();
+
+                verify(discoveryPort).getRdbmsInstance(INSTANCE_ID, mockSession);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("RDBMS 인스턴스 생성 테스트")
+    class CreateRdbmsTest {
+
+        private RdbmsCreateRequest request;
+        private CloudResource expectedInstance;
+
+        @BeforeEach
+        void setUp() {
+            Map<String, String> tags = new HashMap<>();
+            tags.put("Environment", "test");
+            tags.put("Project", "agenticcp");
+
+            request = RdbmsCreateRequest.builder()
+                    .providerType(AWS)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .region(REGION)
+                    .instanceName("test-instance")
+                    .engine("mysql")
+                    .engineVersion("8.0")
+                    .instanceSize("db.t3.micro")
+                    .allocatedStorage(20)
+                    .masterUsername("admin")
+                    .masterPassword("password123")
+                    .dbName("testdb")
+                    .tags(tags)
+                    .build();
+
+            expectedInstance = CloudResource.builder()
+                    .resourceId(INSTANCE_ID)
+                    .resourceName("test-instance")
+                    .displayName("Test RDBMS Instance")
+                    .build();
+        }
+
+        @Test
+        @DisplayName("정상적인 RDBMS 인스턴스 생성")
+        void createRdbms_Success() {
+            try (MockedStatic<TenantContextHolder> mockedStatic = mockStatic(TenantContextHolder.class)) {
+                // Given
+                mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
+                when(credentialPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
+                when(encryptionService.encrypt("password123")).thenReturn("encrypted-password");
+                when(managementPort.createRdbms(any())).thenReturn(expectedInstance);
+                when(resourceHelper.registerResource(any(), any(), any())).thenReturn(expectedInstance);
+
+                // When
+                CloudResource result = rdbmsUseCaseService.createRdbms(request);
+
+                // Then
+                assertThat(result).isNotNull();
+                assertThat(result.getResourceId()).isEqualTo(INSTANCE_ID);
+                assertThat(result.getResourceName()).isEqualTo("test-instance");
+
+                verify(capabilityGuard).ensureSupported(AWS, "RDS", "DATABASE", CapabilityGuard.Operation.CREATE);
+                verify(credentialPort).getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS);
+                verify(encryptionService).encrypt("password123");
+                verify(managementPort).createRdbms(any());
+                verify(resourceHelper).registerResource(eq(AWS), eq("RDS"), any());
+            }
+        }
+
+        @Test
+        @DisplayName("Capability 검증 실패 시 예외 발생")
+        void createRdbms_CapabilityCheckFailed_ThrowsException() {
+            // Given
+            doThrow(new RuntimeException("Capability not supported"))
+                    .when(capabilityGuard).ensureSupported(any(), any(), any(), any());
+
+            // When & Then
+            assertThatThrownBy(() -> rdbmsUseCaseService.createRdbms(request))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("Capability not supported");
+
+            verify(capabilityGuard).ensureSupported(AWS, "RDS", "DATABASE", CapabilityGuard.Operation.CREATE);
+            verify(credentialPort, never()).getSession(any(), any(), any());
+            verify(managementPort, never()).createRdbms(any());
+        }
+
+        @Test
+        @DisplayName("암호화 실패 시 예외 발생")
+        void createRdbms_EncryptionFailed_ThrowsException() {
+            try (MockedStatic<TenantContextHolder> mockedStatic = mockStatic(TenantContextHolder.class)) {
+                // Given
+                mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
+                when(credentialPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
+                when(encryptionService.encrypt("password123"))
+                        .thenThrow(new RuntimeException("Encryption failed"));
+
+                // When & Then
+                assertThatThrownBy(() -> rdbmsUseCaseService.createRdbms(request))
+                        .isInstanceOf(RuntimeException.class)
+                        .hasMessageContaining("Encryption failed");
+
+                verify(encryptionService).encrypt("password123");
+                verify(managementPort, never()).createRdbms(any());
+            }
+        }
+
+        @Test
+        @DisplayName("DB 저장 실패 시 보상 트랜잭션 실행")
+        void createRdbms_DbSaveFailed_ExecutesCompensatingTransaction() {
+            try (MockedStatic<TenantContextHolder> mockedStatic = mockStatic(TenantContextHolder.class)) {
+                // Given
+                mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
+                when(credentialPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
+                when(encryptionService.encrypt("password123")).thenReturn("encrypted-password");
+                when(managementPort.createRdbms(any())).thenReturn(expectedInstance);
+                when(resourceHelper.registerResource(any(), any(), any()))
+                        .thenThrow(new RuntimeException("DB save failed"));
+                doNothing().when(managementPort).deleteRdbms(any());
+
+                // When & Then
+                assertThatThrownBy(() -> rdbmsUseCaseService.createRdbms(request))
+                        .isInstanceOf(RuntimeException.class)
+                        .hasMessageContaining("RDBMS 인스턴스 생성 후 DB 저장 실패");
+
+                verify(managementPort).createRdbms(any());
+                verify(resourceHelper).registerResource(any(), any(), any());
+                verify(managementPort).deleteRdbms(any()); // 보상 트랜잭션 확인
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("RDBMS 인스턴스 수정 테스트")
+    class UpdateRdbmsTest {
+
+        private RdbmsUpdateRequest request;
+        private CloudResource expectedInstance;
+
+        @BeforeEach
+        void setUp() {
+            Map<String, String> tags = new HashMap<>();
+            tags.put("Environment", "production");
+            tags.put("Updated", "true");
+
+            request = RdbmsUpdateRequest.builder()
+                    .providerType(AWS)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .instanceId(INSTANCE_ID)
+                    .instanceSize("db.t3.small")
+                    .allocatedStorage(50)
+                    .tagsToAdd(tags)
+                    .build();
+
+            expectedInstance = CloudResource.builder()
+                    .resourceId(INSTANCE_ID)
+                    .resourceName("test-instance")
+                    .displayName("Updated Test RDBMS Instance")
+                    .build();
+        }
+
+        @Test
+        @DisplayName("정상적인 RDBMS 인스턴스 수정")
+        void updateRdbms_Success() {
+            try (MockedStatic<TenantContextHolder> mockedStatic = mockStatic(TenantContextHolder.class)) {
+                // Given
+                mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
+                when(credentialPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
+                when(managementPort.updateRdbms(any())).thenReturn(expectedInstance);
+
+                // When
+                CloudResource result = rdbmsUseCaseService.updateRdbms(request);
+
+                // Then
+                assertThat(result).isNotNull();
+                assertThat(result.getResourceId()).isEqualTo(INSTANCE_ID);
+                assertThat(result.getDisplayName()).isEqualTo("Updated Test RDBMS Instance");
+
+                verify(capabilityGuard).ensureSupported(AWS, "RDS", "DATABASE", CapabilityGuard.Operation.UPDATE);
+                verify(credentialPort).getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS);
+                verify(managementPort).updateRdbms(any());
+            }
+        }
+
+        @Test
+        @DisplayName("패스워드 변경 포함 수정")
+        void updateRdbms_WithPasswordChange_Success() {
+            try (MockedStatic<TenantContextHolder> mockedStatic = mockStatic(TenantContextHolder.class)) {
+                // Given
+                request.setMasterPassword("newpassword123");
+                mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
+                when(credentialPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
+                when(encryptionService.encrypt("newpassword123")).thenReturn("encrypted-new-password");
+                when(managementPort.updateRdbms(any())).thenReturn(expectedInstance);
+
+                // When
+                CloudResource result = rdbmsUseCaseService.updateRdbms(request);
+
+                // Then
+                assertThat(result).isNotNull();
+                verify(encryptionService).encrypt("newpassword123");
+                verify(managementPort).updateRdbms(any());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("RDBMS 인스턴스 삭제 테스트")
+    class DeleteRdbmsTest {
+
+        private RdbmsDeleteRequest request;
+
+        @BeforeEach
+        void setUp() {
+            request = RdbmsDeleteRequest.builder()
+                    .providerType(AWS)
+                    .accountScope(ACCOUNT_SCOPE)
+                    .instanceId(INSTANCE_ID)
+                    .skipSnapshot(false)
+                    .snapshotName("final-snapshot")
+                    .deleteAutomatedBackups(false)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("정상적인 RDBMS 인스턴스 삭제")
+        void deleteRdbms_Success() {
+            try (MockedStatic<TenantContextHolder> mockedStatic = mockStatic(TenantContextHolder.class)) {
+                // Given
+                mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
+                when(credentialPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
+                doNothing().when(managementPort).deleteRdbms(any());
+                doNothing().when(resourceHelper).softDeleteResource(INSTANCE_ID);
+
+                // When
+                rdbmsUseCaseService.deleteRdbms(request);
+
+                // Then
+                verify(capabilityGuard).ensureSupported(AWS, "RDS", "DATABASE", CapabilityGuard.Operation.TERMINATE);
+                verify(credentialPort).getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS);
+                verify(managementPort).deleteRdbms(any());
+                verify(resourceHelper).softDeleteResource(INSTANCE_ID);
+            }
+        }
+
+        @Test
+        @DisplayName("Capability 검증 실패 시 예외 발생")
+        void deleteRdbms_CapabilityCheckFailed_ThrowsException() {
+            // Given
+            doThrow(new RuntimeException("Delete capability not supported"))
+                    .when(capabilityGuard).ensureSupported(any(), any(), any(), any());
+
+            // When & Then
+            assertThatThrownBy(() -> rdbmsUseCaseService.deleteRdbms(request))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("Delete capability not supported");
+
+            verify(capabilityGuard).ensureSupported(AWS, "RDS", "DATABASE", CapabilityGuard.Operation.TERMINATE);
+            verify(credentialPort, never()).getSession(any(), any(), any());
+            verify(managementPort, never()).deleteRdbms(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("RDBMS 인스턴스 시작 테스트")
+    class StartInstanceTest {
+
+        private CloudResource mockInstance;
+
+        @BeforeEach
+        void setUp() {
+            mockInstance = CloudResource.builder()
+                    .resourceId(INSTANCE_ID)
+                    .resourceName("test-instance")
+                    .build();
+        }
+
+        @Test
+        @DisplayName("정상적인 RDBMS 인스턴스 시작")
+        void startInstance_Success() {
+            try (MockedStatic<TenantContextHolder> mockedStatic = mockStatic(TenantContextHolder.class)) {
+                // Given
+                mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
+                when(credentialPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
+                when(discoveryPort.getRdbmsInstance(INSTANCE_ID, mockSession))
+                        .thenReturn(Optional.of(mockInstance));
+                doNothing().when(lifecyclePort).start(any(ResourceIdentity.class), eq(mockSession));
+                doNothing().when(resourceHelper).updateLifecycleState(INSTANCE_ID, LifecycleState.RUNNING);
+
+                // When
+                rdbmsUseCaseService.startInstance(AWS, ACCOUNT_SCOPE, INSTANCE_ID);
+
+                // Then
+                verify(capabilityGuard).ensureSupported(AWS, "RDS", "DATABASE", CapabilityGuard.Operation.START);
+                verify(credentialPort).getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS);
+                verify(discoveryPort).getRdbmsInstance(INSTANCE_ID, mockSession);
+                verify(lifecyclePort).start(any(ResourceIdentity.class), eq(mockSession));
+                verify(resourceHelper).updateLifecycleState(INSTANCE_ID, LifecycleState.RUNNING);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("RDBMS 인스턴스 중지 테스트")
+    class StopInstanceTest {
+
+        private CloudResource mockInstance;
+
+        @BeforeEach
+        void setUp() {
+            mockInstance = CloudResource.builder()
+                    .resourceId(INSTANCE_ID)
+                    .resourceName("test-instance")
+                    .build();
+        }
+
+        @Test
+        @DisplayName("정상적인 RDBMS 인스턴스 중지")
+        void stopInstance_Success() {
+            try (MockedStatic<TenantContextHolder> mockedStatic = mockStatic(TenantContextHolder.class)) {
+                // Given
+                mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
+                when(credentialPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
+                when(discoveryPort.getRdbmsInstance(INSTANCE_ID, mockSession))
+                        .thenReturn(Optional.of(mockInstance));
+                doNothing().when(lifecyclePort).stop(any(ResourceIdentity.class), eq(mockSession));
+                doNothing().when(resourceHelper).updateLifecycleState(INSTANCE_ID, LifecycleState.STOPPED);
+
+                // When
+                rdbmsUseCaseService.stopInstance(AWS, ACCOUNT_SCOPE, INSTANCE_ID);
+
+                // Then
+                verify(capabilityGuard).ensureSupported(AWS, "RDS", "DATABASE", CapabilityGuard.Operation.STOP);
+                verify(credentialPort).getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS);
+                verify(discoveryPort).getRdbmsInstance(INSTANCE_ID, mockSession);
+                verify(lifecyclePort).stop(any(ResourceIdentity.class), eq(mockSession));
+                verify(resourceHelper).updateLifecycleState(INSTANCE_ID, LifecycleState.STOPPED);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("RDBMS 인스턴스 재시작 테스트")
+    class RebootInstanceTest {
+
+        @Test
+        @DisplayName("정상적인 RDBMS 인스턴스 재시작")
+        void rebootInstance_Success() {
+            try (MockedStatic<TenantContextHolder> mockedStatic = mockStatic(TenantContextHolder.class)) {
+                // Given
+                mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
+                when(credentialPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
+                doNothing().when(lifecyclePort).rebootInstance(INSTANCE_ID, mockSession);
+                doNothing().when(resourceHelper).updateLifecycleState(INSTANCE_ID, LifecycleState.RUNNING);
+
+                // When
+                rdbmsUseCaseService.rebootInstance(AWS, ACCOUNT_SCOPE, INSTANCE_ID);
+
+                // Then
+                verify(capabilityGuard).ensureSupported(AWS, "RDS", "DATABASE", CapabilityGuard.Operation.STOP);
+                verify(capabilityGuard).ensureSupported(AWS, "RDS", "DATABASE", CapabilityGuard.Operation.START);
+                verify(credentialPort).getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS);
+                verify(lifecyclePort).rebootInstance(INSTANCE_ID, mockSession);
+                verify(resourceHelper).updateLifecycleState(INSTANCE_ID, LifecycleState.RUNNING);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("RDBMS 인스턴스 상태 확인 테스트")
+    class GetInstanceStatusTest {
+
+        @Test
+        @DisplayName("정상적인 RDBMS 인스턴스 상태 확인")
+        void getInstanceStatus_Success() {
+            try (MockedStatic<TenantContextHolder> mockedStatic = mockStatic(TenantContextHolder.class)) {
+                // Given
+                mockedStatic.when(TenantContextHolder::getCurrentTenantKeyOrThrow).thenReturn(TENANT_KEY);
+                when(credentialPort.getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS)).thenReturn(mockSession);
+                when(discoveryPort.getInstanceStatus(INSTANCE_ID, mockSession)).thenReturn("available");
+
+                // When
+                String result = rdbmsUseCaseService.getInstanceStatus(AWS, ACCOUNT_SCOPE, INSTANCE_ID);
+
+                // Then
+                assertThat(result).isEqualTo("available");
+
+                verify(credentialPort).getSession(TENANT_KEY, ACCOUNT_SCOPE, AWS);
+                verify(discoveryPort).getInstanceStatus(INSTANCE_ID, mockSession);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# [Phase 1] RDBMS 포트 및 모델 정의 구현

## 📋 개요

AWS RDS 자원 관리 기능 구현의 Phase 1로, 헥사고날 아키텍처를 준수하여 CSP(Cloud Service Provider) 비종속적인 포트 인터페이스와 도메인 모델을 정의했습니다.

## 🎯 구현 목표

- **CSP 비종속성**: AWS, Azure, GCP 등 다양한 클라우드 프로바이더를 동일한 인터페이스로 지원
- **헥사고날 아키텍처 준수**: 포트와 어댑터를 명확히 분리하여 도메인 로직과 인프라 의존성 분리
- **확장성**: `providerSpecificConfig`를 통한 CSP별 특화 설정 지원

## 📦 구현 내용

### 1. Command 모델 정의 (`port/model/rdbms/`)

#### 1.1 RdbmsCreateCommand

RDBMS 인스턴스 생성을 위한 도메인 커맨드입니다. CSP 중립적인 필드를 사용하여 모든 클라우드 프로바이더를 동일한 인터페이스로 지원합니다.

**주요 추상화 전략:**

| CSP 중립적 필드 | AWS | Azure | GCP |
|----------------|-----|-------|-----|
| `instanceName` | `dbInstanceIdentifier` | `serverName` | `instanceId` |
| `instanceSize` | `db.t3.micro` | `GP_Gen5_2` | `db-custom-2-7680` |
| `networkSecurityId` | `securityGroupId` | `firewallRule` | `authorizedNetworks` |
| `zone` | `availabilityZone` | `zone` | `zone` |
| `highAvailability` | `multiAz` | `highAvailability` | `highAvailability` |

**핵심 필드:**
- `engine`: 데이터베이스 엔진 타입 (mysql, postgresql, mariadb, oracle, sqlserver)
- `allocatedStorage`: 스토리지 크기 (GB) - 모든 CSP 공통 단위
- `providerSpecificConfig`: CSP별 특화 설정을 위한 확장 포인트
  - AWS: `subnetGroupName`, `parameterGroupName` 등
  - Azure: `resourceGroupName`, `sku` 등
  - GCP: `databaseFlags`, `backupConfiguration` 등

**설계 고려사항:**
- CSP 공통 개념은 중립적 필드로 추상화
- CSP 특화 기능은 `providerSpecificConfig`로 확장 가능
- JIT 세션 관리 패턴을 위한 `CloudSessionCredential` 포함

#### 1.2 RdbmsUpdateCommand

RDBMS 인스턴스 수정을 위한 도메인 커맨드입니다. 인스턴스 크기, 스토리지, 패스워드 등 변경 가능한 속성만 포함합니다.

**주요 필드:**
- `instanceSize`: 인스턴스 크기 변경 (CSP 중립적)
- `allocatedStorage`: 스토리지 크기 변경 (GB)
- `adminPassword`: 관리자 패스워드 변경 (선택적)
- `applyImmediately`: 즉시 적용 여부 (일부 CSP만 지원)
- `providerSpecificConfig`: CSP별 특화 수정 옵션

**설계 고려사항:**
- 수정 가능한 속성만 포함하여 불필요한 필드 제거
- CSP별 지원 여부 차이는 `providerSpecificConfig`로 처리

#### 1.3 RdbmsDeleteCommand

RDBMS 인스턴스 삭제를 위한 도메인 커맨드입니다. 스냅샷, 백업 등 삭제 관련 옵션을 포함합니다.

**주요 필드:**
- `skipSnapshot`: 최종 스냅샷 건너뛰기 (AWS 특화, 다른 CSP는 `providerSpecificConfig`로)
- `snapshotName`: 최종 스냅샷 이름 (선택적)
- `deleteAutomatedBackups`: 자동 백업 삭제 여부
- `providerSpecificConfig`: CSP별 특화 삭제 옵션

**설계 고려사항:**
- AWS 특화 기능(`skipSnapshot`)도 포함하되, 주석으로 다른 CSP 처리 방법 명시
- CSP별 차이는 `providerSpecificConfig`로 확장 가능

#### 1.4 RdbmsQuery

RDBMS 인스턴스 목록 조회를 위한 쿼리 모델입니다. 페이징, 필터링 기능을 제공합니다.

**주요 필드:**
- `regions`: 조회할 리전 목록 (null이면 모든 리전)
- `instanceName`: 인스턴스 이름으로 필터링 (CSP 중립적)
- `engine`: 엔진 타입으로 필터링
- `instanceSize`: 인스턴스 크기로 필터링 (CSP 중립적)
- `status`: 상태로 필터링 (CSP별 상태 값 다를 수 있음)
- `tagsEquals`: 태그로 필터링
- `page`, `size`: 페이징 정보

**편의 메서드:**
- `all()`: 모든 인스턴스 조회
- `byInstanceName()`: 특정 이름으로 조회
- `byEngine()`: 특정 엔진 타입으로 조회
- `byStatus()`: 특정 상태로 조회

**설계 고려사항:**
- CSP별 상태 값 차이는 Adapter에서 처리
- 페이징은 Spring Data의 `Page` 인터페이스와 호환

### 2. Port 인터페이스 정의 (`port/outbound/rdbms/`)

헥사고날 아키텍처의 핵심인 포트 인터페이스를 정의했습니다. 포트는 도메인과 외부 시스템 간의 **계약(Contract)**을 정의하며, CSP별 구현은 Adapter에서 담당합니다.

#### 2.1 RdbmsManagementPort

**역할**: RDBMS 인스턴스의 CRUD 작업을 담당하는 포트입니다.

**책임:**
- RDBMS 인스턴스 생성 (`createRdbms`)
- RDBMS 인스턴스 수정 (`updateRdbms`)
- RDBMS 인스턴스 삭제 (`deleteRdbms`)

**특징:**
- 모든 메서드는 `Command` 객체를 받아 도메인 중심 설계
- 반환 타입은 `CloudResource`로 통일하여 일관성 유지
- 세션 자격증명은 Command 내부에 포함되어 JIT 패턴 준수

#### 2.2 RdbmsDiscoveryPort

**역할**: RDBMS 인스턴스의 조회/탐색 기능을 담당하는 포트입니다.

**책임:**
- RDBMS 인스턴스 목록 조회 (`listRdbmsInstances`)
- 특정 RDBMS 인스턴스 조회 (`getRdbmsInstance`)
- RDBMS 인스턴스 상태 조회 (`getInstanceStatus`)

**특징:**
- 조회 작업은 읽기 전용이므로 `@Transactional(readOnly = true)` 적용 가능
- 페이징을 위해 Spring Data의 `Page<CloudResource>` 반환
- 단건 조회는 `Optional<CloudResource>`로 null 안전성 보장
- 세션 자격증명을 명시적으로 전달하여 JIT 패턴 준수

#### 2.3 RdbmsLifecyclePort

**역할**: RDBMS 인스턴스의 생명주기 관리(시작/중지/재시작)를 담당하는 포트입니다.

**책임:**
- `ResourceLifecyclePort`를 확장하여 일반적인 리소스 생명주기 관리 기능 상속
  - 리소스 시작 (`start(ResourceIdentity, CloudSessionCredential)`)
  - 리소스 중지 (`stop(ResourceIdentity, CloudSessionCredential)`)
  - 리소스 종료 (`terminate(ResourceIdentity, CloudSessionCredential)`)
- RDBMS 특화 기능 추가
  - RDBMS 인스턴스 재시작 (`rebootInstance(String, CloudSessionCredential)`)

**특징:**
- `ResourceLifecyclePort`를 확장하여 인터페이스 계층 구조 명확화
- 일반적인 리소스 생명주기 관리는 부모 인터페이스의 메서드 사용
- RDBMS 특화 기능인 `reboot`만 추가로 제공
- `reboot`는 OS 레벨 재부팅으로 `stop` + `start`보다 빠르고 안전
- CSP별 지원 여부는 Capability 시스템에서 검증

## 🔄 Phase 2: AWS RDS 어댑터 구현

Phase 1에서 정의한 포트 인터페이스를 구현하는 AWS RDS 어댑터를 구현했습니다.

### 1. AWS RDS 어댑터 구현 (`adapter/outbound/aws/rds/`)

#### 1.1 AwsRdsConfig

**역할**: AWS RDS 클라이언트를 생성하는 설정 클래스입니다.

**주요 기능:**
- 세션 자격증명 기반 RDS 클라이언트 생성
- JIT 패턴 준수: 요청별로 클라이언트 생성 및 종료
- 리전 처리: 명시적 리전 전달 또는 세션 리전 사용
- 세션 검증: AWS 세션 자격증명 유효성 검증

**설계 특징:**
- `@ConditionalOnProperty`로 AWS 활성화 여부에 따라 빈 생성 제어
- 세션 만료 검증 및 타입 검증 포함
- 리전 기본값 처리 (null이면 us-east-1)

#### 1.1.1 AwsS3Config 리팩토링

**역할**: AWS S3 설정 클래스를 JIT 세션 관리 패턴으로 리팩토링했습니다.

**리팩토링 배경:**
- AwsRdsConfig와 일관된 패턴 유지
- JIT 세션 관리 패턴 적용으로 멀티 테넌트 환경 지원 강화

#### 1.2 AwsRdsMapper

**역할**: AWS SDK의 `DBInstance` 객체를 도메인 모델인 `CloudResource`로 변환하는 매퍼입니다.

#### 1.3 AwsRdsManagementAdapter

**역할**: RDBMS 인스턴스의 생성, 수정, 삭제 기능을 제공하는 어댑터입니다.

**구현된 기능:**

**1. createRdbms (인스턴스 생성)**
- `RdbmsCreateCommand` → `CreateDbInstanceRequest` 변환
- CSP 중립 필드 → AWS 특화 필드 매핑:
  - `instanceName` → `dbInstanceIdentifier`
  - `instanceSize` → `dbInstanceClass`
  - `networkSecurityId` → `vpcSecurityGroupIds`
  - `zone` → `availabilityZone`
  - `highAvailability` → `multiAZ`
- 인스턴스 생성 후 `available` 상태까지 대기 (최대 30분)
- 생성된 인스턴스를 `AwsRdsMapper`를 통해 `CloudResource`로 변환하여 반환

**2. updateRdbms (인스턴스 수정)**
- `RdbmsUpdateCommand` → `ModifyDbInstanceRequest` 변환
- 수정 가능한 필드만 변환: `instanceSize`, `allocatedStorage`, `adminPassword`, `applyImmediately`
- 수정 후 `available` 상태까지 대기
- 수정된 인스턴스를 `CloudResource`로 변환하여 반환

**3. deleteRdbms (인스턴스 삭제)**
- `RdbmsDeleteCommand` → `DeleteDbInstanceRequest` 변환
- 삭제 옵션 처리: `skipSnapshot`, `snapshotName`, `deleteAutomatedBackups`
- 삭제는 비동기로 진행되므로 대기하지 않음

**주요 특징:**
- 모든 작업은 세션 자격증명을 사용하여 요청별로 RDS 클라이언트 생성
- 작업 완료 후 클라이언트 자동 종료 (try-finally)
- 에러 발생 시 `CloudErrorTranslator`를 통한 통일된 예외 처리
- `waitForInstanceAvailable` 메서드로 인스턴스 상태 대기 (폴링 간격: 30초)

#### 1.4 AwsRdsDiscoveryAdapter

**역할**: RDBMS 인스턴스의 조회/탐색 기능을 제공하는 어댑터입니다.

**구현된 기능:**

**1. listRdbmsInstances (인스턴스 목록 조회)**
- `RdbmsQuery` → `DescribeDbInstancesRequest` 변환
- 쿼리 조건에 따른 필터링:
  - `instanceName`: `dbInstanceIdentifier`로 필터링
  - `engine`: 엔진 타입으로 필터링
  - `instanceSize`: `dbInstanceClass`로 필터링
  - `status`: `dbInstanceStatus`로 필터링
- 페이징 처리: Spring Data `Page` 인터페이스 반환
- 조회된 인스턴스들을 `AwsRdsMapper`를 통해 `CloudResource`로 변환

**2. getRdbmsInstance (특정 인스턴스 조회)**
- 인스턴스 ID로 단건 조회
- `Optional<CloudResource>` 반환으로 null 안전성 보장
- Availability Zone에서 리전 추출

**3. getInstanceStatus (인스턴스 상태 조회)**
- 인스턴스 ID로 상태만 조회
- AWS 상태 문자열 그대로 반환

**주요 특징:**
- `executeWithRdsClient` 헬퍼 메서드로 클라이언트 생성/종료 자동화
- 리전 처리: 쿼리의 첫 번째 리전 사용 또는 null 처리
- 에러 발생 시 `CloudErrorTranslator`를 통한 통일된 예외 처리

#### 1.5 AwsRdsLifecycleAdapter

**역할**: RDBMS 인스턴스의 생명주기 관리(시작/중지/재시작) 기능을 제공하는 어댑터입니다.

**구현된 기능:**

**1. start (인스턴스 시작) - ResourceLifecyclePort 구현**
- ⚠️ **제한사항**: AWS RDS는 EC2와 달리 인스턴스를 시작/중지할 수 없습니다
- `UnsupportedOperationException` 발생
- RDS 인스턴스는 항상 실행 중이거나 중지된 상태로만 존재
- `ResourceIdentity`를 통해 리소스 정보 전달

**2. stop (인스턴스 중지) - ResourceLifecyclePort 구현**
- `StopDbInstanceRequest` 생성 및 실행
- RDS 인스턴스 중지 지원 (일부 엔진만 지원)
- `ResourceIdentity`를 통해 리소스 정보 전달

**3. terminate (인스턴스 종료) - ResourceLifecyclePort 구현**
- RDS의 경우 terminate는 `RdbmsManagementPort.deleteRdbms()`를 통해 처리해야 함
- `UnsupportedOperationException` 발생하여 명시적으로 처리 방법 안내

**4. rebootInstance (인스턴스 재시작) - RdbmsLifecyclePort 추가 기능**
- `RebootDbInstanceRequest` 생성 및 실행
- RDS 인스턴스 재시작 지원
- OS 레벨 재부팅으로 `stop` + `start`보다 빠르고 안전한 재시작 제공

**주요 특징:**
- `RdbmsLifecyclePort`를 구현하여 `ResourceLifecyclePort`의 모든 기능 상속
- 모든 작업은 세션 자격증명을 사용하여 요청별로 RDS 클라이언트 생성
- 작업 완료 후 클라이언트 자동 종료
- 에러 발생 시 `CloudErrorTranslator`를 통한 통일된 예외 처리

**아키텍처 개선:**
- `RdbmsLifecyclePort`가 `ResourceLifecyclePort`를 확장하여 일반적인 리소스 생명주기 관리 기능 상속
- RDBMS 특화 기능인 `reboot`만 추가로 제공하여 인터페이스 계층 구조 명확화

### 2. DTO 클래스 구현 (`dto/`)

Controller 계층에서 사용하는 요청/응답 DTO 클래스들을 구현했습니다.

#### 2.1 RdbmsCreateRequest

**역할**: RDBMS 인스턴스 생성을 위한 요청 DTO입니다.

#### 2.2 RdbmsUpdateRequest

**역할**: RDBMS 인스턴스 수정을 위한 요청 DTO입니다.

#### 2.3 RdbmsDeleteRequest

**역할**: RDBMS 인스턴스 삭제를 위한 요청 DTO입니다.

#### 2.4 RdbmsQueryRequest

**역할**: RDBMS 인스턴스 목록 조회를 위한 요청 DTO입니다.

#### 2.5 RdbmsResponse

**역할**: RDBMS 인스턴스 정보를 반환하는 응답 DTO입니다.

### 3. 의존성 추가 (pom.xml)

AWS RDS SDK 의존성을 추가했습니다.

```xml
<dependency>
    <groupId>software.amazon.awssdk</groupId>
    <artifactId>rds</artifactId>
</dependency>
```


## ✅ 체크리스트

### Phase 1
- [x] Command 모델 정의 (Create, Update, Delete, Query)
- [x] Port 인터페이스 정의 (Management, Discovery, Lifecycle)
- [x] CSP 비종속적 필드 추상화
- [x] `providerSpecificConfig` 확장 포인트 제공
- [x] JIT 세션 관리 패턴 준수
- [x] 헥사고날 아키텍처 원칙 준수

### Phase 2
- [x] AwsRdsConfig 구현 (RDS 클라이언트 생성)
- [x] AwsRdsMapper 구현 (AWS SDK ↔ CloudResource 변환)
- [x] AwsRdsManagementAdapter 구현 (CRUD 작업)
- [x] AwsRdsDiscoveryAdapter 구현 (조회 작업)
- [x] AwsRdsLifecycleAdapter 구현 (생명주기 관리)
- [x] DTO 클래스 구현 (Request/Response)
- [x] pom.xml에 AWS RDS SDK 의존성 추가
- [x] AwsS3Config 리팩토링 (JIT 세션 관리 패턴 적용)
- [x] RdbmsLifecyclePort 구조 개선 (ResourceLifecyclePort 확장)
- [x] RdbmsController에 감사 로깅 추가
- [x] ObjectStorageController 감사 로깅 리소스 타입 통일 (CLOUD_PROVIDER 사용)

## 🔒 감사 로깅 적용

### 배경

RDBMS 인스턴스 관리 작업에 대한 보안 감사 및 컴플라이언스를 위해 감사 로깅을 추가했습니다. `ObjectStorageController`와 동일한 패턴을 적용하여 일관된 감사 로깅 정책을 유지합니다.

### 변경 사항

#### 1. AuditResourceType 통일

**변경 전:**
- `OBJECT_STORAGE_CONTAINER`: Object Storage Container 전용 리소스 타입
- `RDBMS_INSTANCE`: RDBMS 인스턴스 전용 리소스 타입 (신규 추가 예정)
- `S3_BUCKET`: S3 버킷 전용 리소스 타입

**변경 후:**
- 모든 클라우드 리소스는 `CLOUD_PROVIDER` 리소스 타입 사용
- 리소스별 타입 제거 (`OBJECT_STORAGE_CONTAINER`, `RDBMS_INSTANCE`, `S3_BUCKET`)

**변경 이유:**
- 클라우드 리소스가 늘어날수록 `AuditResourceType` enum에 필드가 과도하게 증가하는 문제 방지
- 클라우드 리소스는 모두 동일한 감사 정책을 적용하므로 통합된 리소스 타입 사용이 적절
- `action` 필드로 구체적인 작업을 구분할 수 있어 리소스 타입 분리가 불필요

**영향받는 파일:**
- `AuditResourceType.java`: `OBJECT_STORAGE_CONTAINER`, `RDBMS_INSTANCE`, `S3_BUCKET` 제거
- `ObjectStorageController.java`: 모든 `@AuditRequired`의 `resourceType`을 `CLOUD_PROVIDER`로 변경
- `RdbmsController.java`: 모든 `@AuditRequired`의 `resourceType`을 `CLOUD_PROVIDER`로 변경

#### 2. RdbmsController 감사 로깅 추가

**추가된 감사 로깅:**

| 메서드 | Action | Severity | Request Data | Response Data | 설명 |
|--------|--------|----------|--------------|---------------|------|
| `listRdbmsInstances` | `LIST_RDBMS_INSTANCES` | LOW | ✅ | ❌ | RDBMS 인스턴스 목록 조회 |
| `getRdbmsInstance` | `GET_RDBMS_INSTANCE` | LOW | ✅ | ❌ | RDBMS 인스턴스 상세 조회 |
| `createRdbms` | `CREATE_RDBMS_INSTANCE` | HIGH | ✅ | ✅ | RDBMS 인스턴스 생성 |
| `updateRdbms` | `UPDATE_RDBMS_INSTANCE` | HIGH | ✅ | ✅ | RDBMS 인스턴스 수정 |
| `deleteRdbms` | `DELETE_RDBMS_INSTANCE` | CRITICAL | ✅ | ❌ | RDBMS 인스턴스 삭제 |
| `startInstance` | `START_RDBMS_INSTANCE` | MEDIUM | ✅ | ❌ | RDBMS 인스턴스 시작 |
| `stopInstance` | `STOP_RDBMS_INSTANCE` | MEDIUM | ✅ | ❌ | RDBMS 인스턴스 중지 |
| `rebootInstance` | `REBOOT_RDBMS_INSTANCE` | MEDIUM | ✅ | ❌ | RDBMS 인스턴스 재시작 |
| `getInstanceStatus` | `GET_RDBMS_INSTANCE_STATUS` | LOW | ✅ | ❌ | RDBMS 인스턴스 상태 확인 |

**데이터 포함 정책:**
- **생성/수정**: 요청 데이터와 응답 데이터 모두 포함 (변경 내용 추적)
- **삭제**: 요청 데이터만 포함 (응답은 없음)
- **조회/상태 확인**: 요청 데이터만 포함 (응답 데이터는 대용량일 수 있음)

#### 3. 보안 및 안전성 보장

**원본 데이터 보호:**
- 감사 로깅은 원본 요청/응답 데이터를 변경하지 않음
- `MaskingService.toMaskedJson()`은 깊은 복사본을 생성하여 마스킹 처리
- 비즈니스 로직에 영향을 주지 않음

**민감 정보 자동 마스킹:**
- `password`, `pwd`, `pass` → `***`
- `token`, `jwt`, `auth`, `key` → `***`
- `secretkey`, `secret_key` → 마스킹
- `accountscope`, `account_scope` → 마스킹
- `email`, `phone`, `ssn` 등 → 부분 마스킹

**비동기 처리:**
- DB 저장은 `@Async`로 비동기 처리되어 성능 영향 최소화
- 로깅 실패가 비즈니스 로직에 영향을 주지 않음

**예외 처리:**
- 감사 로깅 중 예외 발생 시에도 원본 메서드 실행은 정상 진행
- 로깅 실패는 로그로만 기록되고 사용자 요청은 실패하지 않음

### 참고 사항

1. **기존 감사 로깅 시스템 활용**
   - 기존에 구축된 `@AuditRequired` 어노테이션 기반 감사 로깅 시스템을 그대로 활용
   - 추가 설정이나 인프라 변경 없이 어노테이션만 추가하여 적용

2. **ObjectStorageController와의 일관성**
   - `ObjectStorageController`와 동일한 패턴으로 구현
   - 리소스 타입도 `CLOUD_PROVIDER`로 통일하여 일관성 유지

3. **확장성**
   - 향후 다른 클라우드 리소스 컨트롤러에도 동일한 패턴으로 감사 로깅 추가 가능
   - `CLOUD_PROVIDER` 리소스 타입을 사용하여 enum 확장 없이 적용 가능

## 🔐 adminPassword 암호화 보안 구현

### 배경

RDBMS 인스턴스 생성 및 수정 시 전달되는 `adminPassword`는 민감한 정보이므로, 로그 파일 유출 및 메모리 덤프 공격으로부터 보호하기 위해 암호화 처리를 적용했습니다.

### 구현 내용

#### 1. Service 계층에서 암호화

**RdbmsUseCaseService**에서 `EncryptionService`를 사용하여 `adminPassword`를 암호화합니다.

**특징:**
- `RdbmsCreateCommand`와 `RdbmsUpdateCommand`에는 암호화된 값이 전달됨
- 평문 패스워드는 Service 계층에서만 존재하고, Command에는 암호화된 값만 전달
- 암호화 실패 시 `CloudErrorCode.ENCRYPTION_FAILED` 예외 발생

#### 2. Adapter 계층에서 복호화

**AwsRdsManagementAdapter**에서 AWS SDK로 전달하기 직전에 복호화합니다.

**특징:**
- AWS SDK로 전달하기 직전에만 복호화하여 평문 노출 시간 최소화
- 복호화 실패 시 `CloudErrorCode.DECRYPTION_FAILED` 예외 발생
- 복호화된 패스워드는 AWS SDK 요청에만 사용되고 즉시 GC 대상이 됨

#### 3. 로깅 시 마스킹 처리

**원본 데이터 보호:**
- 로깅 시 `LogMaskingUtils.maskSensitiveData()`를 사용하여 민감 정보 마스킹
- 원본 요청 객체는 변경하지 않고, 마스킹된 문자열만 로그에 출력

**마스킹 규칙:**
- `password`, `pwd`, `pass` → `***`
- `token`, `jwt`, `auth`, `key` → `***`
- `secretkey`, `secret_key` → 마스킹

### 보안상 이점

#### 1. 로그 파일 보호 (가장 큰 이점)
- ✅ 로그 파일에 평문 패스워드가 저장되지 않음
- ✅ 감사 로그, 애플리케이션 로그, 에러 로그에서 평문 노출 방지
- ✅ 로그 파일 유출 시에도 패스워드 노출 없음

#### 2. 메모리 덤프 시 부분적 보호
- ✅ Command 객체에 암호화된 값이 저장됨
- ✅ 메모리 덤프 시 평문보다는 암호문이 노출됨
- ⚠️ 한계: 복호화 키가 있으면 복호화 가능 (키 관리 중요)

#### 3. 레이어 간 전달 보호
- ✅ Service → Command → Adapter 전달 과정에서 암호화된 값 전달
- ✅ 같은 JVM 내부이지만 레이어 간 전달 시 암호화된 형태로 전달

